### PR TITLE
fix: Explicitly use host arch

### DIFF
--- a/docker/unified-builder
+++ b/docker/unified-builder
@@ -45,7 +45,6 @@ WORKDIR /app
 FROM base AS test
 
 ARG BUILD_ARGS
-ARG HOSTARCH
 COPY Cargo.lock /app
 COPY .cargo /app/.cargo
 COPY Cargo.toml /app


### PR DESCRIPTION
* This should mean compiled dependencies are re-used for the non test build on same architecture

Signed-off-by: Ryan Roberts <ryan@blockchaintp.com>