### PR TITLE
Accept and verify JSON web tokens

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,6 +85,7 @@ dependencies = [
  "async-graphql-poem",
  "async-stream",
  "async-trait",
+ "base64 0.21.0",
  "chrono",
  "common",
  "custom_error",
@@ -99,6 +100,7 @@ dependencies = [
  "iref-enum",
  "json",
  "json-ld",
+ "jwtk",
  "open",
  "opentelemetry",
  "parking_lot 0.12.1",
@@ -112,6 +114,7 @@ dependencies = [
  "static-iref",
  "telemetry",
  "tempfile",
+ "thiserror",
  "tokio",
  "tracing",
  "url",
@@ -175,7 +178,7 @@ dependencies = [
  "async-graphql-value",
  "async-stream",
  "async-trait",
- "base64",
+ "base64 0.13.1",
  "blocking",
  "bytes",
  "chrono",
@@ -358,6 +361,12 @@ name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
 name = "base64ct"
@@ -1604,7 +1613,7 @@ version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3e372db8e5c0d213e0cd0b9be18be2aca3d44cf2fe30a9d46a65581cd454584"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "bitflags",
  "bytes",
  "headers-core",
@@ -1966,7 +1975,7 @@ checksum = "6ca9e2b45609132ae2214d50482c03aeee78826cd6fd53a8940915b81acedf16"
 dependencies = [
  "ahash 0.8.2",
  "anyhow",
- "base64",
+ "base64 0.13.1",
  "bytecount",
  "clap 4.1.1",
  "fancy-regex",
@@ -1995,6 +2004,23 @@ checksum = "effcb749443c905fbaef49d214f8b1049c240e0adb7af9baa0e201e625e4f9de"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "jwtk"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6833c8be7e70530a018d6c48ef2a338b4d9df198ddb9d4ec0da436820a094526"
+dependencies = [
+ "base64 0.13.1",
+ "foreign-types",
+ "openssl",
+ "openssl-sys",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "smallvec",
+ "tokio",
 ]
 
 [[package]]
@@ -2838,7 +2864,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b43fad06b128ce16d2eab9ff430b7d16c4a68c714eee59fd1c720fefdd71b42b"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.13.1",
  "bytes",
  "futures-util",
  "headers",
@@ -3361,7 +3387,7 @@ version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68cc60575865c7831548863cc02356512e3f1dc2f3f82cb837d7fc4cc8f3c97c"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -3447,7 +3473,7 @@ version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "log",
  "ring",
  "sct",
@@ -3874,7 +3900,7 @@ checksum = "e48c61941ccf5ddcada342cd59e3e5173b007c509e1e8e990dafc830294d9dc5"
 dependencies = [
  "ahash 0.7.6",
  "atoi",
- "base64",
+ "base64 0.13.1",
  "bitflags",
  "byteorder",
  "bytes",
@@ -4330,7 +4356,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c84d8ae362ca1383729d2c37e53468ed2681b8d01ab589705b32d37638f79549"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.13.1",
  "fxhash",
  "rand 0.8.5",
  "reqwest",
@@ -4410,7 +4436,7 @@ version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e27992fd6a8c29ee7eef28fc78349aa244134e10ad447ce3b9f0ac0ed0fa4ce0"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "byteorder",
  "bytes",
  "http",
@@ -4555,7 +4581,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "647856408e327686b6640397d19f60fac3e64c3bfaa6afc409da63ef7da45edb"
 dependencies = [
  "addr",
- "base64",
+ "base64 0.13.1",
  "chrono",
  "json-pointer",
  "jsonway",

--- a/component.puml
+++ b/component.puml
@@ -11,8 +11,6 @@ component "Chronicle" {
 
     [API]
 
-    [graphql playground]
-
     () GraphQL
 }
 
@@ -28,8 +26,6 @@ component "Sawtooth" {
 
 
 [Apollo Server] <..> GraphQL: federates
-[API] ..> [graphql playground]: serves
-[graphql playground] <..> GraphQL
 CLI <..> API: spawns or uses remote
 CLI <..> GraphQL: uses
 [API] <..> GraphQL

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -62,5 +62,9 @@ tempfile = "3.3.0"
 [build-dependencies]
 
 [features]
+devmode = ["anonymous-api", "inmem"]
+# Allow unauthenticated API access
+anonymous-api = []
+# Use an in-memory stub ledger
 inmem  = []
 strict = []

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -16,6 +16,7 @@ async-graphql = { features = [
 async-graphql-poem = "4.0.9"
 async-stream = "0.3.3"
 async-trait = "0.1.53"
+base64 = "0.21"
 chrono = "0.4.19"
 common = { path = "../common" }
 custom_error = "1.9.2"
@@ -34,6 +35,7 @@ iref = "2.1.2"
 iref-enum = "2.0.0"
 json = "0.12.4"
 json-ld = "0.4.0"
+jwtk = { version = "0.2.4", features = ["remote-jwks"] }
 open = "3.2.0"
 opentelemetry = { version = "0.18.0", features = ["rt-tokio"] }
 parking_lot = "0.12.0"
@@ -46,6 +48,7 @@ serde_derive = "1.0.136"
 serde_json = "1.0.81"
 static-iref = "2.0.0"
 telemetry = { path = "../telemetry" }
+thiserror = "1.0.36"
 tokio = { version = "1.20.3", features = ["time", "macros", "rt-multi-thread"] }
 tracing = "0.1.32"
 url = "2.2.2"

--- a/crates/api/src/chronicle_graphql/authorization.rs
+++ b/crates/api/src/chronicle_graphql/authorization.rs
@@ -1,0 +1,71 @@
+use base64::Engine;
+use jwtk::jwk::RemoteJwksVerifier;
+use serde_json::Value;
+use std::time::Duration;
+use thiserror::Error;
+use tracing::instrument;
+use url::Url;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("Base64 decoding failure: {0}", source)]
+    Base64 {
+        #[from]
+        source: base64::DecodeError,
+    },
+    #[error("JSON decoding failure: {0}", source)]
+    Json {
+        #[from]
+        source: serde_json::Error,
+    },
+    #[error("JWT validation failure: {0}", source)]
+    Jwks {
+        #[from]
+        source: jwtk::Error,
+    },
+    #[error("application error: {0}", message)]
+    Simple { message: String },
+}
+
+pub struct JwtChecker {
+    verifier: RemoteJwksVerifier,
+}
+
+impl JwtChecker {
+    pub fn new(jwks_uri: &Url) -> Self {
+        Self {
+            verifier: RemoteJwksVerifier::new(jwks_uri.to_string(), None, Duration::from_secs(100)),
+        }
+    }
+
+    #[instrument(skip(self))]
+    pub async fn verify_jwt(
+        &self,
+        token: &str,
+    ) -> Result<serde_json::map::Map<String, Value>, Error> {
+        let base64_engine = base64::engine::general_purpose::URL_SAFE_NO_PAD;
+
+        // JWT is composed of three base64-encoded components
+        let components = token
+            .split('.')
+            .map(|component| base64_engine.decode(component))
+            .collect::<Result<Vec<Vec<u8>>, base64::DecodeError>>()?;
+        if components.len() != 3 {
+            return Err(Error::Simple {
+                message: format!("JWT has unexpected format: {}", token),
+            });
+        };
+
+        self.verifier
+            .verify::<serde_json::map::Map<String, Value>>(token)
+            .await?;
+
+        if let Value::Object(claims) = serde_json::from_slice(components[1].as_slice())? {
+            Ok(claims)
+        } else {
+            Err(Error::Simple {
+                message: format!("JWT claims have unexpected format: {:?}", components[1]),
+            })
+        }
+    }
+}

--- a/crates/chronicle/Cargo.toml
+++ b/crates/chronicle/Cargo.toml
@@ -58,9 +58,12 @@ valico = "3.6.0"
 
 
 [features]
+devmode = ["anonymous-api", "inmem"]
+# Allow unauthenticated API access
+anonymous-api = []
+# Use an in-memory stub ledger
+inmem  = []
 strict = []
-# Use an in memory stub ledger
-inmem = []
 
 [build-dependencies]
 

--- a/crates/chronicle/src/bootstrap/cli.rs
+++ b/crates/chronicle/src/bootstrap/cli.rs
@@ -954,13 +954,6 @@ impl SubCommand for CliModel {
                 Command::new("serve-graphql")
                     .about("Start a graphql server")
                     .arg(
-                        Arg::new("open")
-                            .long("open")
-                            .required(false)
-                            .takes_value(false)
-                            .help("Open apollo studio sandbox"),
-                    )
-                    .arg(
                         Arg::new("interface")
                             .long("interface")
                             .required(false)

--- a/crates/chronicle/src/bootstrap/cli.rs
+++ b/crates/chronicle/src/bootstrap/cli.rs
@@ -900,8 +900,7 @@ impl SubCommand for CliModel {
                     .long("embedded-database")
                     .help("use an embedded PostgreSQL")
                     .conflicts_with("remote-database")
-                    // see https://github.com/clap-rs/clap/issues/1605 - fixed in v3.x - then use ArgGroup or,
-                    // .conflicts_with_all(&["remote-database", "database-host", "database-port", "database-username", "database-name"])
+                // no conflict with database_* because they may be set in environment but not used for this invocation
             )
             .arg(
                 Arg::new("remote-database")
@@ -979,13 +978,26 @@ impl SubCommand for CliModel {
                         } else {
                             arg
                             .required_unless_present("anonymous-api")
-                            // see https://github.com/clap-rs/clap/issues/1605 - fixed in v3.x
+                        }
+                    }
+                    ).arg({
+                        let arg = Arg::new("id-pointer")
+                            .long("id-pointer")
+                            .takes_value(true)
+                            .env("JWT_POINTER")
+                            .help("JSON pointer into JWT claims for Chronicle ID");
+                        if cfg!(feature = "anonymous-api") {
+                            arg
+                        } else {
+                            arg
+                            .required_unless_present("anonymous-api")
                         }
                     }
                     ).arg(
                         Arg::new("anonymous-api")
                             .long("anonymous-api")
                             .help("accept GraphQL without authentication by web tokens")
+                        // no conflict with JWT/JWKS settings because they may be set in environment but not used for this invocation
                     ),
             )
             .subcommand(Command::new("verify-keystore").about("Initialize and verify keystore, then exit"));

--- a/crates/chronicle/src/bootstrap/mod.rs
+++ b/crates/chronicle/src/bootstrap/mod.rs
@@ -100,7 +100,6 @@ pub async fn graphql_server<Query, Mutation>(
     pool: &ConnectionPool,
     gql: ChronicleGraphQl<Query, Mutation>,
     options: &ArgMatches,
-    open: bool,
     jwks_uri: Option<Url>,
     id_pointer: Option<String>,
 ) -> Result<(), ApiError>
@@ -109,7 +108,7 @@ where
     Mutation: ObjectType + Copy,
 {
     if let Some(addr) = graphql_addr(options)? {
-        gql.serve_graphql(pool.clone(), api.clone(), addr, open, jwks_uri, id_pointer)
+        gql.serve_graphql(pool.clone(), api.clone(), addr, jwks_uri, id_pointer)
             .await
     }
 
@@ -266,16 +265,7 @@ where
             })
         }?;
 
-        graphql_server(
-            &api,
-            &pool,
-            gql,
-            matches,
-            matches.contains_id("open"),
-            jwks_uri,
-            id_pointer,
-        )
-        .await?;
+        graphql_server(&api, &pool, gql, matches, jwks_uri, id_pointer).await?;
 
         Ok((ApiResponse::Unit, ret_api))
     } else if let Some(cmd) = cli.matches(&matches)? {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -12,10 +12,27 @@ Run Chronicle as a GraphQL server.
 
 The GraphQL server socket address - defaults to 127.0.0.1:9982.
 
-#### `--open`
+##### `--anonymous-api`
 
-Serve the GraphQL playground IDE on the GraphQL server interface and open a web
-browser to it.
+Allow unauthenticated access to the GraphQL API.
+Otherwise, the following two arguments are relevant and required.
+
+##### `--jwks-address <URI>`
+
+The URI from which the JSON Web Key Set (JWKS) can be obtained.
+This typically has a suffix of `jwks.json`.
+The JWKS is used for verifying JSON Web Tokens provided via HTTP
+`Authorized: Bearer ...`.
+
+Ignored if `--anonymous-api` is given.
+
+##### `id-pointer <JSON ptr>`
+
+A JSON pointer into the JSON Web Token claims, specifying the location of
+a string value corresponding to the external ID that should be used in
+constructing the authenticated user's Chronicle identity.
+
+Ignored if `--anonymous-api` is given.
 
 ### `export-schema`
 


### PR DESCRIPTION
Resolves CHRON-204, CHRON-205, CHRON-206, and CHRON-209.

Introduces feature `devmode` that implies both `inmem` and new feature `anonymous-api` which allows unauthenticated access to the GraphQL API by default. Without selecting that feature, the `--anonymous-api` option to `serve-graphql` is required to allow it.

Otherwise, access to the API must now be authenticated: supply instead the `--jwks-address` option with a URI to the keyset used to sign the JWT bearer tokens that one's providing via `Authorization:`. The `--id-pointer` option must be used to provide a JSON pointer into the JWT claims for the Chronicle identity. An `AuthId` bearing the verified external ID can then be found in the GraphQL context.

The Apollo Studio sandbox from `--open` is removed but the Altair GraphQL client is a fine substitute that makes it easy to pass extra header lines.