### PR TITLE
allow JWT claims to be fleshed out using /userinfo endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,6 +125,7 @@ dependencies = [
  "r2d2",
  "rand 0.8.5",
  "rand_core 0.6.4",
+ "reqwest",
  "serde",
  "serde_derive",
  "serde_json",
@@ -3789,11 +3790,11 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68cc60575865c7831548863cc02356512e3f1dc2f3f82cb837d7fc4cc8f3c97c"
+checksum = "21eed90ec8570952d53b772ecf8f206aa1ec9a3d76b2521c56c42973f2d91ee9"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.21.0",
  "bytes",
  "encoding_rs",
  "futures-core",

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -44,6 +44,7 @@ poem = { version = "1.3.30", features = ["opentelemetry", "websocket"] }
 r2d2 = "0.8.9"
 rand = { version = "0.8.5", features = ["getrandom"] }
 rand_core = "0.6.3"
+reqwest = "0.11.14"
 serde = "1.0.136"
 serde_derive = "1.0.136"
 serde_json = "1.0.81"

--- a/crates/api/src/chronicle_graphql/authorization.rs
+++ b/crates/api/src/chronicle_graphql/authorization.rs
@@ -1,6 +1,7 @@
 use base64::Engine;
 use jwtk::jwk::RemoteJwksVerifier;
-use serde_json::Value;
+use reqwest::StatusCode;
+use serde_json::{Map, Value};
 use std::time::Duration;
 use thiserror::Error;
 use tracing::instrument;
@@ -23,26 +24,35 @@ pub enum Error {
         #[from]
         source: jwtk::Error,
     },
+    #[error("web access failure: {0}", source)]
+    Reqwest {
+        #[from]
+        source: reqwest::Error,
+    },
     #[error("formatting error: {0}", message)]
     Format { message: String },
+    #[error("unexpected response: {0} responded with status {1}", server, status)]
+    UserInfoResponse { server: String, status: StatusCode },
 }
 
 pub struct JwtChecker {
+    client: reqwest::Client,
     verifier: RemoteJwksVerifier,
+    userinfo_uri: Option<String>,
 }
 
 impl JwtChecker {
-    pub fn new(jwks_uri: &Url) -> Self {
+    #[instrument(level = "debug")]
+    pub fn new(jwks_uri: &Url, userinfo_uri: Option<&Url>) -> Self {
         Self {
+            client: reqwest::Client::new(),
             verifier: RemoteJwksVerifier::new(jwks_uri.to_string(), None, Duration::from_secs(100)),
+            userinfo_uri: userinfo_uri.map(|s| s.to_string()),
         }
     }
 
-    #[instrument(skip(self), ret(Debug))]
-    pub async fn verify_jwt(
-        &self,
-        token: &str,
-    ) -> Result<serde_json::map::Map<String, Value>, Error> {
+    #[instrument(level = "trace", skip(self), ret(Debug))]
+    async fn attempt_jwt(&self, token: &str) -> Result<Map<String, Value>, Error> {
         let base64_engine = base64::engine::general_purpose::URL_SAFE_NO_PAD;
 
         // JWT is composed of three base64-encoded components
@@ -56,9 +66,7 @@ impl JwtChecker {
             });
         };
 
-        self.verifier
-            .verify::<serde_json::map::Map<String, Value>>(token)
-            .await?;
+        self.verifier.verify::<Map<String, Value>>(token).await?;
 
         if let Value::Object(claims) = serde_json::from_slice(components[1].as_slice())? {
             Ok(claims)
@@ -66,6 +74,53 @@ impl JwtChecker {
             Err(Error::Format {
                 message: format!("JWT claims have unexpected format: {:?}", components[1]),
             })
+        }
+    }
+
+    #[instrument(level = "debug", skip(self), ret(Debug))]
+    pub async fn verify_jwt(&self, token: &str) -> Result<Map<String, Value>, Error> {
+        let mut claims = Map::new();
+        let mut error = None;
+        match self.attempt_jwt(token).await {
+            Ok(claims_as_provided) => claims.extend(claims_as_provided),
+            error @ Err(Error::Jwks { .. }) => return error, // abort on JWKS verifier failure
+            Err(err) => error = Some(err), // could tolerate error from what may be opaque token
+        };
+        if let Some(userinfo_uri) = &self.userinfo_uri {
+            let request = self
+                .client
+                .post(userinfo_uri)
+                .header("Authorization", format!("Bearer {token}"));
+            let response = request.send().await?;
+            if response.status() == 200 {
+                let response_text = &response.text().await?;
+                if let Ok(claims_from_userinfo) = self.attempt_jwt(response_text).await {
+                    error = None;
+                    claims.extend(claims_from_userinfo)
+                } else if let Ok(Value::Object(claims_from_userinfo)) =
+                    serde_json::from_str(response_text)
+                {
+                    error = None;
+                    claims.extend(claims_from_userinfo)
+                } else {
+                    error = Some(Error::Format {
+                        message: format!(
+                            "UserInfo response has unexpected format: {response_text}"
+                        ),
+                    })
+                }
+            } else if error.is_some() {
+                tracing::trace!("first error before UserInfo was {error:?}");
+                error = Some(Error::UserInfoResponse {
+                    server: userinfo_uri.clone(),
+                    status: response.status(),
+                })
+            };
+        }
+        if let Some(error) = error {
+            Err(error)
+        } else {
+            Ok(claims)
         }
     }
 }

--- a/crates/api/src/chronicle_graphql/mod.rs
+++ b/crates/api/src/chronicle_graphql/mod.rs
@@ -342,6 +342,7 @@ where
 
 pub struct SecurityConf {
     pub jwks_uri: Option<Url>,
+    pub userinfo_uri: Option<Url>,
     pub id_pointer: Option<String>,
     pub jwt_must_claim: HashMap<String, String>,
     pub opa: ExecutorContext,
@@ -697,7 +698,7 @@ where
                     .at(
                         "/",
                         post(AuthorizationEndpointQuery {
-                            checker: JwtChecker::new(&jwks_uri),
+                            checker: JwtChecker::new(&jwks_uri, sec.userinfo_uri.as_ref()),
                             must_claim: sec.jwt_must_claim.clone(),
                             schema: schema.clone(),
                         }),
@@ -705,7 +706,7 @@ where
                     .at(
                         "/ws",
                         get(AuthorizationEndpointSubscription {
-                            checker: JwtChecker::new(&jwks_uri),
+                            checker: JwtChecker::new(&jwks_uri, sec.userinfo_uri.as_ref()),
                             must_claim: sec.jwt_must_claim,
                             schema,
                         }),

--- a/crates/chronicle/src/bootstrap/cli.rs
+++ b/crates/chronicle/src/bootstrap/cli.rs
@@ -978,6 +978,13 @@ impl SubCommand for CliModel {
                         }
                     }
                     ).arg({
+                        Arg::new("userinfo-address")
+                            .long("userinfo-address")
+                            .takes_value(true)
+                            .env("USERINFO_URI")
+                            .help("URI of the OIDC UserInfo endpoint")
+                    }
+                    ).arg({
                         let arg = Arg::new("id-pointer")
                             .long("id-pointer")
                             .takes_value(true)

--- a/crates/chronicle/src/bootstrap/mod.rs
+++ b/crates/chronicle/src/bootstrap/mod.rs
@@ -371,6 +371,12 @@ where
             })
         }?;
 
+        let userinfo_uri = if let Some(uri) = matches.value_of("userinfo-address") {
+            Some(Url::from_str(uri)?)
+        } else {
+            None
+        };
+
         let id_pointer = if matches.is_present("anonymous-api") {
             Ok(None)
         } else if let Some(id_pointer) = matches.value_of("id-pointer") {
@@ -404,6 +410,7 @@ where
             matches,
             SecurityConf {
                 jwks_uri,
+                userinfo_uri,
                 id_pointer,
                 jwt_must_claim,
                 opa,

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -35,6 +35,13 @@ constructing the authenticated user's Chronicle identity.
 
 Ignored if `--anonymous-api` is given.
 
+##### `--userinfo-address`
+
+The URI that should be used to exchange access tokens for user information,
+typically suffixed `/userinfo`. If this option is supplied then the endpoint
+must supply any additional claims in response to the same `Authorization:`
+header that was provided by a user in making their API request.
+
 ##### `--jwt-must-claim name value`
 
 For security, the GraphQL server can be set to ignore JSON Web Tokens that


### PR DESCRIPTION
Enables optional `--userinfo-address` option which switches behavior to presenting provided bearer token to that endpoint and taking claims as union of those from original token (if not opaque) and those from endpoint (either JWT or plain JSON). Enables CHRON-230 in that scopes may be in access token but user information for deriving Chronicle ID may need requesting separately.

If merged, I'll open a followup ticket for caching the user info so we don't hit the endpoint for every request.