### PR TITLE
retry PgEmbed startup on read file error

### DIFF
--- a/crates/common/src/database.rs
+++ b/crates/common/src/database.rs
@@ -98,6 +98,7 @@ impl DatabaseConnector<Database, PgEmbedError> for EmbeddedDatabaseConnector {
         vec![
             PgEmbedErrorType::PgCleanUpFailure,
             PgEmbedErrorType::PgStartFailure,
+            PgEmbedErrorType::ReadFileError,
             PgEmbedErrorType::UnpackFailure,
         ]
         .contains(&error.error_type)


### PR DESCRIPTION
Error seen by @duncanjw  in running `chronicle-manufacturing-inmem:local`, arising from an underlying `InvalidArchive`: "Could not find central directory end"