### PR TITLE
docs(mkdocs): lowercase site_name

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: "Chronicle"
+site_name: "chronicle"
 theme:
   name: "readthedocs"
   language: "en"


### PR DESCRIPTION
When using the mono repo plugin the url slug is taken from the site name in the imported MkDocs.yml file. This should be lowercase, but is currently capitalised.