### PR TITLE
Generated relation

### DIFF
--- a/api/migrations/2022-01-18-144301_ledger_sync/up.sql
+++ b/api/migrations/2022-01-18-144301_ledger_sync/up.sql
@@ -106,6 +106,15 @@ create table generation (
     primary key(activity_id,generated_entity_id)
 );
 
+create table generated (
+    entity_id integer not null,
+    generated_activity_id integer not null,
+    typ text,
+    foreign key(entity_id) references activity(id),
+    foreign key(generated_activity_id) references entity(id),
+    primary key(entity_id,generated_activity_id)
+);
+
 create table association (
     agent_id integer not null,
     activity_id integer not null,

--- a/api/src/chronicle_graphql/activity.rs
+++ b/api/src/chronicle_graphql/activity.rs
@@ -79,6 +79,22 @@ pub async fn was_informed_by<'a>(
     Ok(res)
 }
 
+pub async fn generated<'a>(id: i32, ctx: &Context<'a>) -> async_graphql::Result<Vec<Entity>> {
+    use crate::persistence::schema::generated::{self, dsl};
+
+    let store = ctx.data_unchecked::<Store>();
+
+    let mut connection = store.pool.get()?;
+
+    let res = generated::table
+        .filter(dsl::generated_activity_id.eq(id))
+        .inner_join(crate::persistence::schema::entity::table)
+        .select(Entity::as_select())
+        .load::<Entity>(&mut connection)?;
+
+    Ok(res)
+}
+
 pub async fn load_attribute<'a>(
     id: i32,
     external_id: &str,

--- a/api/src/chronicle_graphql/mutation.rs
+++ b/api/src/chronicle_graphql/mutation.rs
@@ -352,6 +352,27 @@ pub async fn was_generated_by<'a>(
     transaction_context(res, ctx).await
 }
 
+pub async fn generated<'a>(
+    ctx: &Context<'a>,
+    entity: EntityId,
+    activity: ActivityId,
+    namespace: Option<String>,
+) -> async_graphql::Result<Submission> {
+    let api = ctx.data_unchecked::<ApiDispatch>();
+
+    let namespace = namespace.unwrap_or_else(|| "default".to_owned()).into();
+
+    let res = api
+        .dispatch(ApiCommand::Entity(EntityCommand::Generated {
+            id: activity,
+            namespace,
+            entity: Some(entity),
+        }))
+        .await?;
+
+    transaction_context(res, ctx).await
+}
+
 pub async fn has_attachment<'a>(
     ctx: &Context<'a>,
     entity: EntityId,

--- a/api/src/persistence/schema.rs
+++ b/api/src/persistence/schema.rs
@@ -127,6 +127,17 @@ diesel::table! {
     use diesel::sql_types::*;
     use common::prov::*;
 
+    generated (entity_id, generated_activity_id) {
+        entity_id -> Integer,
+        generated_activity_id -> Integer,
+        typ -> Nullable<Text>,
+    }
+}
+
+diesel::table! {
+    use diesel::sql_types::*;
+    use common::prov::*;
+
     generation (activity_id, generated_entity_id) {
         activity_id -> Integer,
         generated_entity_id -> Integer,
@@ -221,6 +232,8 @@ diesel::joinable!(derivation -> activity (activity_id));
 diesel::joinable!(entity -> attachment (attachment_id));
 diesel::joinable!(entity -> namespace (namespace_id));
 diesel::joinable!(entity_attribute -> entity (entity_id));
+diesel::joinable!(generated -> activity (entity_id));
+diesel::joinable!(generated -> entity (generated_activity_id));
 diesel::joinable!(generation -> activity (activity_id));
 diesel::joinable!(generation -> entity (generated_entity_id));
 diesel::joinable!(hadattachment -> attachment (attachment_id));
@@ -242,6 +255,7 @@ diesel::allow_tables_to_appear_in_same_query!(
     derivation,
     entity,
     entity_attribute,
+    generated,
     generation,
     hadattachment,
     hadidentity,

--- a/chronicle/src/bootstrap/mod.rs
+++ b/chronicle/src/bootstrap/mod.rs
@@ -817,6 +817,7 @@ pub mod test {
         generation: {}
         usage: {}
         was_informed_by: {}
+        generated: {}
         "###);
     }
 

--- a/chronicle/src/codegen/mod.rs
+++ b/chronicle/src/codegen/mod.rs
@@ -276,6 +276,18 @@ fn gen_activity_definition(activity: &ActivityDef) -> rust::Tokens {
                 .collect())
         }
 
+        async fn generated<'a>(
+            &self,
+            ctx: &#context<'a>,
+        ) -> #async_result<Vec<#(entity_union_type_name())>> {
+            Ok(#activity_impl::generated(self.0.id, ctx)
+                .await
+                .map_err(|e| #async_graphql_error_extensions::extend(&e))?
+                .into_iter()
+                .map(map_entity_to_domain_type)
+                .collect())
+        }
+
         #(for attribute in &activity.attributes =>
         async fn #(attribute.as_property())<'a>(&self, ctx: &#context<'a>) -> #async_result<Option<#(attribute.as_scalar_type())>> {
             Ok(#(match attribute.primitive_type {
@@ -1100,6 +1112,16 @@ fn gen_mutation(domain: &ChronicleDomainDef) -> rust::Tokens {
             namespace: Option<String>,
         ) -> async_graphql::#graphql_result<#submission> {
             #impls::was_generated_by(ctx, activity, id, namespace).await.map_err(|e| #async_graphql_error_extensions::extend(&e))
+        }
+
+        pub async fn generated<'a>(
+            &self,
+            ctx: &#graphql_context<'a>,
+            entity: #entity_id,
+            id: #activity_id,
+            namespace: Option<String>,
+        ) -> async_graphql::#graphql_result<#submission> {
+            #impls::generated(ctx, entity, id, namespace).await.map_err(|e| #async_graphql_error_extensions::extend(&e))
         }
 
         pub async fn has_attachment<'a>(

--- a/common/src/commands.rs
+++ b/common/src/commands.rs
@@ -224,6 +224,11 @@ pub enum EntityCommand {
         activity: Option<ActivityId>,
         used_entity: EntityId,
     },
+    Generated {
+        id: ActivityId,
+        namespace: ExternalId,
+        entity: Option<EntityId>,
+    },
 }
 
 impl EntityCommand {
@@ -268,6 +273,14 @@ impl EntityCommand {
             derivation,
             activity,
             used_entity,
+        }
+    }
+
+    pub fn generated(id: ActivityId, namespace: impl AsRef<str>, entity: Option<EntityId>) -> Self {
+        Self::Generated {
+            id,
+            namespace: namespace.as_ref().into(),
+            entity,
         }
     }
 }

--- a/common/src/ledger.rs
+++ b/common/src/ledger.rs
@@ -10,7 +10,7 @@ use crate::{
     prov::{
         operations::{
             ActivityExists, ActivityUses, ActsOnBehalfOf, AgentExists, ChronicleOperation,
-            CreateNamespace, EndActivity, EntityDerive, EntityExists, EntityHasEvidence,
+            CreateNamespace, EndActivity, EntityDerive, EntityExists, EntityHasEvidence, Generated,
             RegisterKey, SetAttributes, StartActivity, WasAssociatedWith, WasGeneratedBy,
             WasInformedBy,
         },
@@ -537,6 +537,15 @@ impl ChronicleOperation {
                     LedgerAddress::in_namespace(namespace, informing_activity.clone()),
                 ]
             }
+            ChronicleOperation::Generated(Generated {
+                namespace,
+                id,
+                entity,
+            }) => vec![
+                LedgerAddress::namespace(namespace),
+                LedgerAddress::in_namespace(namespace, entity.clone()),
+                LedgerAddress::in_namespace(namespace, id.clone()),
+            ],
             ChronicleOperation::EntityHasEvidence(EntityHasEvidence {
                 namespace,
                 id,

--- a/common/src/prov/model/to_json_ld.rs
+++ b/common/src/prov/model/to_json_ld.rs
@@ -1018,6 +1018,35 @@ impl ToJson for ChronicleOperation {
 
                 o
             }
+            ChronicleOperation::Generated(Generated {
+                namespace,
+                id,
+                entity,
+            }) => {
+                let mut o = JsonValue::new_operation(ChronicleOperations::Generated);
+
+                o.has_value(
+                    OperationValue::string(namespace.external_id_part()),
+                    ChronicleOperations::NamespaceName,
+                );
+
+                o.has_value(
+                    OperationValue::string(namespace.uuid_part()),
+                    ChronicleOperations::NamespaceUuid,
+                );
+
+                o.has_value(
+                    OperationValue::string(id.external_id_part()),
+                    ChronicleOperations::ActivityName,
+                );
+
+                o.has_value(
+                    OperationValue::string(entity.external_id_part()),
+                    ChronicleOperations::EntityName,
+                );
+
+                o
+            }
         };
         operation.push(o);
         super::ExpandedJson(operation.into())

--- a/common/src/prov/operations.rs
+++ b/common/src/prov/operations.rs
@@ -234,6 +234,13 @@ pub struct WasInformedBy {
     pub informing_activity: ActivityId,
 }
 
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
+pub struct Generated {
+    pub namespace: NamespaceId,
+    pub id: ActivityId,
+    pub entity: EntityId,
+}
+
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub enum SetAttributes {
     Entity {
@@ -270,4 +277,5 @@ pub enum ChronicleOperation {
     SetAttributes(SetAttributes),
     WasAssociatedWith(WasAssociatedWith),
     WasInformedBy(WasInformedBy),
+    Generated(Generated),
 }

--- a/common/src/prov/vocab.rs
+++ b/common/src/prov/vocab.rs
@@ -81,6 +81,8 @@ pub enum ChronicleOperations {
     WasInformedBy,
     #[iri("chronicleop:informingActivityName")]
     InformingActivityName,
+    #[iri("chronicleop:generated")]
+    Generated,
 }
 
 #[derive(IriEnum, Clone, Copy, PartialEq, Eq, Hash)]
@@ -130,6 +132,8 @@ pub enum Prov {
     HadActivity,
     #[iri("prov:wasInformedBy")]
     WasInformedBy,
+    #[iri("prov:generated")]
+    Generated,
 }
 
 #[derive(IriEnum, Clone, Copy, PartialEq, Eq, Hash)]
@@ -172,6 +176,8 @@ pub enum Chronicle {
     Value,
     #[iri("chronicle:wasInformedBy")]
     WasInformedBy,
+    #[iri("chronicle:generated")]
+    Generated,
 }
 
 /// Operations to format specific Iri kinds, using percentage encoding to ensure they are infallible


### PR DESCRIPTION
## [CHRON-129](https://blockchaintp.atlassian.net/browse/CHRON-129)
- add generated relation, the reverse of wasGeneratedBy, i.e. the relation of an activity having been generated by an entity
---
Signed-off-by: Joseph Livesey <joseph@blockchaintp.com>