### PR TITLE
Improved domain syntax, errors

### DIFF
--- a/chronicle-example/build.rs
+++ b/chronicle-example/build.rs
@@ -7,50 +7,40 @@ fn main() {
     let s = r#"
     name: "chronicle"
     attributes:
-      string:
-        typ: "String"
-      int:
-        typ: "Int"
-      bool:
-        typ: "Bool"
+      String:
+        type: "String"
+      Int:
+        type: "Int"
+      Bool:
+        type: "Bool"
     agents:
       friend:
-        string:
-          typ: "String"
-        int:
-          typ: "Int"
-        bool:
-          typ: "Bool"
+        attributes:
+          - String
+          - Int
+          - Bool
     entities:
       octopi:
-        string:
-          typ: "String"
-        int:
-          typ: "Int"
-        bool:
-          typ: "Bool"
+        attributes:
+          - String
+          - Int
+          - Bool
       the sea:
-        string:
-          typ: "String"
-        int:
-          typ: "Int"
-        bool:
-          typ: "Bool"
+        attributes:
+          - String
+          - Int
+          - Bool
     activities:
       gardening:
-        string:
-          typ: "String"
-        int:
-          typ: "Int"
-        bool:
-          typ: "Bool"
+        attributes:
+          - String
+          - Int
+          - Bool
       swim about:
-        string:
-          typ: "String"
-        int:
-          typ: "Int"
-        bool:
-          typ: "Bool"
+        attributes:
+          - String
+          - Int
+          - Bool
      "#
     .to_string();
 


### PR DESCRIPTION
* from_str now only implements yaml
* removed ParseDomainError that lost source context
* file extension used to select parser
* Attributes on resources in file definition are references to items in
  model.attribute rather than requiring the primitive type

Signed-off-by: Ryan <ryan@blockchaintp.com>