### PR TITLE
Clean up warnings in generated code

### DIFF
--- a/chronicle-domain-test/build.rs
+++ b/chronicle-domain-test/build.rs
@@ -51,10 +51,10 @@ fn main() {
 
     let model = ChronicleDomainDef::from_input_string(&s).unwrap();
 
-    generate_chronicle_domain_schema(model, "src/main.rs");
+    generate_chronicle_domain_schema(model, "src/generated.rs");
 
     Command::new("cargo")
-        .args(["fmt", "--", "src/main.rs"])
+        .args(["fmt", "--", "src/generated.rs"])
         .output()
         .expect("formatting");
 }

--- a/chronicle-domain-test/src/test.rs
+++ b/chronicle-domain-test/src/test.rs
@@ -1,10 +1,10 @@
 use chronicle::{
     api::chronicle_graphql::ChronicleGraphQl, bootstrap, codegen::ChronicleDomainDef, tokio,
 };
-use main::{Mutation, Query};
+use generated::{Mutation, Query};
 
 #[allow(dead_code)]
-mod main;
+mod generated;
 
 ///Entry point here is jigged a little, as we want to run unit tests, see chronicle-untyped for the actual pattern
 #[tokio::main]

--- a/chronicle/src/codegen/mod.rs
+++ b/chronicle/src/codegen/mod.rs
@@ -104,6 +104,7 @@ fn gen_type_enums(domain: &ChronicleDomainDef) -> rust::Tokens {
 
         #[derive(#graphql_enum, Copy, Clone, Eq, PartialEq)]
         #[allow(clippy::upper_case_acronyms)]
+        #[allow(clippy::enum_variant_names)]
         pub enum AgentType {
             #[graphql(name = "ProvAgent", visible=true)]
             ProvAgent,
@@ -127,6 +128,7 @@ fn gen_type_enums(domain: &ChronicleDomainDef) -> rust::Tokens {
 
         #[derive(#graphql_enum, Copy, Clone, Eq, PartialEq)]
         #[allow(clippy::upper_case_acronyms)]
+        #[allow(clippy::enum_variant_names)]
         pub enum EntityType {
             #[graphql(name = "ProvEntity", visible=true)]
             ProvEntity,
@@ -150,6 +152,7 @@ fn gen_type_enums(domain: &ChronicleDomainDef) -> rust::Tokens {
 
         #[derive(#graphql_enum, Copy, Clone, Eq, PartialEq)]
         #[allow(clippy::upper_case_acronyms)]
+        #[allow(clippy::enum_variant_names)]
         pub enum ActivityType {
             #[graphql(name = "ProvActivity", visible=true)]
             ProvActivity,
@@ -675,6 +678,7 @@ fn gen_mappers(domain: &ChronicleDomainDef) -> rust::Tokens {
     let activity_impl = &rust::import("chronicle::api::chronicle_graphql", "Activity").qualified();
 
     quote! {
+    #[allow(clippy::match_single_binding)]
     fn map_agent_to_domain_type(agent: #agent_impl) -> #(agent_union_type_name()) {
         match agent.domaintype.as_deref() {
             #(for agent in domain.agents.iter() =>
@@ -717,7 +721,7 @@ fn gen_mappers(domain: &ChronicleDomainDef) -> rust::Tokens {
             }
         }
     }
-
+    #[allow(clippy::match_single_binding)]
     fn map_activity_to_domain_type(activity: #activity_impl) -> #(activity_union_type_name()) {
         match activity.domaintype.as_deref() {
             #(for activity in domain.activities.iter() =>
@@ -728,7 +732,7 @@ fn gen_mappers(domain: &ChronicleDomainDef) -> rust::Tokens {
             _ => #(activity_union_type_name())::ProvActivity(ProvActivity(activity))
         }
     }
-
+    #[allow(clippy::match_single_binding)]
     fn map_entity_to_domain_type(entity: #entity_impl) -> #(entity_union_type_name()) {
         match entity.domaintype.as_deref() {
             #(for entity in domain.entities.iter() =>

--- a/common/src/protocol.rs
+++ b/common/src/protocol.rs
@@ -46,6 +46,8 @@ static PROTOCOL_VERSION: &str = "1";
 // Include the `submission` module, which is
 // generated from ./protos/submission.proto.
 pub mod messages {
+    #![allow(clippy::derive_partial_eq_without_eq)]
+
     include!(concat!(env!("OUT_DIR"), "/_.rs"));
 }
 

--- a/sawtooth-protocol/src/lib.rs
+++ b/sawtooth-protocol/src/lib.rs
@@ -4,5 +4,7 @@ pub mod messages;
 pub mod messaging;
 
 mod sawtooth {
+    #![allow(clippy::derive_partial_eq_without_eq)]
+
     include!(concat!(env!("OUT_DIR"), "/_.rs"));
 }


### PR DESCRIPTION
## [CHRON-138](https://blockchaintp.atlassian.net/browse/CHRON-138)
- the `mod main;` complaint in chronicle-domain-test
- additional enum variant names
- match single binding
- deriving partial eq w/out eq in generated protobufs
---
Signed-off-by: Joseph Livesey <joseph@blockchaintp.com>