### PR TITLE
address RUSTSEC-2021-0141

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -14,9 +14,6 @@ ignore = [
   #CBOR will be replaced with proto for TP events before long
   "RUSTSEC-2021-0127",
 
-  #dotenv is unmaintained https://rustsec.org/advisories/RUSTSEC-2021-0141
-  "RUSTSEC-2021-0141",
-
   #json is unmaintained https://rustsec.org/advisories/RUSTSEC-2022-0081
   "RUSTSEC-2022-0081"
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -586,7 +586,7 @@ dependencies = [
  "colored_json",
  "common",
  "diesel",
- "dotenv",
+ "dotenvy",
  "futures",
  "genco",
  "hex",
@@ -1436,6 +1436,12 @@ name = "dotenv"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
+
+[[package]]
+name = "dotenvy"
+version = "0.15.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03d8c417d7a8cb362e0c37e5d815f5eb7c37f79ff93707329d5a194e42e54ca0"
 
 [[package]]
 name = "ecdsa"

--- a/crates/chronicle/Cargo.toml
+++ b/crates/chronicle/Cargo.toml
@@ -21,7 +21,7 @@ diesel = { version = "2.0.0-rc.0", features = [
   "chrono",
   "r2d2",
 ] }
-dotenv = "0.15.0"
+dotenvy = "0.15"
 futures = "0.3.21"
 genco = "0.16.1"
 hex = "0.4.3"

--- a/crates/chronicle/src/bootstrap/mod.rs
+++ b/crates/chronicle/src/bootstrap/mod.rs
@@ -291,7 +291,7 @@ where
     Query: ObjectType + Copy,
     Mutation: ObjectType + Copy,
 {
-    dotenv::dotenv().ok();
+    dotenvy::dotenv().ok();
 
     let matches = cli.as_cmd().get_matches();
     let (pool, _pool_scope) = pool(&matches).await?;


### PR DESCRIPTION
Replaces use of unmaintained `dotenv` crate with fork `dotenvy`, resolving CHRON-222.