### PR TITLE
fix: Use arm pgembed images on linux

### DIFF
--- a/crates/common/src/database.rs
+++ b/crates/common/src/database.rs
@@ -22,11 +22,25 @@ lazy_static! {
     static ref TEMP_DIRS: Mutex<Vec<TempDir>> = Mutex::new(Vec::new());
 }
 
+fn arch() -> Architecture {
+    if cfg!(target_os = "macos") {
+        Architecture::Amd64
+    } else if cfg!(target_arch = "aarch64") {
+        Architecture::Arm64v8
+    } else if cfg!(target_arch = "x86_64") {
+        Architecture::Amd64
+    } else if cfg!(target_arch = "x86") {
+        Architecture::I386
+    } else {
+        panic!("Unsupported architecture");
+    }
+}
+
 pub fn pg_fetch_settings() -> PgFetchSettings {
     PgFetchSettings {
         host: "https://repo1.maven.org".to_string(),
         operating_system: OperationSystem::default(),
-        architecture: Architecture::Amd64,
+        architecture: arch(),
         version: PG_V13,
     }
 }

--- a/docker/unified-builder
+++ b/docker/unified-builder
@@ -131,10 +131,19 @@ WORKDIR /
 RUN apt-get update && \
   apt-get install -y \
   libpq5 \
+  ca-certificates \
   && \
   apt-get clean && rm -rf /var/lib/apt/lists/*
 
 COPY .artifacts/artifacts/${TARGETARCH}/chronicle /usr/local/bin
+
+RUN chmod 755 \
+  /usr/local/bin/chronicle
+
+RUN groupadd -g 999 chronicle && \
+  useradd -m -r -u 999 -g chronicle chronicle
+
+USER chronicle
 
 # Copy tp to image
 FROM debian:bullseye-slim AS chronicle-tp


### PR DESCRIPTION
* Rosetta handles this on macos
* There is a linux/arm pgembed image, but not a macos/arm one

Signed-off-by: Ryan Roberts <ryan.roberts@btp.works>