### PR TITLE
API calls resulting in no data will not be dispatched

### DIFF
--- a/crates/api/src/chronicle_graphql/mutation.rs
+++ b/crates/api/src/chronicle_graphql/mutation.rs
@@ -22,10 +22,12 @@ async fn transaction_context<'a>(
     _ctx: &Context<'a>,
 ) -> async_graphql::Result<Submission> {
     match res {
-        ApiResponse::Submission { subject, tx_id, .. } => Ok(Submission {
-            context: subject.to_string(),
-            tx_id: tx_id.to_string(),
-        }),
+        ApiResponse::Submission { subject, tx_id, .. } => {
+            Ok(Submission::from_submission(&subject, &tx_id))
+        }
+        ApiResponse::AlreadyRecorded { subject, .. } => {
+            Ok(Submission::from_already_recorded(&subject))
+        }
         _ => unreachable!(),
     }
 }

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -278,7 +278,7 @@ where
         pool.get()?
             .build_transaction()
             .run(|connection| connection.run_pending_migrations(MIGRATIONS).map(|_| ()))
-            .map_err(|migration| StoreError::DbMigration { migration })?;
+            .map_err(|migration| StoreError::DbMigration(migration))?;
 
         for (ns, uuid) in namespace_bindings {
             store.namespace_binding(&ns, uuid)?

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -1035,11 +1035,11 @@ where
         tokio::task::spawn_blocking(move || {
             let mut connection = api.store.connection()?;
 
-            let (_id, _) = api
+            let (id, _) = api
                 .store
                 .namespace_by_external_id(&mut connection, &ExternalId::from(&query.namespace))?;
             Ok(ApiResponse::query_reply(
-                api.store.prov_model_for_namespace(&mut connection, query)?,
+                api.store.prov_model_for_namespace(&mut connection, &id)?,
             ))
         })
         .await?

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -1980,7 +1980,7 @@ mod test {
             )
             .await;
 
-        insta::assert_snapshot!(res.err().unwrap().to_string(), @r###"Ledger error: Contradiction: Contradiction { attribute value change: test Attribute { typ: "test", value: String("test2") } Attribute { typ: "test", value: String("test") } }"###);
+        insta::assert_snapshot!(res.err().unwrap().to_string(), @r###"Contradiction: Contradiction { attribute value change: test Attribute { typ: "test", value: String("test2") } Attribute { typ: "test", value: String("test") } }"###);
     }
 
     #[tokio::test]
@@ -2111,7 +2111,7 @@ mod test {
             )
             .await;
 
-        insta::assert_snapshot!(res.err().unwrap().to_string(), @"Ledger error: Contradiction: Contradiction { start date alteration: 2014-07-08 09:10:11 UTC 2018-07-08 09:10:11 UTC }");
+        insta::assert_snapshot!(res.err().unwrap().to_string(), @"Contradiction: Contradiction { start date alteration: 2014-07-08 09:10:11 UTC 2018-07-08 09:10:11 UTC }");
     }
 
     #[tokio::test]
@@ -2242,7 +2242,7 @@ mod test {
             )
             .await;
 
-        insta::assert_snapshot!(res.err().unwrap().to_string(), @"Ledger error: Contradiction: Contradiction { end date alteration: 2018-07-08 09:10:11 UTC 2022-07-08 09:10:11 UTC }");
+        insta::assert_snapshot!(res.err().unwrap().to_string(), @"Contradiction: Contradiction { end date alteration: 2018-07-08 09:10:11 UTC 2022-07-08 09:10:11 UTC }");
     }
 
     #[tokio::test]

--- a/crates/api/src/persistence/mod.rs
+++ b/crates/api/src/persistence/mod.rs
@@ -29,8 +29,6 @@ use thiserror::Error;
 use tracing::{debug, instrument, warn};
 use uuid::Uuid;
 
-use crate::QueryCommand;
-
 mod query;
 pub(crate) mod schema;
 pub const MIGRATIONS: EmbeddedMigrations = embed_migrations!();
@@ -1002,11 +1000,11 @@ impl Store {
     pub(crate) fn prov_model_for_namespace(
         &self,
         connection: &mut PgConnection,
-        query: QueryCommand,
+        namespace: &NamespaceId,
     ) -> Result<ProvModel, StoreError> {
         let mut model = ProvModel::default();
         let (namespaceid, nsid) =
-            self.namespace_by_external_id(connection, &ExternalId::from(&query.namespace))?;
+            self.namespace_by_external_id(connection, namespace.external_id_part())?;
 
         let agents = schema::agent::table
             .filter(schema::agent::namespace_id.eq(&nsid))

--- a/crates/chronicle-domain-test/src/test.rs
+++ b/crates/chronicle-domain-test/src/test.rs
@@ -486,6 +486,553 @@ mod test {
     }
 
     #[tokio::test]
+    async fn api_calls_resulting_in_no_data_changes_return_null() {
+        let schema = test_schema().await;
+
+        let from = DateTime::<Utc>::from_utc(
+            NaiveDate::from_ymd_opt(1968, 9, 1)
+                .unwrap()
+                .and_hms_opt(0, 0, 0)
+                .unwrap(),
+            Utc,
+        )
+        .checked_add_signed(chronicle::chrono::Duration::days(1))
+        .unwrap()
+        .to_rfc3339();
+
+        let id_one = chronicle::async_graphql::Name::new("1");
+        let id_two = chronicle::async_graphql::Name::new("2");
+
+        insta::assert_json_snapshot!(schema
+          .execute(Request::new(
+            &format!(
+            r#"
+          mutation {{
+            defineContractorAgent(
+              externalId: "{id_one}",
+              attributes: {{ locationAttribute: "location" }}
+            ) {{
+              context
+              txId
+            }}
+            defineNCBAgent(
+              externalId: "{id_two}",
+              attributes: {{ manifestAttribute: "manifest" }}
+            ) {{
+              context
+              txId
+            }}
+            actedOnBehalfOf(
+              delegate: {{ externalId: "{id_one}", }}
+              responsible: {{ externalId: "{id_two}" }}
+              role: UNSPECIFIED
+            ) {{
+              context
+              txId
+            }}
+            defineItemEntity(
+              externalId: "{id_one}",
+              attributes: {{ partIdAttribute: "part"}}
+            ) {{
+              context
+              txId
+            }}
+            defineCertificateEntity(
+              externalId: "{id_two}",
+              attributes: {{ certIdAttribute: "cert" }}
+            ) {{
+              context
+              txId
+            }}
+            defineItemCertifiedActivity(
+              externalId: "{id_one}"
+              attributes: {{ certIdAttribute: "cert" }}
+            ) {{
+              context
+              txId
+            }}
+            defineItemManufacturedActivity(
+              externalId: "{id_two}"
+              attributes: {{ batchIdAttribute: "batch" }}
+            ) {{
+              context
+              txId
+            }}
+            instantActivity(
+              id: {{ externalId: "{id_one}" }}
+              time: "{from}"
+            ) {{
+              context
+              txId
+            }}
+            startActivity(
+              id: {{ externalId: "{id_two}" }}
+              time: "{from}"
+            ) {{
+              context
+              txId
+            }}
+            endActivity(
+              id: {{ externalId: "{id_two}" }}
+              time: "{from}"
+            ) {{
+              context
+              txId
+            }}
+            wasAssociatedWith(
+              responsible: {{ externalId: "{id_one}" }}
+              activity: {{ externalId: "{id_one}" }}
+              role: UNSPECIFIED
+            ) {{
+              context
+              txId
+            }}
+            used(
+              activity: {{ externalId: "{id_one}" }}
+              id: {{ externalId: "{id_one}" }}
+            ) {{
+              context
+              txId
+            }}
+            wasInformedBy(
+              informingActivity: {{ externalId: "{id_one}" }}
+              activity: {{ externalId: "{id_two}" }}
+            ) {{
+              context
+              txId
+            }}
+            wasGeneratedBy(
+              id: {{ externalId: "{id_one}" }}
+              activity: {{ externalId: "{id_one}" }}
+            ) {{
+              context
+              txId
+            }}
+          }}
+            "#
+                ),
+              ))
+                .await, {
+                  ".**.txId" => insta::dynamic_redaction(|value, _path| {
+                      // assert that the value looks like a txId, i.e. not null
+                      assert_eq!(value
+                        .as_str()
+                        .unwrap()
+                        .chars()
+                        .count(),
+                        36
+                    );
+                      "[txId]"
+                  }),
+              }, @r###"
+        {
+          "data": {
+            "defineContractorAgent": {
+              "context": "chronicle:agent:1",
+              "txId": "[txId]"
+            },
+            "defineNCBAgent": {
+              "context": "chronicle:agent:2",
+              "txId": "[txId]"
+            },
+            "actedOnBehalfOf": {
+              "context": "chronicle:agent:2",
+              "txId": "[txId]"
+            },
+            "defineItemEntity": {
+              "context": "chronicle:entity:1",
+              "txId": "[txId]"
+            },
+            "defineCertificateEntity": {
+              "context": "chronicle:entity:2",
+              "txId": "[txId]"
+            },
+            "defineItemCertifiedActivity": {
+              "context": "chronicle:activity:1",
+              "txId": "[txId]"
+            },
+            "defineItemManufacturedActivity": {
+              "context": "chronicle:activity:2",
+              "txId": "[txId]"
+            },
+            "instantActivity": {
+              "context": "chronicle:activity:1",
+              "txId": "[txId]"
+            },
+            "startActivity": {
+              "context": "chronicle:activity:2",
+              "txId": "[txId]"
+            },
+            "endActivity": {
+              "context": "chronicle:activity:2",
+              "txId": "[txId]"
+            },
+            "wasAssociatedWith": {
+              "context": "chronicle:agent:1",
+              "txId": "[txId]"
+            },
+            "used": {
+              "context": "chronicle:entity:1",
+              "txId": "[txId]"
+            },
+            "wasInformedBy": {
+              "context": "chronicle:activity:2",
+              "txId": "[txId]"
+            },
+            "wasGeneratedBy": {
+              "context": "chronicle:entity:1",
+              "txId": "[txId]"
+            }
+          }
+        }
+        "###);
+
+        insta::assert_json_snapshot!(schema
+          .execute(Request::new(
+            &format!(
+              r#"
+            mutation {{
+              defineContractorAgent(
+                externalId: "{id_one}",
+                attributes: {{ locationAttribute: "location" }}
+              ) {{
+                context
+                txId
+              }}
+              defineNCBAgent(
+                externalId: "{id_two}",
+                attributes: {{ manifestAttribute: "manifest" }}
+              ) {{
+                context
+                txId
+              }}
+              actedOnBehalfOf(
+                delegate: {{ externalId: "{id_one}", }}
+                responsible: {{ externalId: "{id_two}" }}
+                role: UNSPECIFIED
+              ) {{
+                context
+                txId
+              }}
+              defineItemEntity(
+                externalId: "{id_one}",
+                attributes: {{ partIdAttribute: "part"}}
+              ) {{
+                context
+                txId
+              }}
+              defineCertificateEntity(
+                externalId: "{id_two}",
+                attributes: {{ certIdAttribute: "cert" }}
+              ) {{
+                context
+                txId
+              }}
+              defineItemCertifiedActivity(
+                externalId: "{id_one}"
+                attributes: {{ certIdAttribute: "cert" }}
+              ) {{
+                context
+                txId
+              }}
+              defineItemManufacturedActivity(
+                externalId: "{id_two}"
+                attributes: {{ batchIdAttribute: "batch" }}
+              ) {{
+                context
+                txId
+              }}
+              instantActivity(
+                id: {{ externalId: "{id_one}" }}
+                time: "{from}"
+              ) {{
+                context
+                txId
+              }}
+              startActivity(
+                id: {{ externalId: "{id_two}" }}
+                time: "{from}"
+              ) {{
+                context
+                txId
+              }}
+              endActivity(
+                id: {{ externalId: "{id_two}" }}
+                time: "{from}"
+              ) {{
+                context
+                txId
+              }}
+              wasAssociatedWith(
+                responsible: {{ externalId: "{id_one}" }}
+                activity: {{ externalId: "{id_one}" }}
+                role: UNSPECIFIED
+              ) {{
+                context
+                txId
+              }}
+              used(
+                activity: {{ externalId: "{id_one}" }}
+                id: {{ externalId: "{id_one}" }}
+              ) {{
+                context
+                txId
+              }}
+              wasInformedBy(
+                informingActivity: {{ externalId: "{id_one}" }}
+                activity: {{ externalId: "{id_two}" }}
+              ) {{
+                context
+                txId
+              }}
+              wasGeneratedBy(
+                id: {{ externalId: "{id_one}" }}
+                activity: {{ externalId: "{id_one}" }}
+              ) {{
+                context
+                txId
+              }}
+            }}
+              "#
+              )))
+                .await,
+              @r###"
+        {
+          "data": {
+            "defineContractorAgent": {
+              "context": "chronicle:agent:1",
+              "txId": null
+            },
+            "defineNCBAgent": {
+              "context": "chronicle:agent:2",
+              "txId": null
+            },
+            "actedOnBehalfOf": {
+              "context": "chronicle:agent:2",
+              "txId": null
+            },
+            "defineItemEntity": {
+              "context": "chronicle:entity:1",
+              "txId": null
+            },
+            "defineCertificateEntity": {
+              "context": "chronicle:entity:2",
+              "txId": null
+            },
+            "defineItemCertifiedActivity": {
+              "context": "chronicle:activity:1",
+              "txId": null
+            },
+            "defineItemManufacturedActivity": {
+              "context": "chronicle:activity:2",
+              "txId": null
+            },
+            "instantActivity": {
+              "context": "chronicle:activity:1",
+              "txId": null
+            },
+            "startActivity": {
+              "context": "chronicle:activity:2",
+              "txId": null
+            },
+            "endActivity": {
+              "context": "chronicle:activity:2",
+              "txId": null
+            },
+            "wasAssociatedWith": {
+              "context": "chronicle:agent:1",
+              "txId": null
+            },
+            "used": {
+              "context": "chronicle:entity:1",
+              "txId": null
+            },
+            "wasInformedBy": {
+              "context": "chronicle:activity:2",
+              "txId": null
+            },
+            "wasGeneratedBy": {
+              "context": "chronicle:entity:1",
+              "txId": null
+            }
+          }
+        }
+        "###);
+
+        insta::assert_json_snapshot!(schema
+          .execute(Request::new(
+            &format!(
+              r#"
+            mutation {{
+              defineContractorAgent(
+                externalId: "{id_one}",
+                attributes: {{ locationAttribute: "location" }}
+              ) {{
+                context
+                txId
+              }}
+              defineNCBAgent(
+                externalId: "{id_two}",
+                attributes: {{ manifestAttribute: "manifest" }}
+              ) {{
+                context
+                txId
+              }}
+              actedOnBehalfOf(
+                delegate: {{ externalId: "{id_one}", }}
+                responsible: {{ externalId: "{id_two}" }}
+                role: UNSPECIFIED
+              ) {{
+                context
+                txId
+              }}
+              defineItemEntity(
+                externalId: "{id_one}",
+                attributes: {{ partIdAttribute: "part"}}
+              ) {{
+                context
+                txId
+              }}
+              defineCertificateEntity(
+                externalId: "{id_two}",
+                attributes: {{ certIdAttribute: "cert" }}
+              ) {{
+                context
+                txId
+              }}
+              defineItemCertifiedActivity(
+                externalId: "{id_one}"
+                attributes: {{ certIdAttribute: "cert" }}
+              ) {{
+                context
+                txId
+              }}
+              defineItemManufacturedActivity(
+                externalId: "{id_two}"
+                attributes: {{ batchIdAttribute: "batch" }}
+              ) {{
+                context
+                txId
+              }}
+              instantActivity(
+                id: {{ externalId: "{id_one}" }}
+                time: "{from}"
+              ) {{
+                context
+                txId
+              }}
+              startActivity(
+                id: {{ externalId: "{id_two}" }}
+                time: "{from}"
+              ) {{
+                context
+                txId
+              }}
+              endActivity(
+                id: {{ externalId: "{id_two}" }}
+                time: "{from}"
+              ) {{
+                context
+                txId
+              }}
+              wasAssociatedWith(
+                responsible: {{ externalId: "{id_one}" }}
+                activity: {{ externalId: "{id_one}" }}
+                role: UNSPECIFIED
+              ) {{
+                context
+                txId
+              }}
+              used(
+                activity: {{ externalId: "{id_one}" }}
+                id: {{ externalId: "{id_one}" }}
+              ) {{
+                context
+                txId
+              }}
+              wasInformedBy(
+                informingActivity: {{ externalId: "{id_one}" }}
+                activity: {{ externalId: "{id_two}" }}
+              ) {{
+                context
+                txId
+              }}
+              wasGeneratedBy(
+                id: {{ externalId: "{id_one}" }}
+                activity: {{ externalId: "{id_one}" }}
+              ) {{
+                context
+                txId
+              }}
+            }}
+              "#
+              )))
+                .await,
+              @r###"
+        {
+          "data": {
+            "defineContractorAgent": {
+              "context": "chronicle:agent:1",
+              "txId": null
+            },
+            "defineNCBAgent": {
+              "context": "chronicle:agent:2",
+              "txId": null
+            },
+            "actedOnBehalfOf": {
+              "context": "chronicle:agent:2",
+              "txId": null
+            },
+            "defineItemEntity": {
+              "context": "chronicle:entity:1",
+              "txId": null
+            },
+            "defineCertificateEntity": {
+              "context": "chronicle:entity:2",
+              "txId": null
+            },
+            "defineItemCertifiedActivity": {
+              "context": "chronicle:activity:1",
+              "txId": null
+            },
+            "defineItemManufacturedActivity": {
+              "context": "chronicle:activity:2",
+              "txId": null
+            },
+            "instantActivity": {
+              "context": "chronicle:activity:1",
+              "txId": null
+            },
+            "startActivity": {
+              "context": "chronicle:activity:2",
+              "txId": null
+            },
+            "endActivity": {
+              "context": "chronicle:activity:2",
+              "txId": null
+            },
+            "wasAssociatedWith": {
+              "context": "chronicle:agent:1",
+              "txId": null
+            },
+            "used": {
+              "context": "chronicle:entity:1",
+              "txId": null
+            },
+            "wasInformedBy": {
+              "context": "chronicle:activity:2",
+              "txId": null
+            },
+            "wasGeneratedBy": {
+              "context": "chronicle:entity:1",
+              "txId": null
+            }
+          }
+        }
+        "###);
+    }
+
+    #[tokio::test]
     async fn one_of_id_or_external() {
         let schema = test_schema().await;
 

--- a/crates/chronicle/src/bootstrap/mod.rs
+++ b/crates/chronicle/src/bootstrap/mod.rs
@@ -436,6 +436,18 @@ where
             );
         }
         (ApiResponse::Unit, _api) => {}
+        (ApiResponse::AlreadyRecorded { subject, prov }, _api) => {
+            println!("Transaction will not result in any data changes: {subject}");
+            println!(
+                "{}",
+                prov.to_json()
+                    .compact()
+                    .await?
+                    .to_string()
+                    .to_colored_json_auto()
+                    .unwrap()
+            );
+        }
     };
     Ok(())
 }

--- a/crates/chronicle/src/bootstrap/mod.rs
+++ b/crates/chronicle/src/bootstrap/mod.rs
@@ -115,9 +115,7 @@ type ConnectionPool = Pool<ConnectionManager<PgConnection>>;
 async fn pool_embedded() -> Result<(ConnectionPool, Option<Database>), ApiError> {
     let (database, pool) = common::database::get_embedded_db_connection()
         .await
-        .map_err(|source| api::StoreError::EmbeddedDb {
-            message: source.to_string(),
-        })?;
+        .map_err(|source| api::StoreError::EmbeddedDb(source.to_string()))?;
     Ok((pool, Some(database)))
 }
 
@@ -139,9 +137,7 @@ impl DatabaseConnector<(), StoreError> for RemoteDatabaseConnector {
     fn should_retry(&self, error: &StoreError) -> bool {
         matches!(
             error,
-            StoreError::DbConnection {
-                source: diesel::ConnectionError::BadConnection(_),
-            }
+            StoreError::DbConnection(diesel::ConnectionError::BadConnection(_))
         )
     }
 }

--- a/crates/common/src/commands.rs
+++ b/crates/common/src/commands.rs
@@ -306,6 +306,11 @@ pub enum ApiCommand {
 pub enum ApiResponse {
     /// The api has successfully executed the operation, but has no useful output
     Unit,
+    /// The operation will not result in any data changes
+    AlreadyRecorded {
+        subject: ChronicleIri,
+        prov: Box<ProvModel>,
+    },
     /// The api has validated the command and submitted a transaction to a ledger
     Submission {
         subject: ChronicleIri,
@@ -335,6 +340,13 @@ impl ApiResponse {
 
     pub fn query_reply(prov: ProvModel) -> Self {
         ApiResponse::QueryReply {
+            prov: Box::new(prov),
+        }
+    }
+
+    pub fn already_recorded(subject: impl Into<ChronicleIri>, prov: ProvModel) -> Self {
+        ApiResponse::AlreadyRecorded {
+            subject: subject.into(),
             prov: Box::new(prov),
         }
     }


### PR DESCRIPTION
Adds API methods and responses checking whether Chronicle operations resulting from API calls will result in changes in state. If they don't, they won't be submitted to the Transaction Processor and return `Submission::AlreadyRecorded` along with GraphQL data containing `context` and a `null` `tx_id`.

---
[CHRON-146](https://blockchaintp.atlassian.net/browse/CHRON-146)

Signed-off-by: Joseph Livesey [joseph.livesey@btp.works](mailto:joseph.livesey@btp.works)

[CHRON-146]: https://blockchaintp.atlassian.net/browse/CHRON-146?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ