### PR TITLE
ci(github): skip cargo-check in pre-commit workflow

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -44,4 +44,4 @@ jobs:
         with:
           extra_args: --files ${{ steps.file_changes.outputs.files}}
         env:
-          SKIP: no-commit-to-branch
+          SKIP: no-commit-to-branch,cargo-check


### PR DESCRIPTION
since protoc is required by sawtooth-sdk

Signed-off-by: Kevin O'Donnell <kevin@blockchaintp.com>
