### PR TITLE
fix: reduce tracing level to trace on opa policyloader build_opa

### DIFF
--- a/crates/common/src/opa_executor.rs
+++ b/crates/common/src/opa_executor.rs
@@ -48,7 +48,7 @@ pub trait PolicyLoader {
     fn load_policy_from_bytes(&mut self, policy: &[u8]);
 
     /// Return a built OPA instance from the cached policy
-    #[instrument(level = "info", skip(self), ret)]
+    #[instrument(level = "trace", skip(self), ret)]
     fn build_opa(&self) -> Result<Opa, OpaExecutorError> {
         Ok(Opa::new().build(self.get_policy())?)
     }


### PR DESCRIPTION
Signed-off-by: Joseph Livesey [joseph.livesey@btp.works](mailto:joseph.livesey@btp.works)