### PR TITLE
refactor: move identity to its own module

### DIFF
--- a/crates/api/src/chronicle_graphql/mod.rs
+++ b/crates/api/src/chronicle_graphql/mod.rs
@@ -7,8 +7,9 @@ use async_graphql::{
 use async_graphql_poem::{GraphQL, GraphQLSubscription};
 use chrono::{DateTime, NaiveDateTime, Utc};
 use common::{
+    identity::AuthId,
     ledger::{SubmissionError, SubmissionStage},
-    prov::{to_json_ld::ToJson, AuthId, ChronicleTransactionId, ProvModel},
+    prov::{to_json_ld::ToJson, ChronicleTransactionId, ProvModel},
 };
 use custom_error::custom_error;
 use derivative::*;

--- a/crates/api/src/chronicle_graphql/mutation.rs
+++ b/crates/api/src/chronicle_graphql/mutation.rs
@@ -10,7 +10,8 @@ use common::{
         ActivityCommand, AgentCommand, ApiCommand, ApiResponse, EntityCommand, KeyRegistration,
         PathOrFile,
     },
-    prov::{operations::DerivationType, ActivityId, AgentId, AuthId, EntityId, Role},
+    identity::AuthId,
+    prov::{operations::DerivationType, ActivityId, AgentId, EntityId, Role},
 };
 
 use crate::ApiDispatch;

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -12,6 +12,7 @@ use futures::{select, AsyncReadExt, FutureExt, StreamExt};
 use common::{
     attributes::Attributes,
     commands::*,
+    identity::{AuthId, IdentityError},
     k256::ecdsa::{signature::Signer, Signature},
     ledger::{
         LedgerReader, LedgerWriter, Offset, SubmissionError, SubmissionStage, SubscriptionError,
@@ -24,9 +25,8 @@ use common::{
             WasGeneratedBy, WasInformedBy,
         },
         to_json_ld::ToJson,
-        ActivityId, AgentId, AuthId, ChronicleTransaction, ChronicleTransactionId, Contradiction,
-        EntityId, ExternalId, ExternalIdPart, IdentityId, NamespaceId, ProcessorError, ProvModel,
-        Role,
+        ActivityId, AgentId, ChronicleTransaction, ChronicleTransactionId, Contradiction, EntityId,
+        ExternalId, ExternalIdPart, IdentityId, NamespaceId, ProcessorError, ProvModel, Role,
     },
     signing::{DirectoryStoredKeys, SignerError},
 };
@@ -71,6 +71,7 @@ custom_error! {
     EvidenceSigning{source: common::k256::ecdsa::Error}         = "Could not sign message",
     Contradiction{source: Contradiction}                        = "Contradiction {source}",
     ProcessorError{source: ProcessorError}                      = "Processor {source}",
+    IdentityError{source: IdentityError}                        = "Identity {source}",
 }
 
 /// Ugly but we need this until ! is stable, see <https://github.com/rust-lang/rust/issues/64715>
@@ -1296,13 +1297,14 @@ mod test {
             KeyRegistration, NamespaceCommand,
         },
         database::{get_embedded_db_connection, Database},
+        identity::AuthId,
         k256::{
             pkcs8::{EncodePrivateKey, LineEnding},
             SecretKey,
         },
         ledger::InMemLedger,
         prov::{
-            operations::DerivationType, to_json_ld::ToJson, ActivityId, AgentId, AuthId,
+            operations::DerivationType, to_json_ld::ToJson, ActivityId, AgentId,
             ChronicleTransactionId, DomaintypeId, EntityId, ProvModel,
         },
         signing::DirectoryStoredKeys,

--- a/crates/chronicle-domain-test/src/test.rs
+++ b/crates/chronicle-domain-test/src/test.rs
@@ -71,7 +71,7 @@ mod test {
         async_graphql::{Request, Schema},
         chrono::{DateTime, NaiveDate, Utc},
         common::{
-            database::get_embedded_db_connection, ledger::InMemLedger, prov::AuthId,
+            database::get_embedded_db_connection, identity::AuthId, ledger::InMemLedger,
             signing::DirectoryStoredKeys,
         },
         tokio,

--- a/crates/chronicle/src/bootstrap/mod.rs
+++ b/crates/chronicle/src/bootstrap/mod.rs
@@ -12,8 +12,9 @@ pub use cli::*;
 use common::{
     commands::ApiResponse,
     database::Database,
+    identity::AuthId,
     ledger::SubmissionStage,
-    prov::{to_json_ld::ToJson, AuthId},
+    prov::to_json_ld::ToJson,
     signing::{DirectoryStoredKeys, SignerError},
 };
 use tracing::{debug, error, info, instrument};
@@ -402,9 +403,10 @@ pub mod test {
     use common::{
         commands::{ApiCommand, ApiResponse},
         database::{get_embedded_db_connection, Database},
+        identity::AuthId,
         ledger::{InMemLedger, SubmissionStage},
         prov::{
-            to_json_ld::ToJson, ActivityId, AgentId, AuthId, ChronicleIri, ChronicleTransactionId,
+            to_json_ld::ToJson, ActivityId, AgentId, ChronicleIri, ChronicleTransactionId,
             EntityId, ProvModel,
         },
         signing::DirectoryStoredKeys,

--- a/crates/common/src/identity.rs
+++ b/crates/common/src/identity.rs
@@ -1,0 +1,113 @@
+use crate::{
+    prov::{AgentId, ExternalIdPart},
+    signing::{DirectoryStoredKeys, SignerError},
+};
+
+use custom_error::custom_error;
+use k256::ecdsa::{signature::Signer, Signature, SigningKey, VerifyingKey};
+
+custom_error! {pub IdentityError
+    KeyStore{source: SignerError} = "Invalid key store directory {source}",
+    SerdeJson{source: serde_json::Error } = "Malformed JSON {source}",
+    Signing{source: k256::ecdsa::Error} = "Signing error {source}",
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
+pub enum AuthId {
+    Chronicle,
+    Jwt(AgentId),
+}
+
+impl AuthId {
+    pub fn agent(agent: &AgentId) -> Self {
+        Self::Jwt(agent.to_owned())
+    }
+
+    pub fn chronicle() -> Self {
+        Self::Chronicle
+    }
+
+    pub fn signed_identity(
+        &self,
+        store: &DirectoryStoredKeys,
+    ) -> Result<SignedIdentity, IdentityError> {
+        let verifying_key = self.verifying_key(store)?;
+        let signing_key = self.signing_key(store)?;
+
+        let id_and_type = IdentityContext::new(self);
+        let buf = id_and_type.to_sign()?;
+
+        let signature: Signature = signing_key.try_sign(&buf)?;
+        let signed_id = SignedIdentity::new(self, signature, verifying_key)?;
+
+        Ok(signed_id)
+    }
+
+    fn signing_key(&self, store: &DirectoryStoredKeys) -> Result<SigningKey, IdentityError> {
+        match self {
+            Self::Chronicle => Ok(store.chronicle_signing()?),
+            Self::Jwt(agent_id) => Ok(store.agent_signing(agent_id)?),
+        }
+    }
+
+    fn verifying_key(&self, store: &DirectoryStoredKeys) -> Result<VerifyingKey, IdentityError> {
+        match self {
+            Self::Chronicle => Ok(store.chronicle_verifying()?),
+            Self::Jwt(agent_id) => Ok(store.agent_verifying(agent_id)?),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct SignedIdentity {
+    identity_context: String,
+    signature: Signature,
+    verifying_key: VerifyingKey,
+}
+
+impl SignedIdentity {
+    fn new(
+        id: &AuthId,
+        signature: Signature,
+        verifying_key: VerifyingKey,
+    ) -> Result<Self, IdentityError> {
+        let identity_context = serde_json::to_string(&IdentityContext::new(id))?;
+        Ok(Self {
+            identity_context,
+            signature,
+            verifying_key,
+        })
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub(crate) struct IdentityContext {
+    id: serde_json::Value,
+    typ: String,
+}
+
+impl IdentityContext {
+    pub(crate) fn new(id: &AuthId) -> Self {
+        match id {
+            AuthId::Chronicle => Self {
+                id: serde_json::Value::from("chronicle"),
+                typ: "key".to_owned(),
+            },
+            AuthId::Jwt(agent_id) => Self {
+                id: serde_json::Value::from(agent_id.external_id_part().as_str()),
+                typ: "JWT".to_owned(),
+            },
+        }
+    }
+    fn to_sign(&self) -> Result<Vec<u8>, IdentityError> {
+        Ok(serde_json::to_string(self)?.as_bytes().to_vec())
+    }
+}
+
+impl TryFrom<&str> for IdentityContext {
+    type Error = serde_json::Error;
+
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        serde_json::from_str(s)
+    }
+}

--- a/crates/common/src/ledger.rs
+++ b/crates/common/src/ledger.rs
@@ -844,12 +844,13 @@ impl ChronicleOperation {
 pub mod test {
 
     use crate::{
+        identity::{AuthId, SignedIdentity},
         ledger::InMemLedger,
         prov::{
             operations::{ActsOnBehalfOf, AgentExists, ChronicleOperation, CreateNamespace},
             to_json_ld::ToJson,
-            ActivityId, AgentId, AuthId, ChronicleTransaction, DelegationId, ExternalId,
-            ExternalIdPart, NamespaceId, Role, SignedIdentity,
+            ActivityId, AgentId, ChronicleTransaction, DelegationId, ExternalId, ExternalIdPart,
+            NamespaceId, Role,
         },
         signing::DirectoryStoredKeys,
     };

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -8,6 +8,7 @@ pub mod attributes;
 pub mod commands;
 pub mod context;
 pub mod database;
+pub mod identity;
 pub mod ledger;
 pub mod protocol;
 pub mod prov;

--- a/crates/common/src/protocol.rs
+++ b/crates/common/src/protocol.rs
@@ -3,9 +3,12 @@ use std::io::Cursor;
 use prost::Message;
 use tracing::span;
 
-use crate::prov::{
-    operations::ChronicleOperation, to_json_ld::ToJson, ChronicleTransaction, CompactionError,
-    Contradiction, ExpandedJson, ProcessorError, ProvModel, SignedIdentity,
+use crate::{
+    identity::SignedIdentity,
+    prov::{
+        operations::ChronicleOperation, to_json_ld::ToJson, ChronicleTransaction, CompactionError,
+        Contradiction, ExpandedJson, ProcessorError, ProvModel,
+    },
 };
 
 use thiserror::Error;
@@ -188,10 +191,10 @@ pub async fn chronicle_identity_from_submission(
 mod test {
     use super::*;
     use crate::{
+        identity::{AuthId, SignedIdentity},
         prov::{
             operations::{ActsOnBehalfOf, AgentExists, ChronicleOperation, CreateNamespace},
-            ActivityId, AgentId, AuthId, DelegationId, ExternalId, ExternalIdPart, NamespaceId,
-            Role, SignedIdentity,
+            ActivityId, AgentId, DelegationId, ExternalId, ExternalIdPart, NamespaceId, Role,
         },
         signing::DirectoryStoredKeys,
     };

--- a/crates/common/src/prov/model/mod.rs
+++ b/crates/common/src/prov/model/mod.rs
@@ -7,7 +7,6 @@ use custom_error::custom_error;
 use json::JsonValue;
 use json_ld::{context::Local, Document, JsonContext, NoLoader};
 
-use k256::ecdsa::{signature::Signer, Signature, SigningKey, VerifyingKey};
 use serde::Serialize;
 use serde_json::Value;
 use std::{
@@ -21,7 +20,7 @@ use uuid::Uuid;
 
 use crate::{
     attributes::{Attribute, Attributes},
-    signing::{DirectoryStoredKeys, SignerError},
+    identity::SignedIdentity,
 };
 
 use super::{
@@ -43,14 +42,12 @@ custom_error! {pub ProcessorError
     Compaction{source: CompactionError} = "Json Ld Error {source}",
     Expansion{inner: String} = "Json Ld Error {inner}",
     IRef{source: iref::Error} = "Invalid IRI {source}",
-    KeyStore{source: SignerError} = "Invalid key store directory {source}",
     NotAChronicleIri{source: id::ParseIriError } = "Not a Chronicle IRI {source}",
     Tokio{source: JoinError} = "Tokio Error",
     MissingId{object: JsonValue} = "Missing @id {object:?}",
     MissingProperty{iri: String, object: JsonValue} = "Missing property {iri}:{object:?}",
     NotANode{} = "Json LD object is not a node",
     NotAnObject {} = "Chronicle value is not a json object",
-    Signing{source: k256::ecdsa::Error} = "Signing error {source}",
     Time{source: chrono::ParseError} = "Unparsable date/time {source}",
     Json{source: json::JsonError} = "Malformed JSON {source}",
     SerdeJson{source: serde_json::Error } = "Malformed JSON {source}",
@@ -103,106 +100,6 @@ pub struct ChronicleTransaction {
 impl ChronicleTransaction {
     pub fn new(tx: Vec<ChronicleOperation>, identity: SignedIdentity) -> Self {
         Self { tx, identity }
-    }
-}
-
-#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
-pub enum AuthId {
-    Chronicle,
-    Jwt(AgentId),
-}
-
-impl AuthId {
-    pub fn agent(agent: &AgentId) -> Self {
-        Self::Jwt(agent.to_owned())
-    }
-
-    pub fn chronicle() -> Self {
-        Self::Chronicle
-    }
-
-    pub fn signed_identity(
-        &self,
-        store: &DirectoryStoredKeys,
-    ) -> Result<SignedIdentity, ProcessorError> {
-        let verifying_key = self.verifying_key(store)?;
-        let signing_key = self.signing_key(store)?;
-
-        let id_and_type = IdToSign::new(self);
-        let buf = id_and_type.to_sign()?;
-
-        let signature: Signature = signing_key.try_sign(&buf)?;
-        let signed_id = SignedIdentity::new(self, signature, verifying_key)?;
-
-        Ok(signed_id)
-    }
-
-    fn signing_key(&self, store: &DirectoryStoredKeys) -> Result<SigningKey, ProcessorError> {
-        match self {
-            Self::Chronicle => Ok(store.chronicle_signing()?),
-            Self::Jwt(agent_id) => Ok(store.agent_signing(agent_id)?),
-        }
-    }
-
-    fn verifying_key(&self, store: &DirectoryStoredKeys) -> Result<VerifyingKey, ProcessorError> {
-        match self {
-            Self::Chronicle => Ok(store.chronicle_verifying()?),
-            Self::Jwt(agent_id) => Ok(store.agent_verifying(agent_id)?),
-        }
-    }
-}
-
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub struct SignedIdentity {
-    id: String,
-    signature: Signature,
-    verifying_key: VerifyingKey,
-}
-
-impl SignedIdentity {
-    fn new(
-        id: &AuthId,
-        signature: Signature,
-        verifying_key: VerifyingKey,
-    ) -> Result<Self, ProcessorError> {
-        let id = serde_json::to_string(&IdToSign::new(id))?;
-        Ok(Self {
-            id,
-            signature,
-            verifying_key,
-        })
-    }
-}
-
-#[derive(Serialize, Deserialize)]
-struct IdToSign {
-    typ: String,
-    id: serde_json::Value,
-}
-
-impl IdToSign {
-    fn new(id: &AuthId) -> Self {
-        match id {
-            AuthId::Chronicle => Self {
-                typ: "key".to_owned(),
-                id: serde_json::Value::from("chronicle"),
-            },
-            AuthId::Jwt(agent_id) => Self {
-                typ: "JWT".to_owned(),
-                id: serde_json::Value::from(agent_id.external_id_part().as_str()),
-            },
-        }
-    }
-    fn to_sign(&self) -> Result<Vec<u8>, ProcessorError> {
-        Ok(serde_json::to_string(self)?.as_bytes().to_vec())
-    }
-}
-
-impl TryFrom<&str> for IdToSign {
-    type Error = serde_json::Error;
-
-    fn try_from(s: &str) -> Result<Self, Self::Error> {
-        serde_json::from_str(s)
     }
 }
 

--- a/crates/sawtooth-protocol/src/messages.rs
+++ b/crates/sawtooth-protocol/src/messages.rs
@@ -145,9 +145,10 @@ impl MessageBuilder {
 #[cfg(test)]
 mod test {
     use common::{
+        identity::AuthId,
         prov::{
             operations::{ChronicleOperation, CreateNamespace},
-            AuthId, ChronicleTransaction, NamespaceId,
+            ChronicleTransaction, NamespaceId,
         },
         signing::DirectoryStoredKeys,
     };

--- a/crates/sawtooth-tp/src/tp.rs
+++ b/crates/sawtooth-tp/src/tp.rs
@@ -268,12 +268,13 @@ pub mod test {
     use std::{cell::RefCell, collections::BTreeMap};
 
     use common::{
+        identity::AuthId,
         k256::ecdsa::SigningKey,
         protocol::messages,
         prov::{
             operations::{ActsOnBehalfOf, AgentExists, ChronicleOperation, CreateNamespace},
-            ActivityId, AgentId, AuthId, ChronicleTransaction, DelegationId, ExternalId,
-            ExternalIdPart, NamespaceId, Role,
+            ActivityId, AgentId, ChronicleTransaction, DelegationId, ExternalId, ExternalIdPart,
+            NamespaceId, Role,
         },
         signing::DirectoryStoredKeys,
     };


### PR DESCRIPTION
Cleans up `common` by moving all `AuthId` code to a separate identity.rs module.

Signed-off-by: Joseph Livesey <joseph.livesey@btp.works>