### PR TITLE
fix: build - misc

### DIFF
--- a/crates/chronicle/src/bootstrap/cli.rs
+++ b/crates/chronicle/src/bootstrap/cli.rs
@@ -964,19 +964,13 @@ impl SubCommand for CliModel {
                             .takes_value(true)
                             .default_value("127.0.0.1:9982")
                             .help("The graphql server address (default 127.0.0.1:9982)"),
-                    ).arg({
-                        let arg = Arg::new("jwks-address")
+                    ).arg(
+                        Arg::new("jwks-address")
                             .long("jwks-address")
                             .takes_value(true)
                             .env("JWKS_URI")
-                            .help("URI of the JSON key set for verifying web tokens");
-                        if cfg!(feature = "anonymous-api") {
-                            arg
-                        } else {
-                            arg
-                            .required_unless_present("anonymous-api")
-                        }
-                    }
+                            .help("URI of the JSON key set for verifying web tokens"),
+
                     ).arg({
                         Arg::new("userinfo-address")
                             .long("userinfo-address")
@@ -984,19 +978,12 @@ impl SubCommand for CliModel {
                             .env("USERINFO_URI")
                             .help("URI of the OIDC UserInfo endpoint")
                     }
-                    ).arg({
-                        let arg = Arg::new("id-pointer")
+                    ).arg(
+                        Arg::new("id-pointer")
                             .long("id-pointer")
                             .takes_value(true)
                             .env("JWT_POINTER")
-                            .help("JSON pointer into JWT claims for Chronicle ID");
-                        if cfg!(feature = "anonymous-api") {
-                            arg
-                        } else {
-                            arg
-                            .required_unless_present("anonymous-api")
-                        }
-                    }
+                            .help("JSON pointer into JWT claims for Chronicle ID"),
                     ).arg(
                         Arg::new("anonymous-api")
                             .long("anonymous-api")

--- a/crates/chronicle/src/bootstrap/mod.rs
+++ b/crates/chronicle/src/bootstrap/mod.rs
@@ -15,7 +15,7 @@ use common::{
     identity::AuthId,
     ledger::SubmissionStage,
     opa_executor::{CliPolicyLoader, ExecutorContext, PolicyLoader},
-    prov::to_json_ld::ToJson,
+    prov::{to_json_ld::ToJson, AgentId},
     signing::{DirectoryStoredKeys, SignerError},
 };
 use rust_embed::RustEmbed;
@@ -331,6 +331,11 @@ where
             while let (Some(name), Some(value)) = (claims.next(), claims.next()) {
                 jwt_must_claim.insert(name.clone(), value.clone());
             }
+        }
+
+        if jwks_uri.is_none() && id_pointer.is_none() {
+            DirectoryStoredKeys::new(config.secrets.path)?
+                .generate_agent(&AgentId::from_external_id("Anonymous"))?;
         }
 
         let opa = opa_executor().await?;

--- a/crates/chronicle/src/bootstrap/mod.rs
+++ b/crates/chronicle/src/bootstrap/mod.rs
@@ -301,17 +301,11 @@ where
     let api = api.clone();
 
     if let Some(matches) = matches.subcommand_matches("serve-graphql") {
-        let jwks_uri = if matches.is_present("anonymous-api") {
-            Ok(None)
-        } else if let Some(uri) = matches.value_of("jwks-address") {
-            Ok(Some(Url::from_str(uri)?))
-        } else if cfg!(feature = "anonymous-api") {
-            Ok(None)
+        let jwks_uri = if let Some(uri) = matches.value_of("jwks-address") {
+            Some(Url::from_str(uri)?)
         } else {
-            Err(CliError::MissingArgument {
-                arg: "jwks-address".to_string(),
-            })
-        }?;
+            None
+        };
 
         let userinfo_uri = if let Some(uri) = matches.value_of("userinfo-address") {
             Some(Url::from_str(uri)?)
@@ -320,16 +314,12 @@ where
         };
 
         let id_pointer = if matches.is_present("anonymous-api") {
-            Ok(None)
-        } else if let Some(id_pointer) = matches.value_of("id-pointer") {
-            Ok(Some(id_pointer.to_string()))
-        } else if cfg!(feature = "anonymous-api") {
-            Ok(None)
+            None
         } else {
-            Err(CliError::MissingArgument {
-                arg: "id-pointer".to_string(),
-            })
-        }?;
+            matches
+                .value_of("id-pointer")
+                .map(|id_pointer| id_pointer.to_string())
+        };
 
         let mut jwt_must_claim: HashMap<String, String> = HashMap::new();
         for (name, value) in std::env::vars() {

--- a/crates/sawtooth-tp/src/main.rs
+++ b/crates/sawtooth-tp/src/main.rs
@@ -63,12 +63,14 @@ async fn main() {
         },
     );
 
+    let (policy, entrypoint) = ("default_allow.wasm", "default_allow.allow");
+
     Handle::current().spawn_blocking(move || {
         info!(
             "Starting Chronicle Transaction Processor on {:?}",
             matches.get_one::<String>("connect")
         );
-        let handler = match ChronicleTransactionHandler::new() {
+        let handler = match ChronicleTransactionHandler::new(policy, entrypoint) {
             Ok(handler) => handler,
             Err(e) => panic!("Error initializing TransactionHandler: {e}"),
         };


### PR DESCRIPTION
- make cli args optional for `serve-graphql` subcommands `"jwks-address"` and `"id-pointer"` and change `bootstrap/mod` so that no args for `serve-graphql` subcommands `"jwks-address"` and `"id-pointer"` does not result in a `CliError`
- generate an `Anonymous` agent key if cli args dictate `serve-graphql` user will be `Anonymous`
- revert [change](https://github.com/btpworks/chronicle/pull/171/commits) to `async` block in `submit_sawtooth_tx` (`SawtoothSubmitter::submit`)
- change the policy being bootstrapped in the Sawtooth TP from allow user `Chronicle` to default allow

---
Signed-off-by: Joseph Livesey [joseph.livesey@btp.works](mailto:joseph.livesey@btp.works)