### PR TITLE
Correctly pass ID from JWT claims to OPA evaluator

### DIFF
--- a/crates/chronicle-domain-test/src/test.rs
+++ b/crates/chronicle-domain-test/src/test.rs
@@ -153,7 +153,7 @@ mod test {
         .unwrap();
 
         Schema::build(Query, Mutation, Subscription)
-            .extension(OpaCheck)
+            .extension(OpaCheck { claim_parser: None })
             .data(Store::new(pool))
             .data(dispatch)
             .data(database) // share the lifetime

--- a/crates/common/src/opa_executor.rs
+++ b/crates/common/src/opa_executor.rs
@@ -285,6 +285,7 @@ pub struct ExecutorContext {
 }
 
 impl ExecutorContext {
+    #[instrument(skip(self), level = "debug", ret(Debug))]
     pub async fn evaluate(
         &self,
         id: &AuthId,


### PR DESCRIPTION
Fixes CHRON-236.

Data set on the GraphQL request in `prepare_request` reaches the handler code's context just fine but not `resolve`'s extension context. Fortunately, for determining a Chronicle ID, it is easy enough to have `OpaCheck` try the JSON pointer separately.