### PR TITLE
Allow oneof externalid or id for activity timeline array selectors

### DIFF
--- a/crates/chronicle-domain-test/src/test.rs
+++ b/crates/chronicle-domain-test/src/test.rs
@@ -312,7 +312,7 @@ mod test {
                 activityTimeline(
                   activityTypes: [ItemManufacturedActivity]
                   forEntity: []
-                  forAgent: ["chronicle:agent:testagent"]
+                  forAgent: [{externalId: "testagent"}]
                 )
                 {
                   nodes {
@@ -2493,7 +2493,7 @@ mod test {
               query {
               activityTimeline(
                 forEntity: [],
-                forAgent: ["chronicle:agent:testagent2"],
+                forAgent: [{id: "chronicle:agent:testagent2"}],
                 order: NEWEST_FIRST,
                 activityTypes: [],
                               ) {

--- a/crates/chronicle/src/codegen/mod.rs
+++ b/crates/chronicle/src/codegen/mod.rs
@@ -758,8 +758,7 @@ fn gen_query() -> rust::Tokens {
         &rust::import("chronicle::async_graphql", "ErrorExtensions").qualified();
 
     let agent_id = &rust::import("chronicle::common::prov", "AgentIdOrExternal");
-    let entity_id = &rust::import("chronicle::common::prov", "EntityId");
-    let entity_id_or_external = &rust::import("chronicle::common::prov", "EntityIdOrExternal");
+    let entity_id = &rust::import("chronicle::common::prov", "EntityIdOrExternal");
     let activity_id = &rust::import("chronicle::common::prov", "ActivityIdOrExternal");
     let empty_fields =
         &rust::import("chronicle::async_graphql::connection", "EmptyFields").qualified();
@@ -780,7 +779,7 @@ fn gen_query() -> rust::Tokens {
         ctx: &#graphql_context<'a>,
         activity_types: Vec<ActivityType>,
         for_entity: Vec<#entity_id>,
-        for_agent: Vec<AgentId>,
+        for_agent: Vec<#agent_id>,
         from: Option<DateTime<Utc>>,
         to: Option<DateTime<Utc>>,
         order: Option<#timeline_order>,
@@ -796,8 +795,14 @@ fn gen_query() -> rust::Tokens {
                     .into_iter()
                     .filter_map(|x| x.into())
                     .collect(),
-                for_agent,
-                for_entity,
+                for_agent
+                    .into_iter()
+                    .map(|x| x.into())
+                    .collect(),
+                for_entity
+                    .into_iter()
+                    .map(|x| x.into())
+                    .collect(),
                 from,
                 to,
                 order,
@@ -961,7 +966,7 @@ fn gen_query() -> rust::Tokens {
     pub async fn entity_by_id<'a>(
         &self,
         ctx: &#graphql_context<'a>,
-        id: #entity_id_or_external,
+        id: #entity_id,
         namespace: Option<String>,
     ) -> #graphql_result<Option<#(entity_union_type_name())>> {
         Ok(#query_impl::entity_by_id(ctx, id.into(), namespace)

--- a/docs/querying_provenance.md
+++ b/docs/querying_provenance.md
@@ -6,8 +6,8 @@ Currently Chronicle has 7 root queries.
 type Query {
   activityTimeline(
     activityTypes: [ActivityType!]!
-    forEntity: [EntityID!]!
-    forAgent: [AgentID!]!
+    forEntity: [EntityIdOrExternal!]!
+    forAgent: [AgentIdOrExternal!]!
     from: DateTime
     to: DateTime
     order: TimelineOrder
@@ -75,10 +75,10 @@ enum ActivityType {
 
 ```
 
-#### forEntity
+#### EntityIdOrExternal
 
-A list of EntityIDs to filter activities by - leaving this empty will return all
-activity types.
+A list of EntityIDs or externalIds to filter activities by - leaving this empty
+will return all activity types.
 
 #### from
 
@@ -219,7 +219,7 @@ type PublishedActivity {
 
 #### Activity: id
 
-The EntityID of the entity. This is derived from externalId, but clients
+The ActivityID of the activity. This is derived from externalId, but clients
 should not attempt to synthesize it themselves.
 
 #### Activity: namespace

--- a/docs/recording_provenance.md
+++ b/docs/recording_provenance.md
@@ -648,15 +648,15 @@ time](#ended-at-time). Eliding the time parameter will use the current system
 time. Time stamps should be in
 [RFC3339](https://www.rfc-editor.org/rfc/rfc3339.html) format.
 
-Started at time operations also take an optional `AgentId`, to associate the
-activity with the agent - there is no current way to record a role with this
-however, so prefer [wasAssociatedWith](#association) if you need role-based
-modelling.
+Started at time operations also take an optional `AgentIdOrExternal`, to
+associate the activity with the agent - there is no current way to record a role
+with this however, so prefer [wasAssociatedWith](#association) if you need
+role-based modelling.
 
 ```graphql
 mutation {
   startActivity(
-    id: {id: "chronicle:activity:september-2018-review" },
+    id: {id: "chronicle:activity:september-2018-review"},
     time:"2002-10-02T15:00:00Z"
   )
 }
@@ -682,8 +682,8 @@ model a time range. Eliding the time parameter will use the current system time.
 Time stamps should be in [RFC3339](https://www.rfc-editor.org/rfc/rfc3339.html)
 format.
 
-Ended at time operations also take an optional `AgentId`, to associate the
-activity with the agent - there is no current way to record a role with this
+Ended at time operations also take an optional `AgentIdOrExternal`, to associate
+the activity with the agent - there is no current way to record a role with this
 however, so prefer [wasAssociatedWith](#association) if you need role-based
 modelling.
 

--- a/docs/untyped_chronicle.md
+++ b/docs/untyped_chronicle.md
@@ -32,7 +32,7 @@ they will appear on the corresponding type field.
 
 ```graphql
 query {
-    activityTimeline(forEntity: ["chronicle:entity:example"],
+    activityTimeline(forEntity: [{id: "chronicle:entity:example"}],
                     from: "1968-01-01T00:00:00Z",
                     to: "2030-01-01T00:00:00Z",
                     activityTypes: [],


### PR DESCRIPTION
BREAKING CHANGE: Users will need to adjust query inputs to `activityTimeline` accordingly. Examples available in the Querying Provenance, Recording Provenance, and Untyped Chronicle sections of the Chronicle documentation.

Signed-off-by: Joseph Livesey <joseph@blockchaintp.com>