### PR TITLE
feat: Add console logging

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -33,6 +33,11 @@ pub fn cli() -> Command<'static> {
                 .help("Insutrment using RUST_LOG environment"),
         )
         .arg(
+            Arg::new("console-logging")
+                .long("console-logging")
+                .help("Instrument using RUST_LOG environment"),
+        )
+        .arg(
             Arg::new("export-schema")
                 .long("export-schema")
                 .takes_value(false)

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -309,6 +309,10 @@ async fn main() {
         std::process::exit(0);
     }
 
+    if matches.is_present("console-logging") {
+        telemetry::console_logging();
+    }
+
     if matches.is_present("instrument") {
         telemetry::telemetry(
             Url::parse(&*matches.value_of_t::<String>("instrument").unwrap()).unwrap(),

--- a/cli/src/telemetry.rs
+++ b/cli/src/telemetry.rs
@@ -4,7 +4,7 @@ use tracing_subscriber::{prelude::__tracing_subscriber_SubscriberExt, EnvFilter,
 use url::Url;
 
 pub fn telemetry(collector_endpoint: Url) {
-    LogTracer::init().expect("Failed to set logger");
+    LogTracer::init_with_filter(tracing::log::LevelFilter::Trace).ok();
 
     let tracer = opentelemetry_jaeger::new_pipeline()
         .with_service_name("chronicle_api")
@@ -17,4 +17,14 @@ pub fn telemetry(collector_endpoint: Url) {
     let collector = Registry::default().with(env_filter).with(opentelemetry);
 
     set_global_default(collector).expect("Failed to set collector");
+}
+
+pub fn console_logging() {
+    LogTracer::init_with_filter(tracing::log::LevelFilter::Info).ok();
+    let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+    tracing_subscriber::fmt()
+        .with_env_filter(env_filter)
+        .pretty()
+        .try_init()
+        .ok();
 }


### PR DESCRIPTION
* Enable with --console-logging
* Human readable format - the intent is to use opentelemetry for machine
  readable
* Controlled by rust env_logger, similarly to opentelemetry. See https://docs.rs/env_logger/latest/env_logger/

Signed-off-by: Ryan Roberts <ryan@blockchaintp.com>