### PR TITLE
fix(chronicle_graphql): do not open browser when unlocking playground

### DIFF
--- a/crates/chronicle/src/bootstrap/cli.rs
+++ b/crates/chronicle/src/bootstrap/cli.rs
@@ -1004,13 +1004,6 @@ impl SubCommand for CliModel {
                             .default_value("127.0.0.1:9982")
                             .help("The graphql server address (default 127.0.0.1:9982)"),
                     ).arg(
-                        Arg::new("unlock-cors")
-                            .long("unlock-cors")
-                            .alias("open")
-                            .required(false)
-                            .takes_value(false)
-                            .help("unlock CORS"),
-                    ).arg(
                         Arg::new("require-auth")
                             .long("require-auth")
                             .requires("jwks-address")

--- a/crates/chronicle/src/bootstrap/mod.rs
+++ b/crates/chronicle/src/bootstrap/mod.rs
@@ -340,8 +340,6 @@ where
             ("allow_transactions", "allow_transactions.allowed_users");
         let opa = opa_executor_from_embedded_policy(default_policy_name, entrypoint).await?;
 
-        let open_cors = matches.is_present("unlock-cors");
-
         graphql_server(
             &api,
             &pool,
@@ -354,7 +352,6 @@ where
                 jwt_must_claim,
                 allow_anonymous,
                 opa,
-                open_cors,
             ),
         )
         .await?;


### PR DESCRIPTION
Remove arbitrary wait and opening the browser with `--unlock-cors`/`--open` option.
Change existing CLI flag to be less confusing, changing it from `--unlock-cors` to `--playground`

This was sometimes failing with `chronicle-examples` and therefore is something we want to do before next release.

---
Signed-off-by: Joseph Livesey [joseph.livesey@btp.works](mailto:joseph.livesey@btp.works)