### PR TITLE
Better isolation of user domain terms

### DIFF
--- a/chronicle-domain-test/src/test.rs
+++ b/chronicle-domain-test/src/test.rs
@@ -458,14 +458,14 @@ mod test {
           .execute(Request::new(
               r#"
                   mutation one {
-                    defineItemCertified(externalId:"testactivityid1", attributes: { certIdAttribute: "testcertid" }) {
+                    defineItemCertifiedActivity(externalId:"testactivityid1", attributes: { certIdAttribute: "testcertid" }) {
                           context
                       }
                   }
               "#,
           ))
           .await, @r###"
-        [data.defineItemCertified]
+        [data.defineItemCertifiedActivity]
         context = 'chronicle:activity:testactivityid1'
         "###);
 
@@ -474,7 +474,7 @@ mod test {
           .execute(Request::new(
               r#"
           mutation two {
-            defineItemManufactured(externalId:"testactivityid2", attributes: { batchIdAttribute: "testbatchid" }) {
+            defineItemManufacturedActivity(externalId:"testactivityid2", attributes: { batchIdAttribute: "testbatchid" }) {
                   context
               }
           }
@@ -482,7 +482,7 @@ mod test {
               ),
           )
           .await, @r###"
-        [data.defineItemManufactured]
+        [data.defineItemManufacturedActivity]
         context = 'chronicle:activity:testactivityid2'
         "###);
 
@@ -512,11 +512,11 @@ mod test {
                 r#"
             query test {
                 activityById(id: "chronicle:activity:testactivityid1") {
-                    ... on ItemCertified {
+                    ... on ItemCertifiedActivity {
                         id
                         externalId
                         wasInformedBy {
-                            ... on ItemManufactured {
+                            ... on ItemManufacturedActivity {
                                 batchIdAttribute
                                 id
                                 externalId
@@ -545,14 +545,14 @@ mod test {
           .execute(Request::new(
               r#"
                     mutation three {
-                      defineItemCodified(externalId:"testactivityid3") {
+                      defineItemCodifiedActivity(externalId:"testactivityid3") {
                             context
                         }
                     }
                 "#,
           ))
           .await, @r###"
-        [data.defineItemCodified]
+        [data.defineItemCodifiedActivity]
         context = 'chronicle:activity:testactivityid3'
         "###);
 
@@ -584,15 +584,15 @@ mod test {
                 r#"
                 query test {
                   activityById(id: "chronicle:activity:testactivityid1") {
-                      ... on ItemCertified {
+                      ... on ItemCertifiedActivity {
                           id
                           externalId
                           wasInformedBy {
-                              ... on ItemManufactured {
+                              ... on ItemManufacturedActivity {
                                   id
                                   externalId
                               }
-                              ... on ItemCodified {
+                              ... on ItemCodifiedActivity {
                                   id
                                   externalId
                               }
@@ -626,14 +626,14 @@ mod test {
           .execute(Request::new(
               r#"
                   mutation activity {
-                    defineItemCertified(externalId:"testactivity1", attributes: { certIdAttribute: "testcertid" }) {
+                    defineItemCertifiedActivity(externalId:"testactivity1", attributes: { certIdAttribute: "testcertid" }) {
                           context
                       }
                   }
               "#,
           ))
           .await, @r###"
-        [data.defineItemCertified]
+        [data.defineItemCertifiedActivity]
         context = 'chronicle:activity:testactivity1'
         "###);
 
@@ -642,14 +642,14 @@ mod test {
           .execute(Request::new(
               r#"
                   mutation entity {
-                    defineNCBRecord(externalId:"testentity1") {
+                    defineNCBRecordEntity(externalId:"testentity1") {
                           context
                       }
                   }
               "#,
           ))
           .await, @r###"
-        [data.defineNCBRecord]
+        [data.defineNCBRecordEntity]
         context = 'chronicle:entity:testentity1'
         "###);
 
@@ -679,12 +679,12 @@ mod test {
                 r#"
             query test {
                 activityById(id: "chronicle:activity:testactivity1") {
-                  ... on ItemCertified {
+                  ... on ItemCertifiedActivity {
                         id
                         externalId
                         certIdAttribute
                         generated {
-                            ... on NCBRecord {
+                            ... on NCBRecordEntity {
                               id
                               externalId
                             }
@@ -713,7 +713,7 @@ mod test {
             .execute(Request::new(
                 r#"
             mutation second {
-              defineItem(externalId:"testitem", attributes: { partIdAttribute: "testpartid" }) {
+              defineItemEntity(externalId:"testitem", attributes: { partIdAttribute: "testpartid" }) {
                     context
                 }
             }
@@ -721,7 +721,7 @@ mod test {
                 ),
             )
             .await, @r###"
-        [data.defineItem]
+        [data.defineItemEntity]
         context = 'chronicle:entity:testitem'
         "###);
 
@@ -749,16 +749,16 @@ mod test {
               r#"
               query testagain {
                 activityById(id: "chronicle:activity:testactivity1") {
-                  ... on ItemCertified {
+                  ... on ItemCertifiedActivity {
                         id
                         externalId
                         certIdAttribute
                         generated {
-                            ... on Item {
+                            ... on ItemEntity {
                                 id
                                 externalId
                             }
-                            ... on NCBRecord {
+                            ... on NCBRecordEntity {
                               id
                               externalId
                             }
@@ -788,7 +788,7 @@ mod test {
                 .execute(Request::new(
                     r#"
             mutation {
-                defineContractor(externalId:"testagent1", attributes: { locationAttribute: "testlocation" }) {
+                defineContractorAgent(externalId:"testagent1", attributes: { locationAttribute: "testlocation" }) {
                     context
                 }
             }
@@ -804,7 +804,7 @@ mod test {
             .execute(Request::new(
                 r#"
             mutation {
-              defineNCB(externalId:"testagent2") {
+              defineNCBAgent(externalId:"testagent2") {
                     context
                 }
             }
@@ -820,7 +820,7 @@ mod test {
                 .execute(Request::new(
                     r#"
             mutation {
-              defineCertificate(externalId:"testentity1", attributes: { certIdAttribute: "testcertid" }) {
+              defineCertificateEntity(externalId:"testentity1", attributes: { certIdAttribute: "testcertid" }) {
                     context
                 }
             }
@@ -836,7 +836,7 @@ mod test {
             .execute(Request::new(
                 r#"
             mutation {
-              defineNCBRecord(externalId:"testentity2") {
+              defineNCBRecordEntity(externalId:"testentity2") {
                     context
                 }
             }
@@ -863,7 +863,7 @@ mod test {
                         &format!(
                             r#"
                     mutation {{
-                      defineItemCertified(externalId:"{}", attributes: {{ certIdAttribute: "testcertid" }}) {{
+                      defineItemCertifiedActivity(externalId:"{}", attributes: {{ certIdAttribute: "testcertid" }}) {{
                             context
                         }}
                     }}
@@ -879,7 +879,7 @@ mod test {
                     .execute(Request::new(&format!(
                         r#"
                     mutation {{
-                      defineItemCodified(externalId:"{}") {{
+                      defineItemCodifiedActivity(externalId:"{}") {{
                             context
                         }}
                     }}
@@ -991,7 +991,7 @@ mod test {
                   edges {
                       node {
                           __typename
-                          ... on ItemCertified {
+                          ... on ItemCertifiedActivity {
                             id
                             externalId
                             started
@@ -999,11 +999,11 @@ mod test {
                             wasAssociatedWith {
                                     responsible {
                                       agent {
-                                        ... on Contractor {
+                                        ... on ContractorAgent {
                                             id
                                             externalId
                                         }
-                                        ... on NCB {
+                                        ... on NCBAgent {
                                           id
                                           externalId
                                         }
@@ -1012,17 +1012,17 @@ mod test {
                                     }
                             }
                             used {
-                                ... on Certificate {
+                                ... on CertificateEntity {
                                   id
                                   externalId
                                 }
-                                ... on NCBRecord {
+                                ... on NCBRecordEntity {
                                   id
                                   externalId
                                 }
                             }
                         }
-                          ... on ItemCodified {
+                          ... on ItemCodifiedActivity {
                             id
                             externalId
                             started
@@ -1030,11 +1030,11 @@ mod test {
                             wasAssociatedWith {
                                     responsible {
                                         agent {
-                                            ... on Contractor {
+                                            ... on ContractorAgent {
                                                 id
                                                 externalId
                                             }
-                                            ... on NCB {
+                                            ... on NCBAgent {
                                               id
                                               externalId
                                             }
@@ -1043,11 +1043,11 @@ mod test {
                                     }
                             }
                             used {
-                                ... on Certificate {
+                                ... on CertificateEntity {
                                   id
                                   externalId
                                 }
-                                ... on NCBRecord {
+                                ... on NCBRecordEntity {
                                   id
                                   externalId
                                 }
@@ -1073,7 +1073,7 @@ mod test {
               "edges": [
                 {
                   "node": {
-                    "__typename": "ItemCodified",
+                    "__typename": "ItemCodifiedActivity",
                     "id": "chronicle:activity:anothertestactivity1",
                     "externalId": "anothertestactivity1",
                     "started": "1968-09-02T00:00:00+00:00",
@@ -1100,7 +1100,7 @@ mod test {
                 },
                 {
                   "node": {
-                    "__typename": "ItemCertified",
+                    "__typename": "ItemCertifiedActivity",
                     "id": "chronicle:activity:testactivity2",
                     "externalId": "testactivity2",
                     "started": "1968-09-03T00:00:00+00:00",
@@ -1127,7 +1127,7 @@ mod test {
                 },
                 {
                   "node": {
-                    "__typename": "ItemCodified",
+                    "__typename": "ItemCodifiedActivity",
                     "id": "chronicle:activity:anothertestactivity3",
                     "externalId": "anothertestactivity3",
                     "started": "1968-09-04T00:00:00+00:00",
@@ -1154,7 +1154,7 @@ mod test {
                 },
                 {
                   "node": {
-                    "__typename": "ItemCertified",
+                    "__typename": "ItemCertifiedActivity",
                     "id": "chronicle:activity:testactivity4",
                     "externalId": "testactivity4",
                     "started": "1968-09-05T00:00:00+00:00",
@@ -1181,7 +1181,7 @@ mod test {
                 },
                 {
                   "node": {
-                    "__typename": "ItemCodified",
+                    "__typename": "ItemCodifiedActivity",
                     "id": "chronicle:activity:anothertestactivity5",
                     "externalId": "anothertestactivity5",
                     "started": "1968-09-06T00:00:00+00:00",
@@ -1208,7 +1208,7 @@ mod test {
                 },
                 {
                   "node": {
-                    "__typename": "ItemCertified",
+                    "__typename": "ItemCertifiedActivity",
                     "id": "chronicle:activity:testactivity6",
                     "externalId": "testactivity6",
                     "started": "1968-09-07T00:00:00+00:00",
@@ -1235,7 +1235,7 @@ mod test {
                 },
                 {
                   "node": {
-                    "__typename": "ItemCodified",
+                    "__typename": "ItemCodifiedActivity",
                     "id": "chronicle:activity:anothertestactivity7",
                     "externalId": "anothertestactivity7",
                     "started": "1968-09-08T00:00:00+00:00",
@@ -1262,7 +1262,7 @@ mod test {
                 },
                 {
                   "node": {
-                    "__typename": "ItemCertified",
+                    "__typename": "ItemCertifiedActivity",
                     "id": "chronicle:activity:testactivity8",
                     "externalId": "testactivity8",
                     "started": "1968-09-09T00:00:00+00:00",
@@ -1289,7 +1289,7 @@ mod test {
                 },
                 {
                   "node": {
-                    "__typename": "ItemCodified",
+                    "__typename": "ItemCodifiedActivity",
                     "id": "chronicle:activity:anothertestactivity9",
                     "externalId": "anothertestactivity9",
                     "started": "1968-09-10T00:00:00+00:00",
@@ -1340,7 +1340,7 @@ mod test {
                   edges {
                       node {
                           __typename
-                          ... on ItemCertified {
+                          ... on ItemCertifiedActivity {
                             id
                             externalId
                             started
@@ -1348,11 +1348,11 @@ mod test {
                             wasAssociatedWith {
                                     responsible {
                                         agent {
-                                            ... on Contractor {
+                                            ... on ContractorAgent {
                                                 id
                                                 externalId
                                             }
-                                            ... on NCB {
+                                            ... on NCBAgent {
                                               id
                                               externalId
                                             }
@@ -1361,17 +1361,17 @@ mod test {
                                     }
                             }
                             used {
-                                ... on Certificate {
+                                ... on CertificateEntity {
                                   id
                                   externalId
                                 }
-                                ... on NCBRecord {
+                                ... on NCBRecordEntity {
                                   id
                                   externalId
                                 }
                             }
                         }
-                        ... on ItemCodified {
+                        ... on ItemCodifiedActivity {
                           id
                           externalId
                           started
@@ -1379,11 +1379,11 @@ mod test {
                           wasAssociatedWith {
                                   responsible {
                                       agent {
-                                          ... on Contractor {
+                                          ... on ContractorAgent {
                                                 id
                                                 externalId
                                             }
-                                          ... on NCB {
+                                          ... on NCBAgent {
                                               id
                                               externalId
                                             }
@@ -1392,11 +1392,11 @@ mod test {
                                   }
                           }
                           used {
-                          ... on Certificate {
+                          ... on CertificateEntity {
                             id
                             externalId
                           }
-                          ... on NCBRecord {
+                          ... on NCBRecordEntity {
                             id
                             externalId
                           }
@@ -1422,7 +1422,7 @@ mod test {
               "edges": [
                 {
                   "node": {
-                    "__typename": "ItemCodified",
+                    "__typename": "ItemCodifiedActivity",
                     "id": "chronicle:activity:anothertestactivity9",
                     "externalId": "anothertestactivity9",
                     "started": "1968-09-10T00:00:00+00:00",
@@ -1449,7 +1449,7 @@ mod test {
                 },
                 {
                   "node": {
-                    "__typename": "ItemCertified",
+                    "__typename": "ItemCertifiedActivity",
                     "id": "chronicle:activity:testactivity8",
                     "externalId": "testactivity8",
                     "started": "1968-09-09T00:00:00+00:00",
@@ -1476,7 +1476,7 @@ mod test {
                 },
                 {
                   "node": {
-                    "__typename": "ItemCodified",
+                    "__typename": "ItemCodifiedActivity",
                     "id": "chronicle:activity:anothertestactivity7",
                     "externalId": "anothertestactivity7",
                     "started": "1968-09-08T00:00:00+00:00",
@@ -1503,7 +1503,7 @@ mod test {
                 },
                 {
                   "node": {
-                    "__typename": "ItemCertified",
+                    "__typename": "ItemCertifiedActivity",
                     "id": "chronicle:activity:testactivity6",
                     "externalId": "testactivity6",
                     "started": "1968-09-07T00:00:00+00:00",
@@ -1530,7 +1530,7 @@ mod test {
                 },
                 {
                   "node": {
-                    "__typename": "ItemCodified",
+                    "__typename": "ItemCodifiedActivity",
                     "id": "chronicle:activity:anothertestactivity5",
                     "externalId": "anothertestactivity5",
                     "started": "1968-09-06T00:00:00+00:00",
@@ -1557,7 +1557,7 @@ mod test {
                 },
                 {
                   "node": {
-                    "__typename": "ItemCertified",
+                    "__typename": "ItemCertifiedActivity",
                     "id": "chronicle:activity:testactivity4",
                     "externalId": "testactivity4",
                     "started": "1968-09-05T00:00:00+00:00",
@@ -1584,7 +1584,7 @@ mod test {
                 },
                 {
                   "node": {
-                    "__typename": "ItemCodified",
+                    "__typename": "ItemCodifiedActivity",
                     "id": "chronicle:activity:anothertestactivity3",
                     "externalId": "anothertestactivity3",
                     "started": "1968-09-04T00:00:00+00:00",
@@ -1611,7 +1611,7 @@ mod test {
                 },
                 {
                   "node": {
-                    "__typename": "ItemCertified",
+                    "__typename": "ItemCertifiedActivity",
                     "id": "chronicle:activity:testactivity2",
                     "externalId": "testactivity2",
                     "started": "1968-09-03T00:00:00+00:00",
@@ -1638,7 +1638,7 @@ mod test {
                 },
                 {
                   "node": {
-                    "__typename": "ItemCodified",
+                    "__typename": "ItemCodifiedActivity",
                     "id": "chronicle:activity:anothertestactivity1",
                     "externalId": "anothertestactivity1",
                     "started": "1968-09-02T00:00:00+00:00",
@@ -1682,7 +1682,7 @@ mod test {
                 forEntity: [],
                 forAgent: [],
                 order: NEWEST_FIRST,
-                activityTypes: [ItemCertified, ItemCodified],
+                activityTypes: [ItemCertifiedActivity, ItemCodifiedActivity],
                               ) {
                   pageInfo {
                       hasPreviousPage
@@ -1713,55 +1713,55 @@ mod test {
               "edges": [
                 {
                   "node": {
-                    "__typename": "ItemCodified"
+                    "__typename": "ItemCodifiedActivity"
                   },
                   "cursor": "0"
                 },
                 {
                   "node": {
-                    "__typename": "ItemCertified"
+                    "__typename": "ItemCertifiedActivity"
                   },
                   "cursor": "1"
                 },
                 {
                   "node": {
-                    "__typename": "ItemCodified"
+                    "__typename": "ItemCodifiedActivity"
                   },
                   "cursor": "2"
                 },
                 {
                   "node": {
-                    "__typename": "ItemCertified"
+                    "__typename": "ItemCertifiedActivity"
                   },
                   "cursor": "3"
                 },
                 {
                   "node": {
-                    "__typename": "ItemCodified"
+                    "__typename": "ItemCodifiedActivity"
                   },
                   "cursor": "4"
                 },
                 {
                   "node": {
-                    "__typename": "ItemCertified"
+                    "__typename": "ItemCertifiedActivity"
                   },
                   "cursor": "5"
                 },
                 {
                   "node": {
-                    "__typename": "ItemCodified"
+                    "__typename": "ItemCodifiedActivity"
                   },
                   "cursor": "6"
                 },
                 {
                   "node": {
-                    "__typename": "ItemCertified"
+                    "__typename": "ItemCertifiedActivity"
                   },
                   "cursor": "7"
                 },
                 {
                   "node": {
-                    "__typename": "ItemCodified"
+                    "__typename": "ItemCodifiedActivity"
                   },
                   "cursor": "8"
                 }
@@ -1811,31 +1811,31 @@ mod test {
               "edges": [
                 {
                   "node": {
-                    "__typename": "ItemCodified"
+                    "__typename": "ItemCodifiedActivity"
                   },
                   "cursor": "0"
                 },
                 {
                   "node": {
-                    "__typename": "ItemCodified"
+                    "__typename": "ItemCodifiedActivity"
                   },
                   "cursor": "1"
                 },
                 {
                   "node": {
-                    "__typename": "ItemCodified"
+                    "__typename": "ItemCodifiedActivity"
                   },
                   "cursor": "2"
                 },
                 {
                   "node": {
-                    "__typename": "ItemCodified"
+                    "__typename": "ItemCodifiedActivity"
                   },
                   "cursor": "3"
                 },
                 {
                   "node": {
-                    "__typename": "ItemCodified"
+                    "__typename": "ItemCodifiedActivity"
                   },
                   "cursor": "4"
                 }
@@ -1855,7 +1855,7 @@ mod test {
                 .execute(Request::new(format!(
                     r#"
             mutation {{
-                defineContractor(externalId:"testagent{}", attributes: {{ locationAttribute: "testattribute" }}) {{
+                defineContractorAgent(externalId:"testagent{}", attributes: {{ locationAttribute: "testattribute" }}) {{
                     context
                 }}
             }}
@@ -1876,7 +1876,7 @@ mod test {
           .execute(Request::new(
               r#"
               query {
-              agentsByType(agentType: Contractor) {
+              agentsByType(agentType: ContractorAgent) {
                   pageInfo {
                       hasPreviousPage
                       hasNextPage
@@ -1886,7 +1886,7 @@ mod test {
                   edges {
                       node {
                           __typename
-                          ... on Contractor {
+                          ... on ContractorAgent {
                               id
                               externalId
                               locationAttribute
@@ -1911,7 +1911,7 @@ mod test {
               "edges": [
                 {
                   "node": {
-                    "__typename": "Contractor",
+                    "__typename": "ContractorAgent",
                     "id": "chronicle:agent:testagent0",
                     "externalId": "testagent0",
                     "locationAttribute": "testattribute"
@@ -1920,7 +1920,7 @@ mod test {
                 },
                 {
                   "node": {
-                    "__typename": "Contractor",
+                    "__typename": "ContractorAgent",
                     "id": "chronicle:agent:testagent1",
                     "externalId": "testagent1",
                     "locationAttribute": "testattribute"
@@ -1929,7 +1929,7 @@ mod test {
                 },
                 {
                   "node": {
-                    "__typename": "Contractor",
+                    "__typename": "ContractorAgent",
                     "id": "chronicle:agent:testagent10",
                     "externalId": "testagent10",
                     "locationAttribute": "testattribute"
@@ -1938,7 +1938,7 @@ mod test {
                 },
                 {
                   "node": {
-                    "__typename": "Contractor",
+                    "__typename": "ContractorAgent",
                     "id": "chronicle:agent:testagent11",
                     "externalId": "testagent11",
                     "locationAttribute": "testattribute"
@@ -1947,7 +1947,7 @@ mod test {
                 },
                 {
                   "node": {
-                    "__typename": "Contractor",
+                    "__typename": "ContractorAgent",
                     "id": "chronicle:agent:testagent12",
                     "externalId": "testagent12",
                     "locationAttribute": "testattribute"
@@ -1956,7 +1956,7 @@ mod test {
                 },
                 {
                   "node": {
-                    "__typename": "Contractor",
+                    "__typename": "ContractorAgent",
                     "id": "chronicle:agent:testagent13",
                     "externalId": "testagent13",
                     "locationAttribute": "testattribute"
@@ -1965,7 +1965,7 @@ mod test {
                 },
                 {
                   "node": {
-                    "__typename": "Contractor",
+                    "__typename": "ContractorAgent",
                     "id": "chronicle:agent:testagent14",
                     "externalId": "testagent14",
                     "locationAttribute": "testattribute"
@@ -1974,7 +1974,7 @@ mod test {
                 },
                 {
                   "node": {
-                    "__typename": "Contractor",
+                    "__typename": "ContractorAgent",
                     "id": "chronicle:agent:testagent15",
                     "externalId": "testagent15",
                     "locationAttribute": "testattribute"
@@ -1983,7 +1983,7 @@ mod test {
                 },
                 {
                   "node": {
-                    "__typename": "Contractor",
+                    "__typename": "ContractorAgent",
                     "id": "chronicle:agent:testagent16",
                     "externalId": "testagent16",
                     "locationAttribute": "testattribute"
@@ -1992,7 +1992,7 @@ mod test {
                 },
                 {
                   "node": {
-                    "__typename": "Contractor",
+                    "__typename": "ContractorAgent",
                     "id": "chronicle:agent:testagent17",
                     "externalId": "testagent17",
                     "locationAttribute": "testattribute"
@@ -2014,7 +2014,7 @@ mod test {
           .execute(Request::new(
               r#"
               query {
-              agentsByType(agentType: Contractor, first: 20, after: "3") {
+              agentsByType(agentType: ContractorAgent, first: 20, after: "3") {
                   pageInfo {
                       hasPreviousPage
                       hasNextPage
@@ -2024,7 +2024,7 @@ mod test {
                   edges {
                       node {
                           __typename
-                          ... on Contractor {
+                          ... on ContractorAgent {
                               id
                               externalId
                               locationAttribute
@@ -2049,7 +2049,7 @@ mod test {
               "edges": [
                 {
                   "node": {
-                    "__typename": "Contractor",
+                    "__typename": "ContractorAgent",
                     "id": "chronicle:agent:testagent12",
                     "externalId": "testagent12",
                     "locationAttribute": "testattribute"
@@ -2058,7 +2058,7 @@ mod test {
                 },
                 {
                   "node": {
-                    "__typename": "Contractor",
+                    "__typename": "ContractorAgent",
                     "id": "chronicle:agent:testagent13",
                     "externalId": "testagent13",
                     "locationAttribute": "testattribute"
@@ -2067,7 +2067,7 @@ mod test {
                 },
                 {
                   "node": {
-                    "__typename": "Contractor",
+                    "__typename": "ContractorAgent",
                     "id": "chronicle:agent:testagent14",
                     "externalId": "testagent14",
                     "locationAttribute": "testattribute"
@@ -2076,7 +2076,7 @@ mod test {
                 },
                 {
                   "node": {
-                    "__typename": "Contractor",
+                    "__typename": "ContractorAgent",
                     "id": "chronicle:agent:testagent15",
                     "externalId": "testagent15",
                     "locationAttribute": "testattribute"
@@ -2085,7 +2085,7 @@ mod test {
                 },
                 {
                   "node": {
-                    "__typename": "Contractor",
+                    "__typename": "ContractorAgent",
                     "id": "chronicle:agent:testagent16",
                     "externalId": "testagent16",
                     "locationAttribute": "testattribute"
@@ -2094,7 +2094,7 @@ mod test {
                 },
                 {
                   "node": {
-                    "__typename": "Contractor",
+                    "__typename": "ContractorAgent",
                     "id": "chronicle:agent:testagent17",
                     "externalId": "testagent17",
                     "locationAttribute": "testattribute"
@@ -2103,7 +2103,7 @@ mod test {
                 },
                 {
                   "node": {
-                    "__typename": "Contractor",
+                    "__typename": "ContractorAgent",
                     "id": "chronicle:agent:testagent18",
                     "externalId": "testagent18",
                     "locationAttribute": "testattribute"
@@ -2112,7 +2112,7 @@ mod test {
                 },
                 {
                   "node": {
-                    "__typename": "Contractor",
+                    "__typename": "ContractorAgent",
                     "id": "chronicle:agent:testagent19",
                     "externalId": "testagent19",
                     "locationAttribute": "testattribute"
@@ -2121,7 +2121,7 @@ mod test {
                 },
                 {
                   "node": {
-                    "__typename": "Contractor",
+                    "__typename": "ContractorAgent",
                     "id": "chronicle:agent:testagent2",
                     "externalId": "testagent2",
                     "locationAttribute": "testattribute"
@@ -2130,7 +2130,7 @@ mod test {
                 },
                 {
                   "node": {
-                    "__typename": "Contractor",
+                    "__typename": "ContractorAgent",
                     "id": "chronicle:agent:testagent20",
                     "externalId": "testagent20",
                     "locationAttribute": "testattribute"
@@ -2139,7 +2139,7 @@ mod test {
                 },
                 {
                   "node": {
-                    "__typename": "Contractor",
+                    "__typename": "ContractorAgent",
                     "id": "chronicle:agent:testagent21",
                     "externalId": "testagent21",
                     "locationAttribute": "testattribute"
@@ -2148,7 +2148,7 @@ mod test {
                 },
                 {
                   "node": {
-                    "__typename": "Contractor",
+                    "__typename": "ContractorAgent",
                     "id": "chronicle:agent:testagent22",
                     "externalId": "testagent22",
                     "locationAttribute": "testattribute"
@@ -2157,7 +2157,7 @@ mod test {
                 },
                 {
                   "node": {
-                    "__typename": "Contractor",
+                    "__typename": "ContractorAgent",
                     "id": "chronicle:agent:testagent23",
                     "externalId": "testagent23",
                     "locationAttribute": "testattribute"
@@ -2166,7 +2166,7 @@ mod test {
                 },
                 {
                   "node": {
-                    "__typename": "Contractor",
+                    "__typename": "ContractorAgent",
                     "id": "chronicle:agent:testagent24",
                     "externalId": "testagent24",
                     "locationAttribute": "testattribute"
@@ -2175,7 +2175,7 @@ mod test {
                 },
                 {
                   "node": {
-                    "__typename": "Contractor",
+                    "__typename": "ContractorAgent",
                     "id": "chronicle:agent:testagent25",
                     "externalId": "testagent25",
                     "locationAttribute": "testattribute"
@@ -2184,7 +2184,7 @@ mod test {
                 },
                 {
                   "node": {
-                    "__typename": "Contractor",
+                    "__typename": "ContractorAgent",
                     "id": "chronicle:agent:testagent26",
                     "externalId": "testagent26",
                     "locationAttribute": "testattribute"
@@ -2193,7 +2193,7 @@ mod test {
                 },
                 {
                   "node": {
-                    "__typename": "Contractor",
+                    "__typename": "ContractorAgent",
                     "id": "chronicle:agent:testagent27",
                     "externalId": "testagent27",
                     "locationAttribute": "testattribute"
@@ -2202,7 +2202,7 @@ mod test {
                 },
                 {
                   "node": {
-                    "__typename": "Contractor",
+                    "__typename": "ContractorAgent",
                     "id": "chronicle:agent:testagent28",
                     "externalId": "testagent28",
                     "locationAttribute": "testattribute"
@@ -2211,7 +2211,7 @@ mod test {
                 },
                 {
                   "node": {
-                    "__typename": "Contractor",
+                    "__typename": "ContractorAgent",
                     "id": "chronicle:agent:testagent29",
                     "externalId": "testagent29",
                     "locationAttribute": "testattribute"
@@ -2220,7 +2220,7 @@ mod test {
                 },
                 {
                   "node": {
-                    "__typename": "Contractor",
+                    "__typename": "ContractorAgent",
                     "id": "chronicle:agent:testagent3",
                     "externalId": "testagent3",
                     "locationAttribute": "testattribute"
@@ -2242,7 +2242,7 @@ mod test {
           .execute(Request::new(
               r#"
               query {
-              agentsByType(agentType: Contractor, first: 20, after: "90") {
+              agentsByType(agentType: ContractorAgent, first: 20, after: "90") {
                   pageInfo {
                       hasPreviousPage
                       hasNextPage
@@ -2252,7 +2252,7 @@ mod test {
                   edges {
                       node {
                           __typename
-                          ... on Contractor {
+                          ... on ContractorAgent {
                               id
                               externalId
                               locationAttribute
@@ -2277,7 +2277,7 @@ mod test {
               "edges": [
                 {
                   "node": {
-                    "__typename": "Contractor",
+                    "__typename": "ContractorAgent",
                     "id": "chronicle:agent:testagent91",
                     "externalId": "testagent91",
                     "locationAttribute": "testattribute"
@@ -2286,7 +2286,7 @@ mod test {
                 },
                 {
                   "node": {
-                    "__typename": "Contractor",
+                    "__typename": "ContractorAgent",
                     "id": "chronicle:agent:testagent92",
                     "externalId": "testagent92",
                     "locationAttribute": "testattribute"
@@ -2295,7 +2295,7 @@ mod test {
                 },
                 {
                   "node": {
-                    "__typename": "Contractor",
+                    "__typename": "ContractorAgent",
                     "id": "chronicle:agent:testagent93",
                     "externalId": "testagent93",
                     "locationAttribute": "testattribute"
@@ -2304,7 +2304,7 @@ mod test {
                 },
                 {
                   "node": {
-                    "__typename": "Contractor",
+                    "__typename": "ContractorAgent",
                     "id": "chronicle:agent:testagent94",
                     "externalId": "testagent94",
                     "locationAttribute": "testattribute"
@@ -2313,7 +2313,7 @@ mod test {
                 },
                 {
                   "node": {
-                    "__typename": "Contractor",
+                    "__typename": "ContractorAgent",
                     "id": "chronicle:agent:testagent95",
                     "externalId": "testagent95",
                     "locationAttribute": "testattribute"
@@ -2322,7 +2322,7 @@ mod test {
                 },
                 {
                   "node": {
-                    "__typename": "Contractor",
+                    "__typename": "ContractorAgent",
                     "id": "chronicle:agent:testagent96",
                     "externalId": "testagent96",
                     "locationAttribute": "testattribute"
@@ -2331,7 +2331,7 @@ mod test {
                 },
                 {
                   "node": {
-                    "__typename": "Contractor",
+                    "__typename": "ContractorAgent",
                     "id": "chronicle:agent:testagent97",
                     "externalId": "testagent97",
                     "locationAttribute": "testattribute"
@@ -2340,7 +2340,7 @@ mod test {
                 },
                 {
                   "node": {
-                    "__typename": "Contractor",
+                    "__typename": "ContractorAgent",
                     "id": "chronicle:agent:testagent98",
                     "externalId": "testagent98",
                     "locationAttribute": "testattribute"
@@ -2349,7 +2349,7 @@ mod test {
                 },
                 {
                   "node": {
-                    "__typename": "Contractor",
+                    "__typename": "ContractorAgent",
                     "id": "chronicle:agent:testagent99",
                     "externalId": "testagent99",
                     "locationAttribute": "testattribute"

--- a/chronicle/src/bootstrap/mod.rs
+++ b/chronicle/src/bootstrap/mod.rs
@@ -474,7 +474,7 @@ pub mod test {
 
     #[tokio::test]
     async fn agent_define() {
-        let command_line = r#"chronicle test-agent define test_agent --test-bool-attr false --test-string-attr "test" --test-int-attr 23 --namespace testns "#;
+        let command_line = r#"chronicle test-agent-agent define test_agent --test-bool-attr false --test-string-attr "test" --test-int-attr 23 --namespace testns "#;
 
         insta::assert_snapshot!(
           serde_json::to_string_pretty(
@@ -511,7 +511,7 @@ pub mod test {
     async fn agent_define_id() {
         let id = ChronicleIri::from(common::prov::AgentId::from_external_id("test_agent"));
         let command_line = format!(
-            r#"chronicle test-agent define --test-bool-attr false --test-string-attr "test" --test-int-attr 23 --namespace testns --id {id} "#
+            r#"chronicle test-agent-agent define --test-bool-attr false --test-string-attr "test" --test-int-attr 23 --namespace testns --id {id} "#
         );
 
         insta::assert_snapshot!(
@@ -550,7 +550,7 @@ pub mod test {
         let mut api = test_api().await;
         let id = ChronicleIri::from(common::prov::AgentId::from_external_id("test_agent"));
         let command_line =
-            format!(r#"chronicle test-agent register-key --namespace testns {id} -g "#);
+            format!(r#"chronicle test-agent-agent register-key --namespace testns {id} -g "#);
         let cmd = get_api_cmd(&command_line);
         let delta = api.dispatch(cmd).await.unwrap().unwrap();
         insta::assert_yaml_snapshot!(delta.0, {
@@ -618,7 +618,7 @@ pub mod test {
         let mut api = test_api().await;
 
         // note, if you don't supply all three types of attribute this won't run
-        let command_line = r#"chronicle test-agent define testagent --namespace testns --test-string-attr "test" --test-bool-attr true --test-int-attr 23 "#;
+        let command_line = r#"chronicle test-agent-agent define testagent --namespace testns --test-string-attr "test" --test-bool-attr true --test-int-attr 23 "#;
 
         let cmd = get_api_cmd(command_line);
 
@@ -654,14 +654,14 @@ pub mod test {
 
         let id = AgentId::from_external_id("testagent");
 
-        let command_line = format!(r#"chronicle test-agent use --namespace testns {id} "#);
+        let command_line = format!(r#"chronicle test-agent-agent use --namespace testns {id} "#);
         let cmd = get_api_cmd(&command_line);
 
         api.dispatch(cmd).await.unwrap();
 
         let id = ActivityId::from_external_id("testactivity");
         let command_line = format!(
-            r#"chronicle test-activity start {id} --namespace testns --time 2014-07-08T09:10:11Z "#
+            r#"chronicle test-activity-activity start {id} --namespace testns --time 2014-07-08T09:10:11Z "#
         );
         let cmd = get_api_cmd(&command_line);
 
@@ -707,7 +707,7 @@ pub mod test {
 
     #[tokio::test]
     async fn entity_define() {
-        let command_line = r#"chronicle test-entity define test_entity --test-bool-attr false --test-string-attr "test" --test-int-attr 23 --namespace testns "#;
+        let command_line = r#"chronicle test-entity-entity define test_entity --test-bool-attr false --test-string-attr "test" --test-int-attr 23 --namespace testns "#;
         let _delta = parse_and_execute(command_line, test_cli_model());
 
         insta::assert_snapshot!(
@@ -745,7 +745,7 @@ pub mod test {
     async fn entity_define_id() {
         let id = ChronicleIri::from(common::prov::EntityId::from_external_id("test_entity"));
         let command_line = format!(
-            r#"chronicle test-entity define --test-bool-attr false --test-string-attr "test" --test-int-attr 23 --namespace testns --id {id} "#
+            r#"chronicle test-entity-entity define --test-bool-attr false --test-string-attr "test" --test-int-attr 23 --namespace testns --id {id} "#
         );
 
         insta::assert_snapshot!(
@@ -787,7 +787,7 @@ pub mod test {
         let used_entity_id = EntityId::from_external_id("testusedentity");
 
         let command_line = format!(
-            r#"chronicle test-entity derive {generated_entity_id} {used_entity_id} --namespace testns "#
+            r#"chronicle test-entity-entity derive {generated_entity_id} {used_entity_id} --namespace testns "#
         );
         let cmd = get_api_cmd(&command_line);
 
@@ -833,7 +833,7 @@ pub mod test {
         let used_entity_id = EntityId::from_external_id("testusedentity");
 
         let command_line = format!(
-            r#"chronicle test-entity derive {generated_entity_id} {used_entity_id} --namespace testns --subtype primary-source "#
+            r#"chronicle test-entity-entity derive {generated_entity_id} {used_entity_id} --namespace testns --subtype primary-source "#
         );
         let cmd = get_api_cmd(&command_line);
 
@@ -879,7 +879,7 @@ pub mod test {
         let used_entity_id = EntityId::from_external_id("testusedentity");
 
         let command_line = format!(
-            r#"chronicle test-entity derive {generated_entity_id} {used_entity_id} --namespace testns --subtype revision "#
+            r#"chronicle test-entity-entity derive {generated_entity_id} {used_entity_id} --namespace testns --subtype revision "#
         );
         let cmd = get_api_cmd(&command_line);
 
@@ -925,7 +925,7 @@ pub mod test {
         let used_entity_id = EntityId::from_external_id("testusedentity");
 
         let command_line = format!(
-            r#"chronicle test-entity derive {generated_entity_id} {used_entity_id} --namespace testns --subtype quotation "#
+            r#"chronicle test-entity-entity derive {generated_entity_id} {used_entity_id} --namespace testns --subtype quotation "#
         );
         let cmd = get_api_cmd(&command_line);
 
@@ -965,7 +965,7 @@ pub mod test {
 
     #[tokio::test]
     async fn activity_define() {
-        let command_line = r#"chronicle test-activity define test_activity --test-bool-attr false --test-string-attr "test" --test-int-attr 23 --namespace testns "#;
+        let command_line = r#"chronicle test-activity-activity define test_activity --test-bool-attr false --test-string-attr "test" --test-int-attr 23 --namespace testns "#;
 
         insta::assert_snapshot!(
           serde_json::to_string_pretty(
@@ -1002,7 +1002,7 @@ pub mod test {
     async fn activity_define_id() {
         let id = ChronicleIri::from(common::prov::ActivityId::from_external_id("test_activity"));
         let command_line = format!(
-            r#"chronicle test-activity define --test-bool-attr false --test-string-attr "test" --test-int-attr 23 --namespace testns --id {id} "#
+            r#"chronicle test-activity-activity define --test-bool-attr false --test-string-attr "test" --test-int-attr 23 --namespace testns --id {id} "#
         );
 
         insta::assert_snapshot!(
@@ -1040,18 +1040,18 @@ pub mod test {
     async fn activity_start() {
         let mut api = test_api().await;
 
-        let command_line = r#"chronicle test-agent define testagent --namespace testns --test-string-attr "test" --test-bool-attr true --test-int-attr 40 "#;
+        let command_line = r#"chronicle test-agent-agent define testagent --namespace testns --test-string-attr "test" --test-bool-attr true --test-int-attr 40 "#;
         let cmd = get_api_cmd(command_line);
         api.dispatch(cmd).await.unwrap();
 
         let id = ChronicleIri::from(AgentId::from_external_id("testagent"));
-        let command_line = format!(r#"chronicle test-agent use --namespace testns {id} "#);
+        let command_line = format!(r#"chronicle test-agent-agent use --namespace testns {id} "#);
         let cmd = get_api_cmd(&command_line);
         api.dispatch(cmd).await.unwrap();
 
         let id = ChronicleIri::from(ActivityId::from_external_id("testactivity"));
         let command_line = format!(
-            r#"chronicle test-activity start {id} --namespace testns --time 2014-07-08T09:10:11Z "#
+            r#"chronicle test-activity-activity start {id} --namespace testns --time 2014-07-08T09:10:11Z "#
         );
         let cmd = get_api_cmd(&command_line);
 
@@ -1099,18 +1099,18 @@ pub mod test {
     async fn activity_end() {
         let mut api = test_api().await;
 
-        let command_line = r#"chronicle test-agent define testagent --namespace testns --test-string-attr "test" --test-bool-attr true --test-int-attr 40 "#;
+        let command_line = r#"chronicle test-agent-agent define testagent --namespace testns --test-string-attr "test" --test-bool-attr true --test-int-attr 40 "#;
         let cmd = get_api_cmd(command_line);
         api.dispatch(cmd).await.unwrap();
 
         let id = ChronicleIri::from(AgentId::from_external_id("testagent"));
-        let command_line = format!(r#"chronicle test-agent use --namespace testns {id} "#);
+        let command_line = format!(r#"chronicle test-agent-agent use --namespace testns {id} "#);
         let cmd = get_api_cmd(&command_line);
         api.dispatch(cmd).await.unwrap();
 
         let id = ChronicleIri::from(ActivityId::from_external_id("testactivity"));
         let command_line = format!(
-            r#"chronicle test-activity start {id} --namespace testns --time 2014-07-08T09:10:11Z "#
+            r#"chronicle test-activity-activity start {id} --namespace testns --time 2014-07-08T09:10:11Z "#
         );
         let cmd = get_api_cmd(&command_line);
         api.dispatch(cmd).await.unwrap();
@@ -1118,7 +1118,7 @@ pub mod test {
         // Should end the last opened activity
         let id = ActivityId::from_external_id("testactivity");
         let command_line = format!(
-            r#"chronicle test-activity end --namespace testns --time 2014-08-09T09:10:12Z {id} "#
+            r#"chronicle test-activity-activity end --namespace testns --time 2014-08-09T09:10:12Z {id} "#
         );
         let cmd = get_api_cmd(&command_line);
 
@@ -1152,14 +1152,14 @@ pub mod test {
     async fn activity_generate() {
         let mut api = test_api().await;
 
-        let command_line = r#"chronicle test-activity define testactivity --namespace testns --test-string-attr "test" --test-bool-attr true --test-int-attr 40 "#;
+        let command_line = r#"chronicle test-activity-activity define testactivity --namespace testns --test-string-attr "test" --test-bool-attr true --test-int-attr 40 "#;
         let cmd = get_api_cmd(command_line);
         api.dispatch(cmd).await.unwrap();
 
         let activity_id = ActivityId::from_external_id("testactivity");
         let entity_id = EntityId::from_external_id("testentity");
         let command_line = format!(
-            r#"chronicle test-activity generate --namespace testns {entity_id} {activity_id} "#
+            r#"chronicle test-activity-activity generate --namespace testns {entity_id} {activity_id} "#
         );
         let cmd = get_api_cmd(&command_line);
 
@@ -1194,23 +1194,24 @@ pub mod test {
     async fn activity_use() {
         let mut api = test_api().await;
 
-        let command_line = r#"chronicle test-agent define testagent --namespace testns --test-string-attr "test" --test-bool-attr true --test-int-attr 40 "#;
+        let command_line = r#"chronicle test-agent-agent define testagent --namespace testns --test-string-attr "test" --test-bool-attr true --test-int-attr 40 "#;
         let cmd = get_api_cmd(command_line);
         api.dispatch(cmd).await.unwrap();
 
         let id = ChronicleIri::from(AgentId::from_external_id("testagent"));
-        let command_line = format!(r#"chronicle test-agent use --namespace testns {id} "#);
+        let command_line = format!(r#"chronicle test-agent-agent use --namespace testns {id} "#);
         let cmd = get_api_cmd(&command_line);
         api.dispatch(cmd).await.unwrap();
 
-        let command_line = r#"chronicle test-activity define testactivity --namespace testns --test-string-attr "test" --test-bool-attr true --test-int-attr 40 "#;
+        let command_line = r#"chronicle test-activity-activity define testactivity --namespace testns --test-string-attr "test" --test-bool-attr true --test-int-attr 40 "#;
         let cmd = get_api_cmd(command_line);
         api.dispatch(cmd).await.unwrap();
 
         let activity_id = ActivityId::from_external_id("testactivity");
         let entity_id = EntityId::from_external_id("testentity");
-        let command_line =
-            format!(r#"chronicle test-activity use --namespace testns {entity_id} {activity_id} "#);
+        let command_line = format!(
+            r#"chronicle test-activity-activity use --namespace testns {entity_id} {activity_id} "#
+        );
 
         let cmd = get_api_cmd(&command_line);
 

--- a/chronicle/src/codegen/model.rs
+++ b/chronicle/src/codegen/model.rs
@@ -134,14 +134,13 @@ pub struct AgentDef {
 
 impl TypeName for &AgentDef {
     fn as_type_name(&self) -> String {
-        match (
-            self.external_id.chars().next(),
-            self.external_id.chars().nth(1),
-            &self.external_id[1..],
-        ) {
-            (_, Some(c), _) if c.is_uppercase() => self.external_id.clone(),
-            (Some(first), _, body) => format!("{}{}", first.to_uppercase(), body),
-            _ => to_pascal_case(&self.external_id),
+        match &self.external_id {
+            ex_id if ex_id == "ProvAgent" => ex_id.to_owned(),
+            ex_id => match (ex_id.chars().next(), ex_id.chars().nth(1), &ex_id[1..]) {
+                (_, Some(c), _) if c.is_uppercase() => format!("{}Agent", self.external_id.clone()),
+                (Some(first), _, body) => format!("{}{}Agent", first.to_uppercase(), body),
+                _ => format!("{}Agent", to_pascal_case(&self.external_id)),
+            },
         }
     }
 
@@ -202,14 +201,15 @@ pub struct EntityDef {
 
 impl TypeName for &EntityDef {
     fn as_type_name(&self) -> String {
-        match (
-            self.external_id.chars().next(),
-            self.external_id.chars().nth(1),
-            &self.external_id[1..],
-        ) {
-            (_, Some(c), _) if c.is_uppercase() => self.external_id.clone(),
-            (Some(first), _, body) => format!("{}{}", first.to_uppercase(), body),
-            _ => to_pascal_case(&self.external_id),
+        match &self.external_id {
+            ex_id if ex_id == "ProvEntity" => ex_id.to_owned(),
+            ex_id => match (ex_id.chars().next(), ex_id.chars().nth(1), &ex_id[1..]) {
+                (_, Some(c), _) if c.is_uppercase() => {
+                    format!("{}Entity", self.external_id.clone())
+                }
+                (Some(first), _, body) => format!("{}{}Entity", first.to_uppercase(), body),
+                _ => format!("{}Entity", to_pascal_case(&self.external_id)),
+            },
         }
     }
 
@@ -270,14 +270,15 @@ pub struct ActivityDef {
 
 impl TypeName for &ActivityDef {
     fn as_type_name(&self) -> String {
-        match (
-            self.external_id.chars().next(),
-            self.external_id.chars().nth(1),
-            &self.external_id[1..],
-        ) {
-            (_, Some(c), _) if c.is_uppercase() => self.external_id.clone(),
-            (Some(first), _, body) => format!("{}{}", first.to_uppercase(), body),
-            _ => to_pascal_case(&self.external_id),
+        match &self.external_id {
+            ex_id if ex_id == "ProvActivity" => ex_id.to_owned(),
+            ex_id => match (ex_id.chars().next(), ex_id.chars().nth(1), &ex_id[1..]) {
+                (_, Some(c), _) if c.is_uppercase() => {
+                    format!("{}Activity", self.external_id.clone())
+                }
+                (Some(first), _, body) => format!("{}{}Activity", first.to_uppercase(), body),
+                _ => format!("{}Activity", to_pascal_case(&self.external_id)),
+            },
         }
     }
 
@@ -1077,15 +1078,15 @@ pub mod test {
           String:
             type: String
         agents:
-          Friend:
+          FriendAgent:
             attributes:
               - String
         entities:
-          Octopi:
+          OctopiEntity:
             attributes:
               - String
         activities:
-          Gardening:
+          GardeningActivity:
             attributes:
               - String
         roles:


### PR DESCRIPTION
## [CHRON-122](https://blockchaintp.atlassian.net/browse/CHRON-122)
## [Notes](https://blockchaintp.atlassian.net/wiki/spaces/~62816e8604eb160068349638/pages/1513488385/Better+Isolation+of+user+domain+terms#Note)

- [Test domain with target vocabulary](https://blockchaintp.atlassian.net/wiki/spaces/~62816e8604eb160068349638/pages/1513488385/Better+Isolation+of+user+domain+terms#Test-Domain-With-Target-Vocabulary)
- [Schema Generated From Test Domain](https://blockchaintp.atlassian.net/wiki/spaces/~62816e8604eb160068349638/pages/1513488385/Better+Isolation+of+user+domain+terms#Schema-Generated-From-Test-Domain)
---

## BREAKING CHANGE: 
All domain types except for Attributes will be suffixed with their PROV type (Activity, Agent, or Entity) in all their manifestations--`defineContractorAgent`, `... on ItemEntity`, and so on. CLI commands and GraphQL mutations and queries will need to be written with this in mind.

---
Signed-off-by: Joseph Livesey <joseph@blockchaintp.com>