### PR TITLE
Allow one of id / externalid for relational mutations and ById queries ids

### DIFF
--- a/crates/chronicle-domain-test/src/test.rs
+++ b/crates/chronicle-domain-test/src/test.rs
@@ -132,6 +132,228 @@ mod test {
     }
 
     #[tokio::test]
+    async fn one_of_id_or_external() {
+        let schema = test_schema().await;
+
+        let external_id_input = chronicle::async_graphql::Name::new("withexternalid");
+
+        insta::assert_json_snapshot!(schema
+          .execute(Request::new(
+            &format!(
+            r#"
+          mutation {{
+            defineContractorAgent(
+              externalId: "{external_id_input}",
+              attributes: {{ locationAttribute: "location" }}
+            ) {{
+              context
+            }}
+            defineAgent(
+              externalId: "{external_id_input}",
+              attributes: {{ type: "attribute" }}
+            ) {{
+              context
+            }}
+            actedOnBehalfOf(
+              delegate: {{ externalId: "{external_id_input}", }}
+              responsible: {{ externalId: "{external_id_input}" }}
+              role: UNSPECIFIED
+            ) {{
+              context
+            }}
+            defineItemEntity(
+              externalId: "{external_id_input}",
+              attributes: {{ partIdAttribute: "part"}}
+            ) {{
+              context
+            }}
+            defineCertificateEntity(
+              externalId: "{external_id_input}",
+              attributes: {{ certIdAttribute: "cert" }}
+            ) {{
+              context
+            }}
+            wasDerivedFrom(
+              generatedEntity: {{ externalId: "{external_id_input}" }}
+              usedEntity: {{ externalId: "{external_id_input}" }}
+            ) {{
+              context
+            }}
+            wasRevisionOf(
+              generatedEntity: {{ externalId: "{external_id_input}" }}
+              usedEntity: {{ externalId: "{external_id_input}" }}
+            ) {{
+              context
+            }}
+            hadPrimarySource(
+              generatedEntity: {{ externalId: "{external_id_input}" }}
+              usedEntity: {{ externalId: "{external_id_input}" }}
+            ) {{
+              context
+            }}
+            wasQuotedFrom(
+              generatedEntity: {{ externalId: "{external_id_input}" }}
+              usedEntity: {{ externalId: "{external_id_input}" }}
+            ) {{
+              context
+            }}
+            generateKey(
+              id: {{ externalId: "{external_id_input}" }}
+            ) {{
+              context
+            }}
+            defineItemCertifiedActivity(
+              externalId: "{external_id_input}"
+              attributes: {{ certIdAttribute: "cert" }}
+            ) {{
+              context
+            }}
+            defineActivity(
+              externalId: "{external_id_input}"
+              attributes: {{ type: "attr" }}
+            ) {{
+              context
+            }}
+            instantActivity(
+              id: {{ externalId: "{external_id_input}" }}
+            ) {{
+              context
+            }}
+            wasAssociatedWith(
+              responsible: {{ externalId: "{external_id_input}" }}
+              activity: {{ externalId: "{external_id_input}" }}
+              role: UNSPECIFIED
+            ) {{
+              context
+            }}
+            used(
+              activity: {{ externalId: "{external_id_input}" }}
+              id: {{ externalId: "{external_id_input}" }}
+            ) {{
+              context
+            }}
+            wasInformedBy(
+              informingActivity: {{ externalId: "anotherexternalid" }}
+              activity: {{ externalId: "{external_id_input}" }}
+            ) {{
+              context
+            }}
+            wasGeneratedBy(
+              id: {{ externalId: "{external_id_input}" }}
+              activity: {{ externalId: "{external_id_input}" }}
+            ) {{
+              context
+            }}
+          }}
+            "#
+                ),
+              ))
+                .await, @r###"
+        {
+          "data": {
+            "defineContractorAgent": {
+              "context": "chronicle:agent:withexternalid"
+            },
+            "defineAgent": {
+              "context": "chronicle:agent:withexternalid"
+            },
+            "actedOnBehalfOf": {
+              "context": "chronicle:agent:withexternalid"
+            },
+            "defineItemEntity": {
+              "context": "chronicle:entity:withexternalid"
+            },
+            "defineCertificateEntity": {
+              "context": "chronicle:entity:withexternalid"
+            },
+            "wasDerivedFrom": {
+              "context": "chronicle:entity:withexternalid"
+            },
+            "wasRevisionOf": {
+              "context": "chronicle:entity:withexternalid"
+            },
+            "hadPrimarySource": {
+              "context": "chronicle:entity:withexternalid"
+            },
+            "wasQuotedFrom": {
+              "context": "chronicle:entity:withexternalid"
+            },
+            "generateKey": {
+              "context": "chronicle:agent:withexternalid"
+            },
+            "defineItemCertifiedActivity": {
+              "context": "chronicle:activity:withexternalid"
+            },
+            "defineActivity": {
+              "context": "chronicle:activity:withexternalid"
+            },
+            "instantActivity": {
+              "context": "chronicle:activity:withexternalid"
+            },
+            "wasAssociatedWith": {
+              "context": "chronicle:agent:withexternalid"
+            },
+            "used": {
+              "context": "chronicle:entity:withexternalid"
+            },
+            "wasInformedBy": {
+              "context": "chronicle:activity:withexternalid"
+            },
+            "wasGeneratedBy": {
+              "context": "chronicle:entity:withexternalid"
+            }
+          }
+        }
+        "###);
+
+        insta::assert_json_snapshot!(schema
+          .execute(Request::new(
+            &format!(
+            r#"
+          query multipleQueries {{
+            activityById(id: {{externalId: "{external_id_input}" }}) {{
+              ... on ProvActivity {{
+                id
+                externalId
+              }}
+            }}
+            agentById(id: {{externalId: "{external_id_input}" }}) {{
+              ... on ProvAgent {{
+                id
+                externalId
+              }}
+            }}
+            entityById(id: {{externalId: "{external_id_input}" }}) {{
+              ... on CertificateEntity {{
+                id
+                externalId
+              }}
+            }}
+          }}
+          "#
+        ),
+      ))
+        .await, @r###"
+        {
+          "data": {
+            "activityById": {
+              "id": "chronicle:activity:withexternalid",
+              "externalId": "withexternalid"
+            },
+            "agentById": {
+              "id": "chronicle:agent:withexternalid",
+              "externalId": "withexternalid"
+            },
+            "entityById": {
+              "id": "chronicle:entity:withexternalid",
+              "externalId": "withexternalid"
+            }
+          }
+        }
+        "###);
+    }
+
+    #[tokio::test]
     async fn generic_json_object_attribute() {
         let schema = test_schema().await;
 
@@ -169,7 +391,7 @@ mod test {
           .execute(Request::new(
             r#"
             query agent {
-              agentById(id: "chronicle:agent:testagent2") {
+              agentById(id: {id: "chronicle:agent:testagent2" }) {
                 __typename
                 ... on NCBAgent {
                   id
@@ -209,8 +431,8 @@ mod test {
               r#"
           mutation {
               actedOnBehalfOf(
-                  responsible: "chronicle:agent:testagent",
-                  delegate: "http://blockchaintp.com/chronicle/ns#agent:testdelegate",
+                  responsible: { id: "chronicle:agent:testagent" },
+                  delegate: { id: "http://blockchaintp.com/chronicle/ns#agent:testdelegate" },
                   role: MANUFACTURER
                   ) {
                   context
@@ -229,7 +451,7 @@ mod test {
           .execute(Request::new(
               r#"
           query {
-              agentById(id: "chronicle:agent:testagent") {
+              agentById(id: { id: "chronicle:agent:testagent" }) {
                   ... on ProvAgent {
                       id
                       externalId
@@ -272,8 +494,8 @@ mod test {
             .execute(Request::new(
                 r#"
             mutation {
-                wasDerivedFrom(generatedEntity: "chronicle:entity:testentity1",
-                               usedEntity: "chronicle:entity:testentity2") {
+                wasDerivedFrom(generatedEntity: {id: "chronicle:entity:testentity1" },
+                               usedEntity: {id: "chronicle:entity:testentity2" }) {
                     context
                 }
             }
@@ -291,7 +513,7 @@ mod test {
             .execute(Request::new(
                 r#"
             query {
-                entityById(id: "chronicle:entity:testentity1") {
+                entityById(id: {id: "chronicle:entity:testentity1" }) {
                     ... on ProvEntity {
                         id
                         externalId
@@ -324,8 +546,8 @@ mod test {
             .execute(Request::new(
                 r#"
             mutation {
-                hadPrimarySource(generatedEntity: "chronicle:entity:testentity1",
-                               usedEntity: "chronicle:entity:testentity2") {
+                hadPrimarySource(generatedEntity: {id: "chronicle:entity:testentity1" },
+                               usedEntity: {id: "chronicle:entity:testentity2" }) {
                     context
                 }
             }
@@ -343,7 +565,7 @@ mod test {
             .execute(Request::new(
                 r#"
             query {
-                entityById(id: "chronicle:entity:testentity1") {
+                entityById(id: {id: "chronicle:entity:testentity1" }) {
 
                     ... on ProvEntity {
                         id
@@ -385,8 +607,8 @@ mod test {
             .execute(Request::new(
                 r#"
             mutation {
-                wasRevisionOf(generatedEntity: "chronicle:entity:testentity1",
-                            usedEntity: "chronicle:entity:testentity2") {
+                wasRevisionOf(generatedEntity: {id: "chronicle:entity:testentity1" },
+                            usedEntity: {id: "chronicle:entity:testentity2" }) {
                     context
                 }
             }
@@ -404,7 +626,7 @@ mod test {
             .execute(Request::new(
                 r#"
             query {
-                entityById(id: "chronicle:entity:testentity1") {
+                entityById(id: {id: "chronicle:entity:testentity1" }) {
                     ... on ProvEntity {
                         id
                         externalId
@@ -445,8 +667,8 @@ mod test {
             .execute(Request::new(
                 r#"
             mutation {
-                wasQuotedFrom(generatedEntity: "chronicle:entity:testentity1",
-                            usedEntity: "chronicle:entity:testentity2") {
+                wasQuotedFrom(generatedEntity: {id: "chronicle:entity:testentity1" },
+                            usedEntity: {id: "chronicle:entity:testentity2" }) {
                     context
                 }
             }
@@ -464,7 +686,7 @@ mod test {
             .execute(Request::new(
                 r#"
             query {
-                entityById(id: "chronicle:entity:testentity1") {
+                entityById(id: {id: "chronicle:entity:testentity1" }) {
                     ... on ProvEntity {
                         id
                         externalId
@@ -690,8 +912,8 @@ mod test {
           .execute(Request::new(
               r#"
           mutation exec {
-              wasInformedBy(activity: "chronicle:activity:testactivityid1",
-              informingActivity: "chronicle:activity:testactivityid2",)
+              wasInformedBy(activity: {id: "chronicle:activity:testactivityid1" },
+              informingActivity: {id: "chronicle:activity:testactivityid2" },)
               {
                   context
               }
@@ -710,7 +932,7 @@ mod test {
             .execute(Request::new(
                 r#"
             query test {
-                activityById(id: "chronicle:activity:testactivityid1") {
+                activityById(id: {id: "chronicle:activity:testactivityid1" }) {
                     ... on ItemCertifiedActivity {
                         id
                         externalId
@@ -762,8 +984,8 @@ mod test {
           .execute(Request::new(
               r#"
           mutation execagain {
-              wasInformedBy(activity: "chronicle:activity:testactivityid1",
-              informingActivity: "chronicle:activity:testactivityid3",)
+              wasInformedBy(activity: {id: "chronicle:activity:testactivityid1" },
+              informingActivity: {id: "chronicle:activity:testactivityid3" },)
               {
                   context
               }
@@ -782,7 +1004,7 @@ mod test {
             .execute(Request::new(
                 r#"
                 query test {
-                  activityById(id: "chronicle:activity:testactivityid1") {
+                  activityById(id: {id: "chronicle:activity:testactivityid1" }) {
                       ... on ItemCertifiedActivity {
                           id
                           externalId
@@ -857,8 +1079,8 @@ mod test {
           .execute(Request::new(
               r#"
           mutation generated {
-              wasGeneratedBy(activity: "chronicle:activity:testactivity1",
-              id: "chronicle:entity:testentity1",)
+              wasGeneratedBy(activity: { id: "chronicle:activity:testactivity1" },
+              id: { id: "chronicle:entity:testentity1" },)
               {
                   context
               }
@@ -877,7 +1099,7 @@ mod test {
             .execute(Request::new(
                 r#"
             query test {
-                activityById(id: "chronicle:activity:testactivity1") {
+                activityById(id: {id: "chronicle:activity:testactivity1" }) {
                   ... on ItemCertifiedActivity {
                         id
                         externalId
@@ -929,8 +1151,8 @@ mod test {
             .execute(Request::new(
                 r#"
             mutation again {
-                wasGeneratedBy(id: "chronicle:entity:testitem",
-                activity: "chronicle:activity:testactivityid1",)
+                wasGeneratedBy(id: { id: "chronicle:entity:testitem" },
+                activity: { id: "chronicle:activity:testactivityid1" },)
                 {
                     context
                 }
@@ -947,7 +1169,7 @@ mod test {
           .execute(Request::new(
               r#"
               query testagain {
-                activityById(id: "chronicle:activity:testactivity1") {
+                activityById(id: {id: "chronicle:activity:testactivity1" }) {
                   ... on ItemCertifiedActivity {
                         id
                         externalId
@@ -1101,7 +1323,7 @@ mod test {
                 .execute(Request::new(format!(
                     r#"
             mutation {{
-                used(id: "chronicle:entity:testentity1", activity: "chronicle:activity:{}") {{
+                used(id: {{ id: "chronicle:entity:testentity1" }}, activity: {{id: "chronicle:activity:{}" }}) {{
                     context
                 }}
             }}
@@ -1117,7 +1339,7 @@ mod test {
                 .execute(Request::new(format!(
                     r#"
                   mutation {{
-                      startActivity( time: "{}", id: "chronicle:activity:{}") {{
+                      startActivity( time: "{}", id: {{id: "chronicle:activity:{}" }}) {{
                           context
                       }}
                   }}
@@ -1135,7 +1357,7 @@ mod test {
                 .execute(Request::new(format!(
                     r#"
             mutation {{
-                endActivity( time: "{}", id: "chronicle:activity:{}") {{
+                endActivity( time: "{}", id: {{ id: "chronicle:activity:{}" }}) {{
                     context
                 }}
             }}
@@ -1161,7 +1383,7 @@ mod test {
                 .execute(Request::new(format!(
                     r#"
             mutation {{
-                wasAssociatedWith( role: CERTIFIER, responsible: "chronicle:agent:{}", activity: "chronicle:activity:{}") {{
+                wasAssociatedWith( role: CERTIFIER, responsible: {{ id: "chronicle:agent:{}" }}, activity: {{id: "chronicle:activity:{}" }}) {{
                     context
                 }}
             }}

--- a/crates/common/src/prov/id/mod.rs
+++ b/crates/common/src/prov/id/mod.rs
@@ -1,4 +1,5 @@
 mod graphlql_scalars;
+use async_graphql::OneofObject;
 pub use graphlql_scalars::*;
 use tracing::trace;
 
@@ -758,6 +759,21 @@ impl From<&EntityId> for IriRefBuf {
     }
 }
 
+#[derive(OneofObject)]
+pub enum EntityIdOrExternal {
+    ExternalId(String),
+    Id(EntityId),
+}
+
+impl From<EntityIdOrExternal> for EntityId {
+    fn from(input: EntityIdOrExternal) -> Self {
+        match input {
+            EntityIdOrExternal::ExternalId(external_id) => Self::from_external_id(external_id),
+            EntityIdOrExternal::Id(id) => id,
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize, PartialEq, Eq, Hash, Debug, Clone, Ord, PartialOrd)]
 pub struct AgentId(ExternalId);
 
@@ -797,6 +813,21 @@ impl<'a> TryFrom<Iri<'a>> for AgentId {
 impl From<&AgentId> for IriRefBuf {
     fn from(val: &AgentId) -> Self {
         Chronicle::agent(&val.0).into()
+    }
+}
+
+#[derive(OneofObject)]
+pub enum AgentIdOrExternal {
+    ExternalId(String),
+    Id(AgentId),
+}
+
+impl From<AgentIdOrExternal> for AgentId {
+    fn from(input: AgentIdOrExternal) -> Self {
+        match input {
+            AgentIdOrExternal::ExternalId(external_id) => Self::from_external_id(external_id),
+            AgentIdOrExternal::Id(id) => id,
+        }
     }
 }
 
@@ -840,5 +871,20 @@ impl<'a> TryFrom<Iri<'a>> for ActivityId {
 impl From<&ActivityId> for IriRefBuf {
     fn from(val: &ActivityId) -> Self {
         Chronicle::activity(&val.0).into()
+    }
+}
+
+#[derive(OneofObject)]
+pub enum ActivityIdOrExternal {
+    ExternalId(String),
+    Id(ActivityId),
+}
+
+impl From<ActivityIdOrExternal> for ActivityId {
+    fn from(input: ActivityIdOrExternal) -> Self {
+        match input {
+            ActivityIdOrExternal::ExternalId(external_id) => Self::from_external_id(external_id),
+            ActivityIdOrExternal::Id(id) => id,
+        }
     }
 }

--- a/docs/domain_modelling.md
+++ b/docs/domain_modelling.md
@@ -483,7 +483,7 @@ The Agent's id and JSON attribute data can then be queried like so:
 
 ```graphql
 query agentQuery {
-  agentById(id: "chronicle:agent:testagent") {
+  agentById(id: { id: "chronicle:agent:testagent" }) {
     __typename
     ... on TestAgent {
       id

--- a/docs/querying_provenance.md
+++ b/docs/querying_provenance.md
@@ -41,9 +41,9 @@ type Query {
     first: Int
     last: Int
   ): EntityConnection!
-  agentById(id: AgentID!, namespace: String): Agent
-  activityById(id: ActivityID!, namespace: String): Activity
-  entityById(id: EntityID!, namespace: String): Entity
+  agentById(id: AgentIdOrExternal!, namespace: String): Agent
+  activityById(id: ActivityIdOrExternal!, namespace: String): Activity
+  entityById(id: EntityIdOrExternal!, namespace: String): Entity
 }
 ```
 

--- a/docs/recording_provenance.md
+++ b/docs/recording_provenance.md
@@ -17,8 +17,8 @@ For example:
 ```graphql title="'homer' in the activity 'writing-the-iliad' as a writer"
 mutation {
     wasAssociatedWith(
-        activity: "chronicle:activity:writing-the-iliad",
-        responsible: "chronicle:agent:homer",
+        activity: { id: "chronicle:activity:writing-the-iliad" },
+        responsible: { id: "chronicle:agent:homer" },
         role: writer
     )
 }
@@ -65,11 +65,11 @@ recorded - one of these mutations will fail.
 
 ```graphql
     mutation {
-        endActivity(id:"chronicle:activity:birthday",
+        endActivity(id: {id: "chronicle:activity:birthday" },
             time: "2022-07-29T12:41:52.433Z"
         )
 
-        endActivity(id:"chronicle:activity:birthday",
+        endActivity(id: {id: "chronicle:activity:birthday" },
             time: "2020-07-29T12:41:52.433Z"
         )
     }
@@ -129,7 +129,7 @@ An external CMS is being used that has identifiers for documents and users.
 ### The `externalId` parameter
 
 The definition mutations for prov terms -  Entity, Activity and Agent - are all
-supplied with a `externalId` parameter. This should be something meaningful to the
+supplied with an `externalId` parameter. This should be something meaningful to the
 domain you are recording provenance for - a unique identifier from an external
 system or a natural key. This will form part of the identity of the term.
 
@@ -152,8 +152,8 @@ type Submission {
 ```
 
 The `context` property here will be the identity of the Chronicle term you have
-changed in the mutation, i.e calling `agent(..)` will return the identity of the
-agent, calling `startActivity(..)` the identity of the started activity.
+changed in the mutation, i.e calling `defineAgent(..)` will return the identity of
+the agent, calling `startActivity(..)` the identity of the started activity.
 
 The `txId` property corresponds to the transaction id when running
 Chronicle with a backend ledger, or a randomly generated uuid when used in
@@ -594,7 +594,7 @@ To apply using GraphQL:
 
 ```graphql
 mutation {
-  used(activity: "chronicle:activity:september-2018-review", id: "chronicle:entity:anaphylaxis-evidence-12114")
+  used(activity: { id: "chronicle:activity:september-2018-review" }, id: {id: "chronicle:entity:anaphylaxis-evidence-12114" })
 }
 ```
 
@@ -619,7 +619,10 @@ To apply using GraphQL:
 
 ```graphql
 mutation {
-  wasGeneratedBy(activity: "chronicle:activity:september-2018-review", id: "chronicle:entity:anaphylaxis-guidance-9-2018")
+  wasGeneratedBy(
+    activity: {id: "chronicle:activity:september-2018-review" },
+    id: {id: "chronicle:entity:anaphylaxis-guidance-9-2018" }
+  )
 }
 ```
 
@@ -652,7 +655,10 @@ modelling.
 
 ```graphql
 mutation {
-  startActivity(id: "chronicle:activity:september-2018-review",time:"2002-10-02T15:00:00Z")
+  startActivity(
+    id: {id: "chronicle:activity:september-2018-review" },
+    time:"2002-10-02T15:00:00Z"
+  )
 }
 ```
 
@@ -683,7 +689,10 @@ modelling.
 
 ```graphql
 mutation {
-  endActivity(id: "chronicle:activity:september-2018-review",time:"2002-10-02T15:00:00Z")
+  endActivity(
+    id: {id: "chronicle:activity:september-2018-review" },
+    time:"2002-10-02T15:00:00Z"
+  )
 }
 ```
 
@@ -701,7 +710,10 @@ same operation.
 
 ```graphql
 mutation {
-  instantActivity(id: "chronicle:activity:september-2018-review",time:"2002-10-02T15:00:00Z")
+  instantActivity(
+    id: { id: "chronicle:activity:september-2018-review" },
+    time:"2002-10-02T15:00:00Z"
+  )
 }
 ```
 
@@ -739,8 +751,8 @@ To record the asking of a question, we relate an Organization to a
 ```graphql
 mutation {
   wasAssociatedWith(
-    responsible: "chronicle:agent:ncsa",
-    activity: "chronicle:activity:anaphylaxis-assessment",
+    responsible: {id: "chronicle:agent:ncsa" },
+    activity: {id: "chronicle:activity:anaphylaxis-assessment" },
     role: STAKEHOLDER
   )
 }
@@ -783,9 +795,9 @@ required parameter - generic delegation between agents can be recorded.
 ```graphql
 mutation {
   actedOnBehalfOf(
-    responsible: "chronicle:agent:john-roberts",
-    delegate: "chronicle:agent:janet-flynn",
-    activity: "chronicle:activity:september-2018-review",
+    responsible: {id: "chronicle:agent:john-roberts" },
+    delegate: {id: "chronicle:agent:janet-flynn" },
+    activity: {id: "chronicle:activity:september-2018-review" },
     role: EDITOR
   )
 }
@@ -817,8 +829,8 @@ of the useEntity.
 ```graphql
 mutation {
   hadPrimarySource {
-    usedEntity: "chronicle:entity:anaphylaxis-assessment-question",
-    generatedEntity: "chronicle:entity:anaphylaxis-guidance-revision-1",
+    usedEntity: {id: "chronicle:entity:anaphylaxis-assessment-question" },
+    generatedEntity: {id: "chronicle:entity:anaphylaxis-guidance-revision-1" },
   }
 }
 ```
@@ -838,8 +850,8 @@ takes two entities - the generatedEntity being a revision of the usedEntity.
 ```graphql
 mutation {
   wasRevisionOf {
-    usedEntity: "chronicle:entity:anaphylaxis-guidance-revision-1",
-    generatedEntity: "chronicle:entity:anaphylaxis-guidance-revision-2",
+    usedEntity: {id: "chronicle:entity:anaphylaxis-guidance-revision-1" },
+    generatedEntity: {id: "chronicle:entity:anaphylaxis-guidance-revision-2" },
   }
 }
 ```
@@ -859,8 +871,8 @@ usedEntity.
 ```graphql
 mutation {
   wasRevisionOf {
-    usedEntity: "chronicle:entity:evidence-2321231",
-    generatedEntity: "chronicle:entity:anaphylaxis-guidance-revision-2",
+    usedEntity: {id: "chronicle:entity:evidence-2321231" },
+    generatedEntity: {id: "chronicle:entity:anaphylaxis-guidance-revision-2" },
   }
 }
 ```


### PR DESCRIPTION
[CHRON-141](https://blockchaintp.atlassian.net/browse/CHRON-141)
---
BREAKING CHANGE: Relational mutations and queries can take one of either an externalId or Chronicle ID type (ActivityId, AgentId, ActivityId) as id input. Users will need to format GraphQL queries accordingly.
---
Signed-off-by: Joseph Livesey <joseph@blockchaintp.com>