### PR TITLE
Add generic json object attribute

### DIFF
--- a/chronicle-domain-test/build.rs
+++ b/chronicle-domain-test/build.rs
@@ -14,12 +14,15 @@ fn main() {
         type: "String"
       Location:
         type: "String"
+      Manifest:
+        type: JSON
     agents:
       Contractor:
         attributes:
           - Location
       NCB:
-        attributes: []
+        attributes:
+          - Manifest
     entities:
       Certificate:
         attributes:

--- a/chronicle-domain-test/src/test.rs
+++ b/chronicle-domain-test/src/test.rs
@@ -20,12 +20,15 @@ pub async fn main() {
         type: "String"
       Location:
         type: "String"
+      Manifest:
+        type: JSON
     agents:
       Contractor:
         attributes:
           - Location
       NCB:
-        attributes: []
+        attributes:
+          - Manifest
     entities:
       Certificate:
         attributes:
@@ -126,6 +129,73 @@ mod test {
             .data(Store::new(pool))
             .data(dispatch)
             .finish()
+    }
+
+    #[tokio::test]
+    async fn generic_json_object_attribute() {
+        let schema = test_schema().await;
+
+        // We doctor the test JSON input data as done in the `async_graphql` library JSON tests
+        // https://docs.rs/async-graphql/latest/src/async_graphql/types/json.rs.html#20.
+        // In fact, if you make the JSON input more complex, nesting data further, etc, it will cause
+        // "expected Name" errors. However, complex JSON inputs have been tested with success in the GraphQL
+        // Playground, as documented here: https://blockchaintp.atlassian.net/l/cp/0aocArV4
+        let res = schema
+            .execute(Request::new(
+                r#"
+            mutation {
+              defineNCBAgent(
+                  externalId: "testagent2"
+                  attributes: { manifestAttribute: {
+                    username: "test",
+                    email: "test@test.cz",
+                    phone: "479332973",
+                    firstName: "David",
+                    lastName: "Test",
+                  } }
+                ) {
+                  context
+                }
+              }
+        "#,
+            ))
+            .await;
+
+        assert_eq!(res.errors, vec![]);
+
+        tokio::time::sleep(Duration::from_millis(1000)).await;
+
+        insta::assert_json_snapshot!(schema
+          .execute(Request::new(
+            r#"
+            query agent {
+              agentById(id: "chronicle:agent:testagent2") {
+                __typename
+                ... on NCBAgent {
+                  id
+                  manifestAttribute
+                }
+              }
+            }
+            "#,
+          ))
+          .await, @r###"
+        {
+          "data": {
+            "agentById": {
+              "__typename": "NCBAgent",
+              "id": "chronicle:agent:testagent2",
+              "manifestAttribute": {
+                "email": "test@test.cz",
+                "firstName": "David",
+                "lastName": "Test",
+                "phone": "479332973",
+                "username": "test"
+              }
+            }
+          }
+        }
+        "###);
     }
 
     // Note that this test demonstrates Chronicle accepting
@@ -804,10 +874,16 @@ mod test {
             .execute(Request::new(
                 r#"
             mutation {
-              defineNCBAgent(externalId:"testagent2") {
-                    context
+              defineNCBAgent(
+                  externalId: "testagent2"
+                  attributes: { manifestAttribute: {
+                    username: "test",
+                    email: "test@test.cz",
+                  } }
+                ) {
+                  context
                 }
-            }
+              }
         "#,
             ))
             .await;
@@ -1006,6 +1082,7 @@ mod test {
                                         ... on NCBAgent {
                                           id
                                           externalId
+                                          manifestAttribute
                                         }
                                     }
                                         role
@@ -1037,6 +1114,7 @@ mod test {
                                             ... on NCBAgent {
                                               id
                                               externalId
+                                              manifestAttribute
                                             }
                                         }
                                         role
@@ -1083,7 +1161,11 @@ mod test {
                         "responsible": {
                           "agent": {
                             "id": "chronicle:agent:testagent2",
-                            "externalId": "testagent2"
+                            "externalId": "testagent2",
+                            "manifestAttribute": {
+                              "email": "test@test.cz",
+                              "username": "test"
+                            }
                           },
                           "role": "CERTIFIER"
                         }
@@ -1137,7 +1219,11 @@ mod test {
                         "responsible": {
                           "agent": {
                             "id": "chronicle:agent:testagent2",
-                            "externalId": "testagent2"
+                            "externalId": "testagent2",
+                            "manifestAttribute": {
+                              "email": "test@test.cz",
+                              "username": "test"
+                            }
                           },
                           "role": "CERTIFIER"
                         }
@@ -1191,7 +1277,11 @@ mod test {
                         "responsible": {
                           "agent": {
                             "id": "chronicle:agent:testagent2",
-                            "externalId": "testagent2"
+                            "externalId": "testagent2",
+                            "manifestAttribute": {
+                              "email": "test@test.cz",
+                              "username": "test"
+                            }
                           },
                           "role": "CERTIFIER"
                         }
@@ -1245,7 +1335,11 @@ mod test {
                         "responsible": {
                           "agent": {
                             "id": "chronicle:agent:testagent2",
-                            "externalId": "testagent2"
+                            "externalId": "testagent2",
+                            "manifestAttribute": {
+                              "email": "test@test.cz",
+                              "username": "test"
+                            }
                           },
                           "role": "CERTIFIER"
                         }
@@ -1299,7 +1393,11 @@ mod test {
                         "responsible": {
                           "agent": {
                             "id": "chronicle:agent:testagent2",
-                            "externalId": "testagent2"
+                            "externalId": "testagent2",
+                            "manifestAttribute": {
+                              "email": "test@test.cz",
+                              "username": "test"
+                            }
                           },
                           "role": "CERTIFIER"
                         }
@@ -1355,6 +1453,7 @@ mod test {
                                             ... on NCBAgent {
                                               id
                                               externalId
+                                              manifestAttribute
                                             }
                                         }
                                         role
@@ -1386,6 +1485,7 @@ mod test {
                                           ... on NCBAgent {
                                               id
                                               externalId
+                                              manifestAttribute
                                             }
                                       }
                                       role
@@ -1432,7 +1532,11 @@ mod test {
                         "responsible": {
                           "agent": {
                             "id": "chronicle:agent:testagent2",
-                            "externalId": "testagent2"
+                            "externalId": "testagent2",
+                            "manifestAttribute": {
+                              "email": "test@test.cz",
+                              "username": "test"
+                            }
                           },
                           "role": "CERTIFIER"
                         }
@@ -1486,7 +1590,11 @@ mod test {
                         "responsible": {
                           "agent": {
                             "id": "chronicle:agent:testagent2",
-                            "externalId": "testagent2"
+                            "externalId": "testagent2",
+                            "manifestAttribute": {
+                              "email": "test@test.cz",
+                              "username": "test"
+                            }
                           },
                           "role": "CERTIFIER"
                         }
@@ -1540,7 +1648,11 @@ mod test {
                         "responsible": {
                           "agent": {
                             "id": "chronicle:agent:testagent2",
-                            "externalId": "testagent2"
+                            "externalId": "testagent2",
+                            "manifestAttribute": {
+                              "email": "test@test.cz",
+                              "username": "test"
+                            }
                           },
                           "role": "CERTIFIER"
                         }
@@ -1594,7 +1706,11 @@ mod test {
                         "responsible": {
                           "agent": {
                             "id": "chronicle:agent:testagent2",
-                            "externalId": "testagent2"
+                            "externalId": "testagent2",
+                            "manifestAttribute": {
+                              "email": "test@test.cz",
+                              "username": "test"
+                            }
                           },
                           "role": "CERTIFIER"
                         }
@@ -1648,7 +1764,11 @@ mod test {
                         "responsible": {
                           "agent": {
                             "id": "chronicle:agent:testagent2",
-                            "externalId": "testagent2"
+                            "externalId": "testagent2",
+                            "manifestAttribute": {
+                              "email": "test@test.cz",
+                              "username": "test"
+                            }
                           },
                           "role": "CERTIFIER"
                         }

--- a/chronicle/src/bootstrap/cli.rs
+++ b/chronicle/src/bootstrap/cli.rs
@@ -216,6 +216,19 @@ fn attribute_value_from_param(
                 Ok(value)
             }
         }
+        PrimitiveType::JSON => {
+            if let Some(coerced) =
+                valico::json_dsl::object()
+                    .coerce(&mut value, ".")
+                    .map_err(|_e| CliError::InvalidCoercion {
+                        arg: arg.to_owned(),
+                    })?
+            {
+                Ok(coerced)
+            } else {
+                Ok(value)
+            }
+        }
     }
 }
 

--- a/chronicle/src/bootstrap/mod.rs
+++ b/chronicle/src/bootstrap/mod.rs
@@ -444,6 +444,8 @@ pub mod test {
                 .unwrap()
                 .with_attribute_type("testInt", crate::PrimitiveType::Int)
                 .unwrap()
+                .with_attribute_type("testJSON", crate::PrimitiveType::JSON)
+                .unwrap()
                 .with_activity("testActivity", |b| {
                     b.with_attribute("testString")
                         .unwrap()

--- a/chronicle/src/codegen/model.rs
+++ b/chronicle/src/codegen/model.rs
@@ -18,6 +18,7 @@ pub enum PrimitiveType {
     String,
     Bool,
     Int,
+    JSON,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/common/src/prov/id/graphlql_scalars.rs
+++ b/common/src/prov/id/graphlql_scalars.rs
@@ -1,7 +1,9 @@
 use async_graphql::{InputValueError, InputValueResult, Scalar, ScalarType, Value};
 use iref::Iri;
 
-use super::{ActivityId, AgentId, DomaintypeId, EntityId, EvidenceId, IdentityId};
+use super::{ActivityId, AgentId, ChronicleJSON, DomaintypeId, EntityId, EvidenceId, IdentityId};
+
+async_graphql::scalar!(ChronicleJSON);
 
 #[Scalar(name = "AttachmentID")]
 impl ScalarType for EvidenceId {

--- a/common/src/prov/id/mod.rs
+++ b/common/src/prov/id/mod.rs
@@ -320,6 +320,9 @@ impl ChronicleIri {
     }
 }
 
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
+pub struct ChronicleJSON(pub serde_json::Value);
+
 #[derive(Serialize, Deserialize, PartialEq, Eq, Hash, Debug, Clone, Ord, PartialOrd)]
 pub struct EvidenceId {
     external_id: ExternalId,


### PR DESCRIPTION
## [CHRON-136](https://blockchaintp.atlassian.net/browse/CHRON-136)
### [Notes](https://blockchaintp.atlassian.net/l/cp/mH6jEppJ)
- [Passing JSON Variables in GraphQL](https://blockchaintp.atlassian.net/wiki/spaces/~62816e8604eb160068349638/pages/1511391233/Generic+Json+object+attribute#Description) 
- [JSON type in domain.yaml](https://blockchaintp.atlassian.net/wiki/spaces/~62816e8604eb160068349638/pages/1511391233/Generic+Json+object+attribute#Object-type-in-domain.yaml) 
- [Using JSON input in mutations and querying the data](https://blockchaintp.atlassian.net/wiki/spaces/~62816e8604eb160068349638/pages/1511391233/Generic+Json+object+attribute#Using-JSON-input-in-mutations-and-querying-the-data) 
- [Testing JSON inputs into  GraphQL mutations](https://blockchaintp.atlassian.net/wiki/spaces/~62816e8604eb160068349638/pages/1511391233/Generic+Json+object+attribute#Using-JSON-input-in-mutations-and-querying-the-data) 
---
### Steps
- Add `ChronicleJSON` scalar type (becomes `JSON` type in GraphQL schema)
- Add `JSON` as `PrimitiveType`
- Add handling of `JSON` to cli parsing and code generation 
- Fix on the fly an issue with the internal representation of `Attributes` while preserving inflections--make things consistent
---
Signed-off-by: Joseph Livesey <joseph@blockchaintp.com>