### PR TITLE
build(cargo): add git fetch with cli to config

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -3,3 +3,6 @@ linker = "aarch64-linux-gnu-gcc"
 
 [target.x86_64-unknown-linux-gnu]
 linker = "x86_64-linux-gnu-gcc"
+
+[net]
+git-fetch-with-cli = true   # use the `git` executable for git operations


### PR DESCRIPTION
- [similar issue](https://users.rust-lang.org/t/cargo-uses-too-much-memory-being-run-in-qemu/76531), [and another](https://github.com/rust-lang/cargo/issues/9335)
- [net.git-fetch-with-cli](https://doc.rust-lang.org/cargo/reference/config.html#netgit-fetch-with-cli)
- [`.cargo/config` configuration format](https://doc.rust-lang.org/cargo/reference/config.html#configuration-format)
---
Signed-off-by: Joseph Livesey <joseph@blockchaintp.com>