### PR TITLE
retry after PgEmbedError PgStartFailure

### DIFF
--- a/docker/unified-builder
+++ b/docker/unified-builder
@@ -166,6 +166,10 @@ WORKDIR /
 RUN groupadd -g 999 chronicle && \
   useradd -m -r -u 999 -g chronicle chronicle
 
+RUN apt-get update && \
+  apt-get install -y \
+  libpq5
+
 COPY .artifacts/artifacts/${TARGETARCH}/chronicle_sawtooth_tp /usr/local/bin
 
 RUN mkdir -p /var/lib/chronicle \


### PR DESCRIPTION
To resolve CHRON-248 this generalizes the `pool_remote` retry code into a trait that is also then used before constructing the embedded database pool.