### PR TITLE
style(sawtooth-protocol): fix spelling of `make_subscription_request`

### DIFF
--- a/sawtooth-protocol/src/events.rs
+++ b/sawtooth-protocol/src/events.rs
@@ -126,7 +126,7 @@ impl StateDelta {
         impl futures::Stream<Item = Vec<(Offset, Box<ProvModel>, ChronicleTransactionId)>>,
         StateError,
     > {
-        let request = self.builder.make_subcription_request(offset);
+        let request = self.builder.make_subscription_request(offset);
 
         debug!(?request, "Subscription request");
         let mut buf = Vec::new();

--- a/sawtooth-protocol/src/messages.rs
+++ b/sawtooth-protocol/src/messages.rs
@@ -43,7 +43,7 @@ impl MessageBuilder {
     }
 
     #[allow(dead_code)]
-    pub fn make_subcription_request(&self, offset: &Offset) -> ClientEventsSubscribeRequest {
+    pub fn make_subscription_request(&self, offset: &Offset) -> ClientEventsSubscribeRequest {
         let mut request = ClientEventsSubscribeRequest::default();
 
         let mut delta_subscription = EventSubscription::default();


### PR DESCRIPTION
- fixed spelling in events.rs and messages.rs

Signed-off-by: Joseph Livesey <joseph@blockchaintp.com>