### PR TITLE
do not suggest support for wasAttributedTo

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ for testing purposes.
 ![PROV-O](https://www.w3.org/TR/prov-o/diagrams/starting-points.svg)
 
 Chronicle extends the core PROV-O vocabulary as described
-[here](docs/chronicle_vocabulary.md).
+[here](docs/chronicle_vocabulary.md), except for `wasAttributedTo`.
 
 ## Deployment
 


### PR DESCRIPTION
Both @ChrisH1066 and I came away from the starting points diagram and "Chronicle extends the core PROV-O vocabulary" assuming that `wasAttributedTo` is offered, we probably won't be the last. This addition succinctly forestalls that misapprehension, can be reverted once CHRON-124 is done.