### PR TITLE
fix(chronicle/bootstrap): add embedded default-allow opa rule devmode option 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -543,6 +543,7 @@ dependencies = [
  "question",
  "rand 0.8.5",
  "rand_core 0.6.4",
+ "rust-embed",
  "serde",
  "serde_derive",
  "serde_json",
@@ -3704,6 +3705,40 @@ dependencies = [
  "untrusted",
  "web-sys",
  "winapi",
+]
+
+[[package]]
+name = "rust-embed"
+version = "6.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "283ffe2f866869428c92e0d61c2f35dfb4355293cdfdc48f49e895c15f1333d1"
+dependencies = [
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "6.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31ab23d42d71fb9be1b643fe6765d292c5e14d46912d13f3ae2815ca048ea04d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils",
+ "syn",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "7.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1669d81dfabd1b5f8e2856b8bbe146c6192b0ba22162edc738ac0a5de18f054"
+dependencies = [
+ "sha2",
+ "walkdir",
 ]
 
 [[package]]

--- a/crates/chronicle/Cargo.toml
+++ b/crates/chronicle/Cargo.toml
@@ -41,6 +41,7 @@ proto = { path = "../sawtooth-protocol" }
 question = "0.2.2"
 rand = { version = "0.8.5", features = ["getrandom"] }
 rand_core = "0.6.3"
+rust-embed = "6.4.2"
 serde = "1.0.136"
 serde_derive = "1.0.136"
 serde_json = "1.0.81"


### PR DESCRIPTION
Ahead of linking up the various Auth elements under development, for developer and user convenience working on Chronicle's `main` branch, in `devmode` initialize the opa-executor in the GraphQL bootstrap with an embedded default allow OPA policy and appropriate entrypoint if no `--opa-rule` and `--opa-entrypoint` args provided. Users in `devmode` can override this feature by providing `--opa-rule` and `--opa-entrypoint` cli args for a given OPA policy.

Signed-off-by: Joseph Livesey <joseph.livesey@btp.works>