### PR TITLE
Fix bug in domain file input casing

### DIFF
--- a/crates/chronicle/src/codegen/model.rs
+++ b/crates/chronicle/src/codegen/model.rs
@@ -1180,4 +1180,136 @@ pub mod test {
 
         Ok(())
     }
+
+    fn create_test_yaml_file_with_acronyms(
+    ) -> Result<assert_fs::NamedTempFile, Box<dyn std::error::Error>> {
+        let file = assert_fs::NamedTempFile::new("test.yml")?;
+        file.write_str(
+            r#"
+          name: "evidence"
+          attributes:
+            Content:
+              type: String
+            CMSId:
+              type: String
+            Title:
+              type: String
+            SearchParameter:
+              type: String
+            Reference:
+              type: String
+            Version:
+              type: Int
+          entities:
+            Question:
+              attributes:
+                - CMSId
+                - Content
+            EvidenceReference:
+              attributes:
+                - SearchParameter
+                - Reference
+            Guidance:
+              attributes:
+                - Title
+                - Version
+            PublishedGuidance:
+              attributes: []
+          activities:
+            QuestionAsked:
+              attributes:
+                - Content
+            Researched:
+              attributes: []
+            Published:
+              attributes:
+                - Version
+            Revised:
+              attributes:
+                - CMSId
+                - Version
+          agents:
+            Person:
+              attributes:
+                - CMSId
+            Organization:
+              attributes:
+                - Title
+          roles:
+            - STAKEHOLDER
+            - AUTHOR
+            - RESEARCHER
+            - EDITOR
+   "#,
+        )?;
+        Ok(file)
+    }
+
+    #[test]
+    fn test_from_domain_for_file_input_with_inflections() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let file = create_test_yaml_file_with_acronyms()?;
+        let s: String = std::fs::read_to_string(file.path())?;
+        let domain = ChronicleDomainDef::from_str(&s)?;
+        let input = DomainFileInput::from(&domain);
+
+        insta::assert_yaml_snapshot!(input, @r###"
+        ---
+        name: evidence
+        attributes:
+          CMSId:
+            type: String
+          Content:
+            type: String
+          Reference:
+            type: String
+          SearchParameter:
+            type: String
+          Title:
+            type: String
+          Version:
+            type: Int
+        agents:
+          OrganizationAgent:
+            attributes:
+              - Title
+          PersonAgent:
+            attributes:
+              - CMSId
+        entities:
+          EvidenceReferenceEntity:
+            attributes:
+              - SearchParameter
+              - Reference
+          GuidanceEntity:
+            attributes:
+              - Title
+              - Version
+          PublishedGuidanceEntity:
+            attributes: []
+          QuestionEntity:
+            attributes:
+              - CMSId
+              - Content
+        activities:
+          PublishedActivity:
+            attributes:
+              - Version
+          QuestionAskedActivity:
+            attributes:
+              - Content
+          ResearchedActivity:
+            attributes: []
+          RevisedActivity:
+            attributes:
+              - CMSId
+              - Version
+        roles:
+          - Stakeholder
+          - Author
+          - Researcher
+          - Editor
+        "###);
+        Ok(())
+    }
 }


### PR DESCRIPTION
See [CHRON-171](https://blockchaintp.atlassian.net/browse/CHRON-171?atlOrigin=eyJpIjoiODE0NGYyYTY3NzNkNDljYTgyMDc3ZjU3NzNjNTkyZDciLCJwIjoiaiJ9)

- fix bug in parsing attributes from domain file input containing acronyms
- test parsing domain file input containing acronyms

---  

Signed-off-by: Joseph Livesey [joseph.livesey@btp.works](mailto:joseph.livesey@btp.works)