### PR TITLE
Bump crate versions to 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,7 +68,7 @@ checksum = "bb07d2053ccdbe10e2af2995a2f116c1330396493dc1269f6a91d0ae82e19704"
 
 [[package]]
 name = "api"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "async-graphql",
  "async-graphql-poem",
@@ -475,7 +475,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chronicle"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "Inflector",
  "api",
@@ -523,7 +523,7 @@ dependencies = [
 
 [[package]]
 name = "chronicle-domain"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "chronicle",
  "insta",
@@ -532,7 +532,7 @@ dependencies = [
 
 [[package]]
 name = "chronicle-domain-lint"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "chronicle",
  "clap 3.2.14",
@@ -540,7 +540,7 @@ dependencies = [
 
 [[package]]
 name = "chronicle-example"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "chronicle",
  "insta",
@@ -683,7 +683,7 @@ dependencies = [
 
 [[package]]
 name = "common"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "api",
  "async-graphql",
@@ -2893,7 +2893,7 @@ dependencies = [
 
 [[package]]
 name = "proto"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "backoff",
@@ -3295,7 +3295,7 @@ dependencies = [
 
 [[package]]
 name = "sawtooth_tp"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "backoff",
@@ -3796,7 +3796,7 @@ dependencies = [
 
 [[package]]
 name = "telemetry"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "opentelemetry 0.18.0",
  "opentelemetry-jaeger",

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -2,7 +2,7 @@
 build   = "build.rs"
 edition = "2021"
 name    = "api"
-version = "0.4.0"
+version = "0.5.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/crates/chronicle-domain-lint/Cargo.toml
+++ b/crates/chronicle-domain-lint/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name    = "chronicle-domain-lint"
-version = "0.4.0"
+version = "0.5.0"
 
 [dependencies]
 chronicle = { path = "../chronicle" }

--- a/crates/chronicle-domain-test/Cargo.toml
+++ b/crates/chronicle-domain-test/Cargo.toml
@@ -2,7 +2,7 @@
 build   = "build.rs"
 edition = "2021"
 name    = "chronicle-example"
-version = "0.4.0"
+version = "0.5.0"
 
 [[bin]]
 name = "chronicle-example"

--- a/crates/chronicle-domain/Cargo.toml
+++ b/crates/chronicle-domain/Cargo.toml
@@ -2,7 +2,7 @@
 build   = "build.rs"
 edition = "2021"
 name    = "chronicle-domain"
-version = "0.4.0"
+version = "0.5.0"
 
 [[bin]]
 name = "chronicle"

--- a/crates/chronicle/Cargo.toml
+++ b/crates/chronicle/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name    = "chronicle"
-version = "0.4.0"
+version = "0.5.0"
 
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -2,7 +2,7 @@
 build   = "build.rs"
 edition = "2021"
 name    = "common"
-version = "0.4.0"
+version = "0.5.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/sawtooth-protocol/Cargo.toml
+++ b/crates/sawtooth-protocol/Cargo.toml
@@ -2,7 +2,7 @@
 build   = "build.rs"
 edition = "2021"
 name    = "proto"
-version = "0.4.0"
+version = "0.5.0"
 
 [lib]
 name = "sawtooth_protocol"

--- a/crates/sawtooth-tp/Cargo.toml
+++ b/crates/sawtooth-tp/Cargo.toml
@@ -5,7 +5,7 @@ path = "src/main.rs"
 [package]
 edition = "2021"
 name    = "sawtooth_tp"
-version = "0.4.0"
+version = "0.5.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/telemetry/Cargo.toml
+++ b/crates/telemetry/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name    = "telemetry"
-version = "0.4.0"
+version = "0.5.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
[CHRON-207](https://blockchaintp.atlassian.net/browse/CHRON-207?atlOrigin=eyJpIjoiYmRkZGQ4ZjI5N2Q2NDc5ZWIzNjg3ZWZjODNlN2I5MTYiLCJwIjoiaiJ9)

api@0.5.0
chronicle@0.5.0
chronicle-domain@0.5.0
chronicle-domain-lint@0.5.0
chronicle-example@0.5.0
common@0.5.0
proto@0.5.0
sawtooth_tp@0.5.0
telemetry@0.5.0

Generated by cargo-workspaces

[CHRON-207]: https://blockchaintp.atlassian.net/browse/CHRON-207?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ