### PR TITLE
fix: make opa available to chronicle-builder image

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -607,7 +607,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "serde_yaml",
- "shellexpand 3.0.0",
+ "shellexpand",
  "tempfile",
  "thiserror",
  "tokio",
@@ -4004,7 +4004,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rust-embed-utils",
- "shellexpand 2.1.2",
  "syn",
  "walkdir",
 ]
@@ -4368,15 +4367,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
 dependencies = [
  "lazy_static",
-]
-
-[[package]]
-name = "shellexpand"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ccc8076840c4da029af4f87e4e8daeb0fca6b87bbb02e10cb60b791450e11e4"
-dependencies = [
- "dirs 4.0.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4014,6 +4014,7 @@ version = "7.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1669d81dfabd1b5f8e2856b8bbe146c6192b0ba22162edc738ac0a5de18f054"
 dependencies = [
+ "globset",
  "sha2",
  "walkdir",
 ]

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ HOST_ARCHITECTURE ?= $(shell uname -m | sed -e 's/x86_64/amd64/' -e 's/aarch64/a
 
 CLEAN_DIRS := $(CLEAN_DIRS)
 
-clean: clean_containers clean_target
+clean: clean_containers clean_target clean-opa
 
 distclean: clean_docker clean_markers
 
@@ -112,7 +112,7 @@ $(1)-manifest: $(1)-$(2)-build
 
 $(1): $(1)-$(2)-build
 
-build: $(1)
+build: build-opa $(1)
 
 build-native: $(1)-$(HOST_ARCHITECTURE)-build
 endef
@@ -127,3 +127,54 @@ clean_docker: stop
 
 clean_target:
 	$(RM) -r target
+
+uname_S := $(shell uname -s)
+uname_M := $(shell uname -m)
+
+ifeq ($(uname_S), Linux)
+	OS = linux
+	OPA_SUFFIX = _static
+else ifeq ($(uname_S), Darwin)
+	OS = darwin
+else
+	OS = windows
+	ARCH = amd64
+endif
+
+ifeq ($(uname_M), x86_64)
+	ARCH = amd64
+else ifeq ($(uname_M), arm)
+	ARCH = arm64
+	OPA_SUFFIX = _static
+else ifeq ($(uname_M), arm64)
+	ARCH = arm64
+	OPA_SUFFIX = _static
+else ifeq ($(uname_M), aarch64)
+	ARCH = arm64
+	OPA_SUFFIX = _static
+endif
+
+OPA_VERSION=v0.49.2
+OPA_DOWNLOAD_URL=https://openpolicyagent.org/downloads/$(OPA_VERSION)/opa_$(OS)_$(ARCH)$(OPA_SUFFIX)
+
+.PHONY: download-opa
+download-opa:
+	if [ ! -r build/opa ]; then \
+		curl -sSL -o build/opa $(OPA_DOWNLOAD_URL); \
+		chmod 755 build/opa; \
+	fi
+
+build-opa: download-opa
+	build/opa build -t wasm -o policies/bundle.tar.gz -b policies -e "allow_transactions" -e "common_rules"
+
+.PHONY: opa-test
+opa-test: download-opa
+	build/opa test -b policies
+
+.PHONY: clean-opa
+clean-opa:
+	if [ -n "$(wildcard policies/*.tar.gz)" ]; then \
+		rm policies/*.tar.gz; \
+	else \
+		echo "No OPA policy archives to remove."; \
+	fi

--- a/crates/chronicle-domain-test/src/test.rs
+++ b/crates/chronicle-domain-test/src/test.rs
@@ -94,18 +94,22 @@ mod test {
     }
 
     async fn test_schema() -> Schema<Query, Mutation, Subscription> {
-        let loader =
-            CliPolicyLoader::from_embedded_policy("default_allow.tar.gz", "default_allow.allow")
-                .unwrap();
+        let loader = CliPolicyLoader::from_embedded_policy(
+            "allow_transactions",
+            "allow_transactions.allowed_users",
+        )
+        .unwrap();
         let opa_executor = ExecutorContext::from_loader(&loader).unwrap();
 
         test_schema_with_opa(opa_executor).await
     }
 
     async fn test_schema_blocked_api() -> Schema<Query, Mutation, Subscription> {
-        let loader =
-            CliPolicyLoader::from_embedded_policy("default_deny.tar.gz", "default_deny.allow")
-                .unwrap();
+        let loader = CliPolicyLoader::from_embedded_policy(
+            "allow_transactions",
+            "allow_transactions.deny_all",
+        )
+        .unwrap();
         let opa_executor = ExecutorContext::from_loader(&loader).unwrap();
 
         test_schema_with_opa(opa_executor).await
@@ -3761,9 +3765,11 @@ mod test {
 
     #[tokio::test]
     async fn subscribe_api_secured() {
-        let loader =
-            CliPolicyLoader::from_embedded_policy("allow_defines.tar.gz", "allow_defines.allow")
-                .unwrap();
+        let loader = CliPolicyLoader::from_embedded_policy(
+            "allow_transactions",
+            "allow_transactions.allow_defines",
+        )
+        .unwrap();
         let opa_executor = ExecutorContext::from_loader(&loader).unwrap();
         let test_schema_allow_defines = test_schema_with_opa(opa_executor).await;
 

--- a/crates/chronicle/src/bootstrap/mod.rs
+++ b/crates/chronicle/src/bootstrap/mod.rs
@@ -91,10 +91,12 @@ impl SetRuleOptions for CliPolicyLoader {
     }
 }
 
-async fn opa_executor() -> Result<ExecutorContext, CliError> {
+async fn opa_executor_from_embedded_policy(
+    policy_name: &str,
+    entrypoint: &str,
+) -> Result<ExecutorContext, CliError> {
     tracing::warn!("insecure operating mode");
-    let loader =
-        CliPolicyLoader::from_embedded_policy("default_allow.tar.gz", "default_allow.allow")?;
+    let loader = CliPolicyLoader::from_embedded_policy(policy_name, entrypoint)?;
     Ok(ExecutorContext::from_loader(&loader)?)
 }
 
@@ -338,7 +340,9 @@ where
             }
         }
 
-        let opa = opa_executor().await?;
+        let (default_policy_name, entrypoint) =
+            ("allow_transactions", "allow_transactions.allowed_users");
+        let opa = opa_executor_from_embedded_policy(default_policy_name, entrypoint).await?;
 
         let open_cors = matches.is_present("unlock-cors");
 

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -54,7 +54,7 @@ protobuf = "2.27.1"
 r2d2 = "0.8.9"
 rand = { version = "0.8.5", features = ["getrandom"] }
 rand_core = "0.6.3"
-rust-embed = { version = "6.4.2", features = ["interpolate-folder-path"] }
+rust-embed = "6.4.2"
 sawtooth-sdk = "0.5.2"
 serde = "1.0.136"
 serde_derive = "1.0.136"
@@ -72,7 +72,6 @@ zmq = "0.9.2"
 glob        = "0.3.0"
 json        = "0.12.4"
 lazy_static = "1.4.0"
-opa = "0.9.0"
 prost-build = "0.10.0"
 
 [dev-dependencies]

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -54,7 +54,7 @@ protobuf = "2.27.1"
 r2d2 = "0.8.9"
 rand = { version = "0.8.5", features = ["getrandom"] }
 rand_core = "0.6.3"
-rust-embed = "6.4.2"
+rust-embed = { version = "6.4.2", features = ["include-exclude"] }
 sawtooth-sdk = "0.5.2"
 serde = "1.0.136"
 serde_derive = "1.0.136"

--- a/crates/common/benches/opa_executor.rs
+++ b/crates/common/benches/opa_executor.rs
@@ -7,8 +7,8 @@ use serde_json::Value;
 use tokio::runtime::Runtime;
 
 fn load_wasm_from_file() -> Result<(), OpaExecutorError> {
-    let wasm = "auth.tar.gz";
-    let entrypoint = "auth.is_authorized";
+    let wasm = "allow_transactions";
+    let entrypoint = "allow_transactions/allowed_users";
     CliPolicyLoader::from_embedded_policy(wasm, entrypoint)?;
     Ok(())
 }
@@ -26,8 +26,8 @@ fn build_executor_from_loader(loader: &CliPolicyLoader) -> Result<(), OpaExecuto
 
 fn bench_build_opa_executor(c: &mut Criterion) {
     let input = {
-        let wasm = "auth.tar.gz";
-        let entrypoint = "auth.is_authorized";
+        let wasm = "allow_transactions";
+        let entrypoint = "allow_transactions.allowed_users";
         CliPolicyLoader::from_embedded_policy(wasm, entrypoint).unwrap()
     };
     c.bench_with_input(
@@ -52,8 +52,8 @@ fn bench_evaluate_policy(c: &mut Criterion) {
     c.bench_function("evaluate", |b| {
         b.iter_batched_ref(
             || {
-                let wasm = "auth.tar.gz";
-                let entrypoint = "auth.is_authorized";
+                let wasm = "allow_transactions";
+                let entrypoint = "allow_transactions.allowed_users";
                 let loader = CliPolicyLoader::from_embedded_policy(wasm, entrypoint).unwrap();
                 let id = AuthId::chronicle();
                 let data = OpaData::Operation(IdentityContext::new(

--- a/crates/common/build.rs
+++ b/crates/common/build.rs
@@ -29,20 +29,5 @@ fn main() -> Result<()> {
         context.pretty(2),
     )?;
 
-    let policies = vec![
-        ("allow_defines", "allow"),
-        ("auth", "is_authorized"),
-        ("default_allow", "allow"),
-        ("default_deny", "allow"),
-    ];
-
-    for (policy_name, entrypoint) in policies {
-        opa::build::policy(policy_name)
-            .add_source(format!("src/policies/{policy_name}.rego"))
-            .add_entrypoint(format!("{policy_name}.{entrypoint}"))
-            .compile()
-            .unwrap();
-    }
-
     Ok(())
 }

--- a/crates/common/src/policies/auth.rego
+++ b/crates/common/src/policies/auth.rego
@@ -1,9 +1,0 @@
-package auth
-
-import input
-
-default is_authorized = false
-
-is_authorized {
-  input.type == "chronicle"
-}

--- a/crates/common/src/policies/default_allow.rego
+++ b/crates/common/src/policies/default_allow.rego
@@ -1,3 +1,0 @@
-package default_allow
-
-default allow = true

--- a/crates/common/src/policies/default_deny.rego
+++ b/crates/common/src/policies/default_deny.rego
@@ -1,3 +1,0 @@
-package default_deny
-
-default allow = false

--- a/crates/sawtooth-tp/src/main.rs
+++ b/crates/sawtooth-tp/src/main.rs
@@ -63,14 +63,16 @@ async fn main() {
         },
     );
 
-    let (policy, entrypoint) = ("default_allow.tar.gz", "default_allow.allow");
+    let (bootstrap_policy, bootstrap_entrypoint) =
+        ("allow_transactions", "allow_transactions.allowed_users");
 
     Handle::current().spawn_blocking(move || {
         info!(
             "Starting Chronicle Transaction Processor on {:?}",
             matches.get_one::<String>("connect")
         );
-        let handler = match ChronicleTransactionHandler::new(policy, entrypoint) {
+        let handler = match ChronicleTransactionHandler::new(bootstrap_policy, bootstrap_entrypoint)
+        {
             Ok(handler) => handler,
             Err(e) => panic!("Error initializing TransactionHandler: {e}"),
         };

--- a/docker/opa-builder
+++ b/docker/opa-builder
@@ -56,6 +56,7 @@ COPY Cargo.lock /app
 COPY .cargo /app/.cargo
 COPY Cargo.toml /app
 COPY crates /app/crates
+COPY policies /app/policies
 
 # Test on the host only
 # PostgreSQL will not run as root
@@ -99,7 +100,6 @@ RUN --mount=type=cache,target=/var/cache/apt \
 FROM  alpine:3.16.3 as tested-artifacts
 COPY --from=tested --link /artifacts /artifacts
 
-# Copy opa-tp to image
 # Copy opa-tp to image
 FROM debian:bullseye-slim AS opa-tp
 ARG TARGETARCH

--- a/docker/unified-builder
+++ b/docker/unified-builder
@@ -39,14 +39,6 @@ ENV VERSION=AUTO_STRICT
 
 ENV PATH=$PATH:/root/.cargo/bin
 
-# Download OPA binary
-ARG TARGETARCH
-ARG OPA_VERSION=0.49.0
-RUN --mount=type=cache,target=/tmp \
-  curl -L -o /tmp/opa "https://openpolicyagent.org/downloads/v${OPA_VERSION}/opa_linux_${TARGETARCH}_static" && \
-  mv /tmp/opa /usr/local/bin/opa && \
-  chmod +x /usr/local/bin/opa
-
 RUN rustup target add x86_64-unknown-linux-gnu && rustup target add aarch64-unknown-linux-gnu
 
 WORKDIR /app
@@ -58,6 +50,7 @@ COPY Cargo.lock /app
 COPY .cargo /app/.cargo
 COPY Cargo.toml /app
 COPY crates /app/crates
+COPY policies /app/policies
 
 # Test on the host only
 # PostgreSQL will not run as root
@@ -100,9 +93,7 @@ RUN --mount=type=cache,target=/var/cache/apt \
   && cargo build --target x86_64-unknown-linux-gnu --release ${BUILD_ARGS} \
   && mv -f target/x86_64-unknown-linux-gnu/release/chronicle /artifacts/amd64 \
   && mv -f target/x86_64-unknown-linux-gnu/release/chronicle_sawtooth_tp /artifacts/amd64 \
-  && mv -f target/x86_64-unknown-linux-gnu/release/chronicle-domain-lint /artifacts/amd64 \
-  && mv -f target/x86_64-unknown-linux-gnu/release/opactl /artifacts/amd64 \
-  && mv -f target/x86_64-unknown-linux-gnu/release/opa-tp /artifacts/amd64
+  && mv -f target/x86_64-unknown-linux-gnu/release/chronicle-domain-lint /artifacts/amd64
 
 
 FROM  alpine:3.16.3 as tested-artifacts
@@ -134,6 +125,7 @@ COPY .cargo /app/.cargo
 COPY Cargo.lock /app
 COPY Cargo.toml /app
 COPY crates /app/crates
+COPY policies /app/policies
 RUN cargo fetch --locked
 
 

--- a/opa.mk
+++ b/opa.mk
@@ -13,7 +13,7 @@ HOST_ARCHITECTURE ?= $(shell uname -m | sed -e 's/x86_64/amd64/' -e 's/aarch64/a
 
 CLEAN_DIRS := $(CLEAN_DIRS)
 
-clean: clean_containers clean_target
+clean: clean_containers clean_target clean-opa
 
 distclean: clean_docker clean_markers
 
@@ -112,7 +112,7 @@ $(1)-manifest: $(1)-$(2)-build
 
 $(1): $(1)-$(2)-build
 
-build: $(1)
+build: build-opa $(1)
 
 build-native: $(1)-$(HOST_ARCHITECTURE)-build
 endef
@@ -127,3 +127,54 @@ clean_docker: stop
 
 clean_target:
 	$(RM) -r target
+
+uname_S := $(shell uname -s)
+uname_M := $(shell uname -m)
+
+ifeq ($(uname_S), Linux)
+	OS = linux
+	OPA_SUFFIX = _static
+else ifeq ($(uname_S), Darwin)
+	OS = darwin
+else
+	OS = windows
+	ARCH = amd64
+endif
+
+ifeq ($(uname_M), x86_64)
+	ARCH = amd64
+else ifeq ($(uname_M), arm)
+	ARCH = arm64
+	OPA_SUFFIX = _static
+else ifeq ($(uname_M), arm64)
+	ARCH = arm64
+	OPA_SUFFIX = _static
+else ifeq ($(uname_M), aarch64)
+	ARCH = arm64
+	OPA_SUFFIX = _static
+endif
+
+OPA_VERSION=v0.49.2
+OPA_DOWNLOAD_URL=https://openpolicyagent.org/downloads/$(OPA_VERSION)/opa_$(OS)_$(ARCH)$(OPA_SUFFIX)
+
+.PHONY: download-opa
+download-opa:
+	if [ ! -r build/opa ]; then \
+		curl -sSL -o build/opa $(OPA_DOWNLOAD_URL); \
+		chmod 755 build/opa; \
+	fi
+
+build-opa: download-opa
+	build/opa build -t wasm -o policies/bundle.tar.gz -b policies -e "allow_transactions" -e "common_rules"
+
+.PHONY: opa-test
+opa-test: download-opa
+	build/opa test -b policies
+
+.PHONY: clean-opa
+clean-opa:
+	if [ -n "$(wildcard policies/*.tar.gz)" ]; then \
+		rm policies/*.tar.gz; \
+	else \
+		echo "No OPA policy archives to remove."; \
+	fi

--- a/policies/allow_transactions.rego
+++ b/policies/allow_transactions.rego
@@ -1,0 +1,17 @@
+package allow_transactions
+
+import data.common_rules
+import future.keywords.in
+import input
+
+default allowed_users = false
+allowed_users {
+  common_rules.allowed_users
+}
+
+default allow_defines = false
+allow_defines {
+  common_rules.allow_defines
+}
+
+default deny_all = false

--- a/policies/common_rules.rego
+++ b/policies/common_rules.rego
@@ -1,10 +1,15 @@
-package allow_defines
+package common_rules
 
 import future.keywords.in
+import input
 
-default allow = false
+allowed := {"chronicle", "anonymous"}
 
-allow {
+allowed_users {
+  input.type in allowed
+}
+
+allow_defines {
   data.context.operation in ["Mutation", "Submission"]
   startswith(data.context.state[0], "define")
 }


### PR DESCRIPTION
This PR makes it possible to use `chronicle-examples` with the most up-to-date Chronicle. 

OPA policies have moved to `/policies` from `/crates/common/policies` and are now built from source via a Makefile directive and distributed in the `unified-builder` to the `chronicle-builder` image.

Building required in order to compile the OPA policies.

See the toolchain and the reorganized policies themselves for the entrypoints being targeted in development.

OPA support and support for embedded policies in bootstrapping and testing has been reorganized around these changes.

Also, worth noting that RustEmbed requires building binaries in `--release` mode.

Signed-off-by: Joseph Livesey [joseph.livesey@btp.works](mailto:joseph.livesey@btp.works)

[CHRON-251](https://blockchaintp.atlassian.net/browse/CHRON-251)

[CHRON-251]: https://blockchaintp.atlassian.net/browse/CHRON-251?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ