### PR TITLE
support prov:wasAttributedTo

### DIFF
--- a/crates/api/migrations/2022-01-18-144301_ledger_sync/down.sql
+++ b/crates/api/migrations/2022-01-18-144301_ledger_sync/down.sql
@@ -7,6 +7,7 @@ drop table hadidentity;
 drop table wasinformedby;
 drop table usage;
 drop table association;
+drop table attribution;
 drop table generation;
 drop table derivation;
 drop table delegation;

--- a/crates/api/migrations/2022-01-18-144301_ledger_sync/up.sql
+++ b/crates/api/migrations/2022-01-18-144301_ledger_sync/up.sql
@@ -129,6 +129,15 @@ create table wasinformedby (
     primary key(activity_id,informing_activity_id)
 );
 
+create table attribution (
+    agent_id integer not null,
+    entity_id integer not null,
+    role text not null default '',
+    foreign key(agent_id) references agent(id),
+    foreign key(entity_id) references entity(id),
+    primary key(agent_id, entity_id, role)
+);
+
 create table hadidentity (
     agent_id integer not null,
     identity_id integer not null,

--- a/crates/api/src/chronicle_graphql/mutation.rs
+++ b/crates/api/src/chronicle_graphql/mutation.rs
@@ -361,6 +361,34 @@ pub async fn was_associated_with<'a>(
     transaction_context(res, ctx).await
 }
 
+pub async fn was_attributed_to<'a>(
+    ctx: &Context<'a>,
+    namespace: Option<String>,
+    responsible: AgentId,
+    id: EntityId,
+    role: Option<Role>,
+) -> async_graphql::Result<Submission> {
+    let api = ctx.data_unchecked::<ApiDispatch>();
+
+    let identity = ctx.data_unchecked::<AuthId>().to_owned();
+
+    let namespace = namespace.unwrap_or_else(|| "default".to_owned()).into();
+
+    let res = api
+        .dispatch(
+            ApiCommand::Entity(EntityCommand::Attribute {
+                id,
+                namespace,
+                responsible,
+                role,
+            }),
+            identity,
+        )
+        .await?;
+
+    transaction_context(res, ctx).await
+}
+
 pub async fn used<'a>(
     ctx: &Context<'a>,
     activity: ActivityId,

--- a/crates/api/src/persistence/schema.rs
+++ b/crates/api/src/persistence/schema.rs
@@ -58,6 +58,14 @@ diesel::table! {
 }
 
 diesel::table! {
+    attribution (agent_id, entity_id, role) {
+        agent_id -> Int4,
+        entity_id -> Int4,
+        role -> Text,
+    }
+}
+
+diesel::table! {
     delegation (responsible_id, delegate_id, activity_id, role) {
         delegate_id -> Int4,
         responsible_id -> Int4,
@@ -162,6 +170,8 @@ diesel::joinable!(association -> activity (activity_id));
 diesel::joinable!(association -> agent (agent_id));
 diesel::joinable!(attachment -> identity (signer_id));
 diesel::joinable!(attachment -> namespace (namespace_id));
+diesel::joinable!(attribution -> agent (agent_id));
+diesel::joinable!(attribution -> entity (entity_id));
 diesel::joinable!(delegation -> activity (activity_id));
 diesel::joinable!(derivation -> activity (activity_id));
 diesel::joinable!(entity -> attachment (attachment_id));
@@ -184,6 +194,7 @@ diesel::allow_tables_to_appear_in_same_query!(
     agent_attribute,
     association,
     attachment,
+    attribution,
     delegation,
     derivation,
     entity,

--- a/crates/chronicle/src/bootstrap/mod.rs
+++ b/crates/chronicle/src/bootstrap/mod.rs
@@ -817,6 +817,7 @@ pub mod test {
         usage: {}
         was_informed_by: {}
         generated: {}
+        attribution: {}
         "###);
     }
 

--- a/crates/common/src/commands.rs
+++ b/crates/common/src/commands.rs
@@ -244,6 +244,12 @@ pub enum EntityCommand {
         locator: Option<String>,
         agent: Option<AgentId>,
     },
+    Attribute {
+        id: EntityId,
+        namespace: ExternalId,
+        responsible: AgentId,
+        role: Option<Role>,
+    },
     Derive {
         id: EntityId,
         namespace: ExternalId,

--- a/crates/common/src/context.rs
+++ b/crates/common/src/context.rs
@@ -78,6 +78,12 @@ lazy_static! {
             "@container": "@set"
         },
 
+        "wasAttributedTo": {
+            "@id": "prov:wasAttributedTo",
+            "@type" : "@id",
+            "@container": "@set"
+        },
+
         "wasDerivedFrom": {
             "@id": "prov:wasDerivedFrom",
             "@type" : "@id",

--- a/crates/common/src/ledger.rs
+++ b/crates/common/src/ledger.rs
@@ -9,7 +9,8 @@ use crate::prov::{
     operations::{
         ActivityExists, ActivityUses, ActsOnBehalfOf, AgentExists, ChronicleOperation,
         CreateNamespace, EndActivity, EntityDerive, EntityExists, EntityHasEvidence, RegisterKey,
-        SetAttributes, StartActivity, WasAssociatedWith, WasGeneratedBy, WasInformedBy,
+        SetAttributes, StartActivity, WasAssociatedWith, WasAttributedTo, WasGeneratedBy,
+        WasInformedBy,
     },
     to_json_ld::ToJson,
     ActivityId, AgentId, ChronicleIri, ChronicleTransaction, ChronicleTransactionId, Contradiction,
@@ -669,6 +670,18 @@ impl ChronicleOperation {
                 LedgerAddress::namespace(namespace),
                 LedgerAddress::in_namespace(namespace, id.clone()),
                 LedgerAddress::in_namespace(namespace, activity_id.clone()),
+                LedgerAddress::in_namespace(namespace, agent_id.clone()),
+            ],
+            ChronicleOperation::WasAttributedTo(WasAttributedTo {
+                id,
+                namespace,
+                entity_id,
+                agent_id,
+                ..
+            }) => vec![
+                LedgerAddress::namespace(namespace),
+                LedgerAddress::in_namespace(namespace, id.clone()),
+                LedgerAddress::in_namespace(namespace, entity_id.clone()),
                 LedgerAddress::in_namespace(namespace, agent_id.clone()),
             ],
             ChronicleOperation::EndActivity(EndActivity { namespace, id, .. }) => {

--- a/crates/common/src/prov/model/proptest.rs
+++ b/crates/common/src/prov/model/proptest.rs
@@ -7,8 +7,9 @@ use crate::{
     attributes::{Attribute, Attributes},
     prov::{
         operations::*, to_json_ld::ToJson, ActivityId, AgentId, Association, AssociationId,
-        Contradiction, Delegation, DelegationId, Derivation, DomaintypeId, EntityId, ExternalId,
-        ExternalIdPart, Generation, IdentityId, NamespaceId, ProvModel, Role, Usage, UuidPart,
+        Attribution, Contradiction, Delegation, DelegationId, Derivation, DomaintypeId, EntityId,
+        ExternalId, ExternalIdPart, Generation, IdentityId, NamespaceId, ProvModel, Role, Usage,
+        UuidPart,
     },
 };
 
@@ -524,6 +525,18 @@ proptest! {
                         );
 
                     prop_assert!(has_asoc);
+                }
+                ChronicleOperation::WasAttributedTo(WasAttributedTo { id : _, role, namespace, entity_id, agent_id }) => {
+                    let has_attribution = prov.attribution.get(&(namespace.to_owned(), entity_id.to_owned()))
+                        .unwrap()
+                        .contains(&Attribution::new(
+                            namespace,
+                            agent_id,
+                            entity_id,
+                            role.clone())
+                        );
+
+                    prop_assert!(has_attribution);
                 }
                 ChronicleOperation::ActivityUses(
                     ActivityUses { namespace, id, activity }) => {

--- a/crates/common/src/prov/operations.rs
+++ b/crates/common/src/prov/operations.rs
@@ -12,8 +12,8 @@ use uuid::Uuid;
 use crate::attributes::Attributes;
 
 use super::{
-    ActivityId, AgentId, AssociationId, DelegationId, EntityId, ExternalId, IdentityId,
-    NamespaceId, Role,
+    ActivityId, AgentId, AssociationId, AttributionId, DelegationId, EntityId, ExternalId,
+    IdentityId, NamespaceId, Role,
 };
 
 #[derive(
@@ -221,6 +221,32 @@ impl WasAssociatedWith {
     }
 }
 
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
+pub struct WasAttributedTo {
+    pub id: AttributionId,
+    pub role: Option<Role>,
+    pub namespace: NamespaceId,
+    pub entity_id: EntityId,
+    pub agent_id: AgentId,
+}
+
+impl WasAttributedTo {
+    pub fn new(
+        namespace: &NamespaceId,
+        entity_id: &EntityId,
+        agent_id: &AgentId,
+        role: Option<Role>,
+    ) -> Self {
+        Self {
+            id: AttributionId::from_component_ids(agent_id, entity_id, role.as_ref()),
+            role,
+            namespace: namespace.clone(),
+            entity_id: entity_id.clone(),
+            agent_id: agent_id.clone(),
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub struct EntityHasEvidence {
     pub namespace: NamespaceId,
@@ -288,6 +314,7 @@ pub enum ChronicleOperation {
     EntityHasEvidence(EntityHasEvidence),
     SetAttributes(SetAttributes),
     WasAssociatedWith(WasAssociatedWith),
+    WasAttributedTo(WasAttributedTo),
     WasInformedBy(WasInformedBy),
 }
 

--- a/crates/common/src/prov/vocab.rs
+++ b/crates/common/src/prov/vocab.rs
@@ -2,7 +2,7 @@ use iref::IriBuf;
 use percent_encoding::{percent_encode, NON_ALPHANUMERIC};
 use uuid::Uuid;
 
-use super::{ActivityId, AgentId, ExternalId, ExternalIdPart, Role};
+use super::{ActivityId, AgentId, EntityId, ExternalId, ExternalIdPart, Role};
 
 #[derive(IriEnum, Clone, Copy, PartialEq, Eq, Hash)]
 #[iri_prefix("chronicleop" = "http://btp.works/chronicleoperations/ns#")]
@@ -43,6 +43,8 @@ pub enum ChronicleOperations {
     EndActivityTime,
     #[iri("chronicleop:WasAssociatedWith")]
     WasAssociatedWith,
+    #[iri("chronicleop:WasAttributedTo")]
+    WasAttributedTo,
     #[iri("chronicleop:ActivityUses")]
     ActivityUses,
     #[iri("chronicleop:entityName")]
@@ -98,8 +100,12 @@ pub enum Prov {
     WasAssociatedWith,
     #[iri("prov:qualifiedAssociation")]
     QualifiedAssociation,
+    #[iri("prov:qualifiedAttribution")]
+    QualifiedAttribution,
     #[iri("prov:Association")]
     Association,
+    #[iri("prov:Attribution")]
+    Attribution,
     #[iri("prov:wasGeneratedBy")]
     WasGeneratedBy,
     #[iri("prov:used")]
@@ -130,6 +136,8 @@ pub enum Prov {
     HadRole,
     #[iri("prov:hadActivity")]
     HadActivity,
+    #[iri("prov:hadEntity")]
+    HadEntity,
     #[iri("prov:wasInformedBy")]
     WasInformedBy,
     #[iri("prov:generated")]
@@ -283,6 +291,22 @@ impl Chronicle {
                     .as_ref()
                     .map(|x| x.external_id_part().as_str())
                     .unwrap_or("")
+            ),
+        ))
+        .unwrap()
+    }
+
+    pub fn attribution(agent: &AgentId, entity: &EntityId, role: &Option<Role>) -> IriBuf {
+        IriBuf::new(&format!(
+            "{}attribution:{}:{}:role={}",
+            Self::PREFIX,
+            Self::encode(agent.external_id_part().as_str()),
+            Self::encode(entity.external_id_part().as_ref()),
+            Self::encode(
+                &role
+                    .as_ref()
+                    .map(|x| x.to_string())
+                    .unwrap_or_else(|| "".to_owned())
             ),
         ))
         .unwrap()

--- a/domain_docs/attribution.md
+++ b/domain_docs/attribution.md
@@ -1,0 +1,7 @@
+# `prov:Attribution`
+
+> Attribution is the ascribing of an entity to an agent.
+
+The Chronicle `Attribution` type refers to the quality of an agent having
+entities attributed to it, while the `Attributed` type refers to the quality
+of an entity being attributed to an agent.

--- a/domain_docs/entity_ref.md
+++ b/domain_docs/entity_ref.md
@@ -1,0 +1,5 @@
+# `chronicle:EntityRef`
+
+Query type returning `Entity` and `Role` data relating to `Attribution`.
+The `Role` refers to the role of the `Agent` in question, to which the
+`Entity` was attributed.

--- a/domain_docs/was_attributed_to.md
+++ b/domain_docs/was_attributed_to.md
@@ -1,0 +1,3 @@
+# `prov:wasAttributedTo`
+
+> Attribution is the ascribing of an entity to an agent.


### PR DESCRIPTION
Add support in Chronicle for [`prov:wasAttributedTo`](https://www.w3.org/TR/prov-o/#wasAttributedTo).

---
Signed-off-by: Joseph Livesey joseph.livesey@btp.works

[CHRON-124](https://blockchaintp.atlassian.net/browse/CHRON-124)

[CHRON-124]: https://blockchaintp.atlassian.net/browse/CHRON-124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ