### PR TITLE
omit cargo test from GitHub workflow

### DIFF
--- a/.github/workflows/cargo-checkmate.yaml
+++ b/.github/workflows/cargo-checkmate.yaml
@@ -17,4 +17,9 @@ jobs:
           toolchain: stable
           override: true
       - run: cargo install cargo-checkmate
-      - run: cargo-checkmate
+      - run: cargo-checkmate check
+      - run: cargo-checkmate format
+      - run: cargo-checkmate clippy
+      - run: cargo-checkmate build
+      - run: cargo-checkmate doc
+      - run: cargo-checkmate audit


### PR DESCRIPTION
Work around [CHRON-173](https://blockchaintp.atlassian.net/browse/CHRON-173) by not running full `cargo checkmate` in a GitHub action. `cargo checkmate test` is omitted here but Jenkins runs `make test`.