### PR TITLE
make graphql playground access part of no auth endpoint

### DIFF
--- a/crates/chronicle/src/bootstrap/cli.rs
+++ b/crates/chronicle/src/bootstrap/cli.rs
@@ -1004,13 +1004,6 @@ impl SubCommand for CliModel {
                             .default_value("127.0.0.1:9982")
                             .help("The graphql server address (default 127.0.0.1:9982)"),
                     ).arg(
-                        Arg::new("unlock-cors")
-                            .long("unlock-cors")
-                            .alias("open")
-                            .required(false)
-                            .takes_value(false)
-                            .help("unlock CORS"),
-                    ).arg(
                         Arg::new("require-auth")
                             .long("require-auth")
                             .requires("jwks-address")

--- a/crates/chronicle/src/bootstrap/cli.rs
+++ b/crates/chronicle/src/bootstrap/cli.rs
@@ -1004,6 +1004,13 @@ impl SubCommand for CliModel {
                             .default_value("127.0.0.1:9982")
                             .help("The graphql server address (default 127.0.0.1:9982)"),
                     ).arg(
+                        Arg::new("playground")
+                            .long("playground")
+                            .alias("open")
+                            .required(false)
+                            .takes_value(false)
+                            .help("Deprecated option (after v0.6.0) to make available the GraphQL Playground"),
+                    ).arg(
                         Arg::new("require-auth")
                             .long("require-auth")
                             .requires("jwks-address")

--- a/crates/chronicle/src/bootstrap/mod.rs
+++ b/crates/chronicle/src/bootstrap/mod.rs
@@ -340,8 +340,6 @@ where
             ("allow_transactions", "allow_transactions.allowed_users");
         let opa = opa_executor_from_embedded_policy(default_policy_name, entrypoint).await?;
 
-        let open_cors = matches.is_present("unlock-cors");
-
         graphql_server(
             &api,
             &pool,
@@ -354,7 +352,6 @@ where
                 jwt_must_claim,
                 allow_anonymous,
                 opa,
-                open_cors,
             ),
         )
         .await?;


### PR DESCRIPTION
- Make setting up access to GraphQL Playground part of no-auth API endpoint path
- Rename `--unlock-cors` to `--playground` while keeping `--open` as a working alias and signal that this flag is now deprecated -- keeping it place for now to ease upgrading `chronicle-examples` for use with latest Chronicle come next release 

[CHRON-270](https://blockchaintp.atlassian.net/browse/CHRON-270)

Signed-off-by: Joseph Livesey [joseph.livesey@btp.works](mailto:joseph.livesey@btp.works)

[CHRON-270]: https://blockchaintp.atlassian.net/browse/CHRON-270?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ