### PR TITLE
replace --anonymous-api with --require-auth

### DIFF
--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -65,9 +65,7 @@ tempfile = "3.3.0"
 [build-dependencies]
 
 [features]
-devmode = ["anonymous-api", "inmem"]
-# Allow unauthenticated API access
-anonymous-api = []
+devmode = ["inmem"]
 # Use an in-memory stub ledger
 inmem  = []
 strict = []

--- a/crates/chronicle-domain-test/Cargo.toml
+++ b/crates/chronicle-domain-test/Cargo.toml
@@ -22,9 +22,7 @@ chronicle = { path = "../chronicle" }
 
 [features]
 strict = []
-devmode = ["anonymous-api", "inmem"]
-# Allow unauthenticated API access
-anonymous-api = ["chronicle/anonymous-api"]
+devmode = ["inmem"]
 # Use an in-memory stub ledger
 inmem = ["chronicle/inmem"]
 

--- a/crates/chronicle/Cargo.toml
+++ b/crates/chronicle/Cargo.toml
@@ -59,9 +59,7 @@ valico = "3.6.0"
 
 
 [features]
-devmode = ["anonymous-api", "inmem"]
-# Allow unauthenticated API access
-anonymous-api = []
+devmode = ["inmem"]
 # Use an in-memory stub ledger
 inmem  = []
 strict = []

--- a/crates/chronicle/src/bootstrap/cli.rs
+++ b/crates/chronicle/src/bootstrap/cli.rs
@@ -1000,10 +1000,14 @@ impl SubCommand for CliModel {
                     .arg(
                         Arg::new("interface")
                             .long("interface")
-                            .required(false)
                             .takes_value(true)
                             .default_value("127.0.0.1:9982")
                             .help("The graphql server address (default 127.0.0.1:9982)"),
+                    ).arg(
+                        Arg::new("require-auth")
+                            .long("require-auth")
+                            .requires("jwks-address")
+                            .help("if JWT must be provided, preventing anonymous requests"),
                     ).arg(
                         Arg::new("jwks-address")
                             .long("jwks-address")
@@ -1025,11 +1029,6 @@ impl SubCommand for CliModel {
                             .env("JWT_POINTER")
                             .default_value("/sub")
                             .help("JSON pointer into JWT claims for Chronicle ID"),
-                    ).arg(
-                        Arg::new("anonymous-api")
-                            .long("anonymous-api")
-                            .help("accept GraphQL without authentication by web tokens")
-                        // no conflict with JWT/JWKS settings because they may be set in environment but not used for this invocation
                     )
                     .arg(
                         Arg::new("jwt-must-claim")

--- a/crates/chronicle/src/bootstrap/mod.rs
+++ b/crates/chronicle/src/bootstrap/mod.rs
@@ -313,7 +313,9 @@ where
             None
         };
 
-        // Defaults to look for "/sub"
+        let allow_anonymous = !matches.is_present("require-auth");
+
+        // CliModel defaults to looking for "/sub"
         let id_pointer = matches
             .value_of("id-pointer")
             .map(|id_pointer| id_pointer.to_string());
@@ -342,6 +344,7 @@ where
                 userinfo_uri,
                 id_pointer,
                 jwt_must_claim,
+                allow_anonymous,
                 opa,
             },
         )

--- a/crates/opactl/src/main.rs
+++ b/crates/opactl/src/main.rs
@@ -263,7 +263,7 @@ async fn dispatch_args<
                 let mut file = File::create(path).unwrap();
                 file.write_all(key.as_bytes()).unwrap();
             } else {
-                println!("{}", key);
+                println!("{key}");
             }
 
             Ok(Waited::NoWait)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -12,12 +12,6 @@ Run Chronicle as a GraphQL server.
 
 The GraphQL server socket address - defaults to 127.0.0.1:9982.
 
-##### `--anonymous-api`
-
-Ignore any JSON Web Tokens that are provided to the GraphQL API,
-regard all access as being anonymous from unauthenticated users.
-Otherwise, the following two arguments are relevant and required.
-
 ##### `--jwks-address <URI>`
 
 The URI from which the JSON Web Key Set (JWKS) can be obtained.
@@ -25,15 +19,16 @@ This typically has a suffix of `jwks.json`.
 The JWKS is used for verifying JSON Web Tokens provided via HTTP
 `Authorized: Bearer ...`.
 
-Ignored if `--anonymous-api` is given.
-
-##### `id-pointer <JSON ptr>`
+##### `--id-pointer <JSON ptr>`
 
 A JSON pointer into the JSON Web Token claims, specifying the location of
 a string value corresponding to the external ID that should be used in
 constructing the authenticated user's Chronicle identity.
 
-Ignored if `--anonymous-api` is given.
+##### `--require-auth`
+
+Reject anonymous requests. Requires `--jwks-address` because identity for
+every request must be established verifiably.
 
 ##### `--userinfo-address`
 
@@ -51,8 +46,6 @@ expected in the JWTs issued by the authorization server.
 
 This option may be given multiple times. To set via environment variables
 instead, prefix each variable name with `JWT_MUST_CLAIM_`.
-
-Ignored if `--anonymous-api` is given.
 
 ### `export-schema`
 


### PR DESCRIPTION
GraphQL API will accept anonymous access as default unless disallowed with new `--require-auth` option. Only with that option must JWKS server be specified for JWT verification. Fixes CHRON-245.