### PR TITLE
cache responses from OIDC /userinfo endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,6 +101,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "base64 0.21.0",
+ "cached",
  "chronicle-telemetry",
  "chrono",
  "common",
@@ -328,6 +329,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "async_once"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ce4f10ea3abcd6617873bae9f91d1c5332b4a778bd9ce34d0cd517474c1de82"
+
+[[package]]
 name = "atoi"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -507,6 +514,44 @@ dependencies = [
  "libc",
  "pkg-config",
 ]
+
+[[package]]
+name = "cached"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5877db5d1af7fae60d06b5db9430b68056a69b3582a0be8e3691e87654aeb6"
+dependencies = [
+ "async-trait",
+ "async_once",
+ "cached_proc_macro",
+ "cached_proc_macro_types",
+ "futures",
+ "hashbrown 0.13.2",
+ "instant",
+ "lazy_static",
+ "once_cell",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
+name = "cached_proc_macro"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10ca87c81aaa3a949dbbe2b5e6c2c45dbc94ba4897e45ea31ff9ec5087be3dc"
+dependencies = [
+ "cached_proc_macro_types",
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "cached_proc_macro_types"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a4f925191b4367301851c6d99b09890311d74b0d43f274c0b34c86d308a3663"
 
 [[package]]
 name = "cast"
@@ -1866,6 +1911,12 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
  "ahash 0.7.6",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 
 [[package]]
 name = "hashlink"

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -17,6 +17,7 @@ async-graphql-poem = "4.0.9"
 async-stream = "0.3.3"
 async-trait = "0.1.53"
 base64 = "0.21"
+cached = "0.42"
 chrono = "0.4.19"
 common = { path = "../common" }
 custom_error = "1.9.2"

--- a/crates/api/src/chronicle_graphql/authorization.rs
+++ b/crates/api/src/chronicle_graphql/authorization.rs
@@ -1,9 +1,11 @@
 use base64::Engine;
+use cached::{Cached, TimedCache};
 use jwtk::jwk::RemoteJwksVerifier;
 use reqwest::StatusCode;
 use serde_json::{Map, Value};
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 use thiserror::Error;
+use tokio::sync::Mutex;
 use tracing::instrument;
 use url::Url;
 
@@ -39,15 +41,23 @@ pub struct JwtChecker {
     client: reqwest::Client,
     verifier: RemoteJwksVerifier,
     userinfo_uri: Option<String>,
+    userinfo_cache: Arc<Mutex<TimedCache<String, Map<String, Value>>>>,
 }
 
 impl JwtChecker {
     #[instrument(level = "debug")]
-    pub fn new(jwks_uri: &Url, userinfo_uri: Option<&Url>) -> Self {
+    pub fn new(jwks_uri: &Url, userinfo_uri: Option<&Url>, cache_expiry_seconds: u32) -> Self {
         Self {
             client: reqwest::Client::new(),
-            verifier: RemoteJwksVerifier::new(jwks_uri.to_string(), None, Duration::from_secs(100)),
+            verifier: RemoteJwksVerifier::new(
+                jwks_uri.to_string(),
+                None,
+                Duration::from_secs(cache_expiry_seconds.into()),
+            ),
             userinfo_uri: userinfo_uri.map(|s| s.to_string()),
+            userinfo_cache: Arc::new(Mutex::new(TimedCache::with_lifespan(
+                cache_expiry_seconds.into(),
+            ))),
         }
     }
 
@@ -87,35 +97,49 @@ impl JwtChecker {
             Err(err) => error = Some(err), // could tolerate error from what may be opaque token
         };
         if let Some(userinfo_uri) = &self.userinfo_uri {
-            let request = self
-                .client
-                .post(userinfo_uri)
-                .header("Authorization", format!("Bearer {token}"));
-            let response = request.send().await?;
-            if response.status() == 200 {
-                let response_text = &response.text().await?;
-                if let Ok(claims_from_userinfo) = self.attempt_jwt(response_text).await {
-                    error = None;
-                    claims.extend(claims_from_userinfo)
-                } else if let Ok(Value::Object(claims_from_userinfo)) =
-                    serde_json::from_str(response_text)
-                {
-                    error = None;
-                    claims.extend(claims_from_userinfo)
+            let mut cache = self.userinfo_cache.lock().await;
+            if let Some(claims_from_userinfo) = cache.cache_get(&token.to_string()) {
+                tracing::trace!("userinfo cache hit");
+                error = None;
+                claims.extend(claims_from_userinfo.clone());
+            } else {
+                tracing::trace!("userinfo cache miss");
+                drop(cache);
+                let request = self
+                    .client
+                    .post(userinfo_uri)
+                    .header("Authorization", format!("Bearer {token}"));
+                let response = request.send().await?;
+                cache = self.userinfo_cache.lock().await;
+                if response.status() == 200 {
+                    let response_text = &response.text().await?;
+                    if let Ok(claims_from_userinfo) = self.attempt_jwt(response_text).await {
+                        error = None;
+                        claims.extend(claims_from_userinfo.clone());
+                        cache.cache_set(token.to_string(), claims_from_userinfo);
+                    } else if let Ok(Value::Object(claims_from_userinfo)) =
+                        serde_json::from_str(response_text)
+                    {
+                        error = None;
+                        claims.extend(claims_from_userinfo.clone());
+                        cache.cache_set(token.to_string(), claims_from_userinfo);
+                    } else {
+                        error = Some(Error::Format {
+                            message: format!(
+                                "UserInfo response has unexpected format: {response_text}"
+                            ),
+                        })
+                    }
+                } else if error.is_some() {
+                    tracing::trace!("first error before UserInfo was {error:?}");
+                    error = Some(Error::UserInfoResponse {
+                        server: userinfo_uri.clone(),
+                        status: response.status(),
+                    });
                 } else {
-                    error = Some(Error::Format {
-                        message: format!(
-                            "UserInfo response has unexpected format: {response_text}"
-                        ),
-                    })
+                    cache.cache_set(token.to_string(), Map::new());
                 }
-            } else if error.is_some() {
-                tracing::trace!("first error before UserInfo was {error:?}");
-                error = Some(Error::UserInfoResponse {
-                    server: userinfo_uri.clone(),
-                    status: response.status(),
-                })
-            };
+            }
         }
         if let Some(error) = error {
             Err(error)

--- a/crates/api/src/chronicle_graphql/mod.rs
+++ b/crates/api/src/chronicle_graphql/mod.rs
@@ -693,12 +693,17 @@ where
 
         let app = match sec.jwks_uri {
             Some(jwks_uri) => {
+                const CACHE_EXPIRY_SECONDS: u32 = 100;
                 tracing::debug!("API endpoint authentication uses {}", jwks_uri);
                 Route::new()
                     .at(
                         "/",
                         post(AuthorizationEndpointQuery {
-                            checker: JwtChecker::new(&jwks_uri, sec.userinfo_uri.as_ref()),
+                            checker: JwtChecker::new(
+                                &jwks_uri,
+                                sec.userinfo_uri.as_ref(),
+                                CACHE_EXPIRY_SECONDS,
+                            ),
                             must_claim: sec.jwt_must_claim.clone(),
                             schema: schema.clone(),
                         }),
@@ -706,7 +711,11 @@ where
                     .at(
                         "/ws",
                         get(AuthorizationEndpointSubscription {
-                            checker: JwtChecker::new(&jwks_uri, sec.userinfo_uri.as_ref()),
+                            checker: JwtChecker::new(
+                                &jwks_uri,
+                                sec.userinfo_uri.as_ref(),
+                                CACHE_EXPIRY_SECONDS,
+                            ),
                             must_claim: sec.jwt_must_claim,
                             schema,
                         }),


### PR DESCRIPTION
Resolves CHRON-237 by adding caching of responses from when with `--userinfo-address` we pass an access token to an authorization server endpoint to obtain user information for determining the Chronicle ID.