### PR TITLE
have CI skip cargo audit

### DIFF
--- a/.github/workflows/cargo-checkmate.yaml
+++ b/.github/workflows/cargo-checkmate.yaml
@@ -22,4 +22,3 @@ jobs:
       - run: cargo-checkmate clippy
       - run: cargo-checkmate build
       - run: cargo-checkmate doc
-      - run: cargo-checkmate audit


### PR DESCRIPTION
temporary workaround for https://github.com/frewsxcv/rust-crates-index/issues/92