### PR TITLE
Bump all crate versions to 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -461,7 +461,7 @@ dependencies = [
 
 [[package]]
 name = "chronicle-domain"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "chronicle",
  "insta",
@@ -623,7 +623,7 @@ dependencies = [
 
 [[package]]
 name = "common"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "api",
  "async-graphql",
@@ -2558,7 +2558,7 @@ dependencies = [
 
 [[package]]
 name = "proto"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "backoff",
@@ -2931,7 +2931,7 @@ dependencies = [
 
 [[package]]
 name = "sawtooth_tp"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "backoff",
@@ -3268,7 +3268,7 @@ dependencies = [
 
 [[package]]
 name = "telemetry"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "opentelemetry",
  "opentelemetry-jaeger",

--- a/crates/chronicle-domain/Cargo.toml
+++ b/crates/chronicle-domain/Cargo.toml
@@ -2,7 +2,7 @@
 build   = "build.rs"
 edition = "2021"
 name    = "chronicle-domain"
-version = "0.1.0"
+version = "0.4.0"
 
 [[bin]]
 name = "chronicle"

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -2,7 +2,7 @@
 build   = "build.rs"
 edition = "2021"
 name    = "common"
-version = "0.1.0"
+version = "0.4.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/sawtooth-protocol/Cargo.toml
+++ b/crates/sawtooth-protocol/Cargo.toml
@@ -2,7 +2,7 @@
 build   = "build.rs"
 edition = "2021"
 name    = "proto"
-version = "0.1.0"
+version = "0.4.0"
 
 [lib]
 name = "sawtooth_protocol"

--- a/crates/sawtooth-tp/Cargo.toml
+++ b/crates/sawtooth-tp/Cargo.toml
@@ -5,7 +5,7 @@ path = "src/main.rs"
 [package]
 edition = "2021"
 name    = "sawtooth_tp"
-version = "0.1.0"
+version = "0.4.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/telemetry/Cargo.toml
+++ b/crates/telemetry/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name    = "telemetry"
-version = "0.1.0"
+version = "0.4.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Useful tool for this purpose: [cargo workspaces](https://github.com/pksunkara/cargo-workspaces/tree/master/cargo-workspaces)
```
$ cargo workspaces version custom 0.4.0 --no-git-commit 
info looking for changes since v0.3.0
info current common version 0.4.0

Changes:
 - api: 0.4.0 => 0.4.0
 - chronicle: 0.4.0 => 0.4.0
 - chronicle-domain: 0.1.0 => 0.4.0
 - chronicle-domain-lint: 0.4.0 => 0.4.0
 - chronicle-example: 0.4.0 => 0.4.0
 - common: 0.1.0 => 0.4.0
 - proto: 0.1.0 => 0.4.0
 - sawtooth_tp: 0.1.0 => 0.4.0
 - telemetry: 0.1.0 => 0.4.0

✔ Are you sure you want to create these versions? · yes
    Updating crates.io index
    Updating chronicle-domain v0.1.0 (/home/jojo/git/catenasys/chronicle/crates/chronicle-domain) -> v0.4.0
    Updating common v0.1.0 (/home/jojo/git/catenasys/chronicle/crates/common) -> v0.4.0
    Updating proto v0.1.0 (/home/jojo/git/catenasys/chronicle/crates/sawtooth-protocol) -> v0.4.0
    Updating sawtooth_tp v0.1.0 (/home/jojo/git/catenasys/chronicle/crates/sawtooth-tp) -> v0.4.0
    Updating telemetry v0.1.0 (/home/jojo/git/catenasys/chronicle/crates/telemetry) -> v0.4.0
    Updating crates.io index
    Updating crates.io index
    Updating crates.io index
    Updating crates.io index
    Updating crates.io index
    Updating crates.io index
    Updating crates.io index
    Updating crates.io index
info success ok
```

---
Signed-off-by: Joseph Livesey [joseph@blockchaintp.com](mailto:joseph@blockchaintp.com)