### PR TITLE
allow specification of required JWT claims

### DIFF
--- a/crates/chronicle/src/bootstrap/cli.rs
+++ b/crates/chronicle/src/bootstrap/cli.rs
@@ -996,6 +996,14 @@ impl SubCommand for CliModel {
                             .help("accept GraphQL without authentication by web tokens")
                         // no conflict with JWT/JWKS settings because they may be set in environment but not used for this invocation
                     )
+                    .arg(
+                        Arg::new("jwt-must-claim")
+                        .long("jwt-must-claim")
+                        .multiple_occurrences(true)
+                        .multiple_values(true)
+                        .number_of_values(2)
+                        .help("claim name and value that must be present for accepting a JWT")
+                    )
                     .arg({
                         let arg = Arg::new("opa-rule")
                             .long("opa-rule")

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -35,6 +35,18 @@ constructing the authenticated user's Chronicle identity.
 
 Ignored if `--anonymous-api` is given.
 
+##### `--jwt-must-claim name value`
+
+For security, the GraphQL server can be set to ignore JSON Web Tokens that
+do not include the expected claims. It may be appropriate to set required
+values for names such as `iss`, `aud`, or `azp` depending on the claims
+expected in the JWTs issued by the authorization server.
+
+This option may be given multiple times. To set via environment variables
+instead, prefix each variable name with `JWT_MUST_CLAIM_`.
+
+Ignored if `--anonymous-api` is given.
+
 ##### `--opa-rule <opa-rule>`
 
 A path or a Sawtooth address of an OPA policy compiled to Wasm. Required


### PR DESCRIPTION
In researching JWT contents for CHRON-230, I came across consensus that specific claims are well worth checking for expected values, so this PR includes ability to have Chronicle check them accordingly before accepting a JWT. This work is enough separable from the main work for the ticket.

So, for instance, in testing with JWTs from Auth0, one might set `JWT_MUST_CLAIM_ISS` to one's Auth0 tenancy and `JWT_MUST_CLAIM_AUD` to the application API created therein. I also set `JWT_MUST_CLAIM_AZP` to the application's client ID. This is part of ensuring that the JWT was created for the use of Chronicle.

I avoided making any specific check mandatory, to cover for variations in deployment environment.