### PR TITLE
Add dependencies using workspace dependencies table

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,7 +118,6 @@ dependencies = [
  "json-ld",
  "jwtk",
  "opa",
- "open",
  "opentelemetry",
  "parking_lot 0.12.1",
  "poem",
@@ -136,7 +135,7 @@ dependencies = [
  "tracing",
  "url",
  "user-error",
- "uuid 0.8.2",
+ "uuid 1.3.0",
 ]
 
 [[package]]
@@ -624,7 +623,6 @@ dependencies = [
  "iref",
  "jsonschema",
  "opa",
- "open",
  "opentelemetry",
  "opentelemetry-jaeger",
  "percent-encoding",
@@ -641,12 +639,12 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
- "toml 0.5.11",
+ "toml 0.7.3",
  "tracing",
  "tracing-log",
  "url",
  "user-error",
- "uuid 0.8.2",
+ "uuid 1.3.0",
  "valico",
 ]
 
@@ -914,7 +912,7 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
- "uuid 0.8.2",
+ "uuid 1.3.0",
  "zmq",
 ]
 
@@ -1579,9 +1577,9 @@ checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "fancy-regex"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0678ab2d46fa5195aaf59ad034c083d351377d4af57f3e073c074d0da3e3c766"
+checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
 dependencies = [
  "bit-set",
  "regex",
@@ -1675,9 +1673,9 @@ dependencies = [
 
 [[package]]
 name = "fraction"
-version = "0.12.2"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aa5de57a62c2440ece64342ea59efb7171aa7d016faf8dfcb8795066a17146b"
+checksum = "3027ae1df8d41b4bed2241c8fdad4acc1e7af60c8e17743534b545e77182d678"
 dependencies = [
  "lazy_static",
  "num",
@@ -1857,8 +1855,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2276,9 +2276,9 @@ dependencies = [
 
 [[package]]
 name = "iso8601"
-version = "0.5.1"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "296af15e112ec6dc38c9fd3ae027b5337a75466e8eed757bd7d5cf742ea85eb6"
+checksum = "924e5d73ea28f59011fec52a0d12185d496a9b075d360657aed2a5707f701153"
 dependencies = [
  "nom",
 ]
@@ -2478,22 +2478,23 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ca9e2b45609132ae2214d50482c03aeee78826cd6fd53a8940915b81acedf16"
+checksum = "e48354c4c4f088714424ddf090de1ff84acc82b2f08c192d46d226ae2529a465"
 dependencies = [
  "ahash 0.8.3",
  "anyhow",
- "base64 0.13.1",
+ "base64 0.21.0",
  "bytecount",
  "clap 4.1.6",
  "fancy-regex",
  "fraction",
+ "getrandom 0.2.8",
  "iso8601",
  "itoa",
- "lazy_static",
  "memchr",
  "num-cmp",
+ "once_cell",
  "parking_lot 0.12.1",
  "percent-encoding",
  "regex",
@@ -3161,16 +3162,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "open"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2078c0039e6a54a0c42c28faa984e115fb4c2d5bf2208f77d1961002df8576f8"
-dependencies = [
- "pathdiff",
- "windows-sys 0.42.0",
-]
-
-[[package]]
 name = "openssl"
 version = "0.10.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3396,12 +3387,6 @@ name = "paste"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d01a5bd0424d00070b0098dd17ebca6f961a959dead1dbcbbbc1d1cd8d3deeba"
-
-[[package]]
-name = "pathdiff"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "pct-str"
@@ -3735,7 +3720,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66618389e4ec1c7afe67d51a9bf34ff9236480f8d51e7489b7d5ab0303c13f34"
 dependencies = [
  "once_cell",
- "toml_edit",
+ "toml_edit 0.18.1",
 ]
 
 [[package]]
@@ -3897,7 +3882,7 @@ dependencies = [
  "openssl",
  "prost 0.10.4",
  "prost-build",
- "prost-types 0.10.1",
+ "prost-types 0.11.6",
  "protobuf",
  "rand 0.8.5",
  "rand_core 0.6.4",
@@ -3909,7 +3894,7 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
- "uuid 0.8.2",
+ "uuid 1.3.0",
  "zmq",
 ]
 
@@ -4460,7 +4445,7 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
- "uuid 0.8.2",
+ "uuid 1.3.0",
  "zmq",
 ]
 
@@ -4598,6 +4583,15 @@ checksum = "cad406b69c91885b5107daf2c29572f6c8cdb3c66826821e286c533490c0bc76"
 dependencies = [
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0efd8caf556a6cebd3b285caf480045fcc1ac04f6bd786b09a6f11af30c4fcf4"
+dependencies = [
  "serde",
 ]
 
@@ -5218,10 +5212,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b403acf6f2bb0859c93c7f0d967cb4a75a7ac552100f9322faf64dc047669b21"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime 0.6.1",
+ "toml_edit 0.19.8",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4553f467ac8e3d374bc9a177a26801e5d0f9b211aa1673fb137a403afd1c9cf5"
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "toml_edit"
@@ -5231,7 +5246,20 @@ checksum = "56c59d8dd7d0dcbc6428bf7aa2f0e823e26e43b3c9aca15bbc9475d23e5fa12b"
 dependencies = [
  "indexmap",
  "nom8",
- "toml_datetime",
+ "toml_datetime 0.5.1",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.19.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "239410c8609e8125456927e6707163a3b1fdb40561e4b803bc041f466ccfdc13"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime 0.6.1",
+ "winnow",
 ]
 
 [[package]]
@@ -5497,7 +5525,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
  "getrandom 0.2.8",
- "serde",
 ]
 
 [[package]]
@@ -6044,6 +6071,15 @@ name = "windows_x86_64_msvc"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
+
+[[package]]
+name = "winnow"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "deac0939bd6e4f24ab5919fbf751c97a8cfc8543bb083a305ed5c0c10bb241d1"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winreg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,117 @@
 [workspace]
 
 members = ["crates/*"]
+
+[workspace.dependencies]
+
+Inflector             = "0.11.4"
+anyhow                = "1.0.68"
+assert_fs             = "1.0"
+async-graphql         = "4.0.9"
+async-graphql-poem    = "4.0.9"
+async-stream          = "0.3.3"
+async-trait           = "0.1.61"
+backoff               = { version = "0.4.0", features = ["futures", "tokio"] }
+base64                = "0.21"
+bytes                 = "1.3.0"
+cached                = "0.42"
+chrono                = "0.4.19"
+clap                  = "3.2.1"  # opactl: version = "4.1.1"
+clap_complete         = "3.1.1"
+clap_generate         = "3.0.3"
+colored_json          = "3.0.1"
+criterion             = { version = "0.4.0", features = ["async_futures", "async_tokio"] }
+crossbeam             = "0.8.1"
+custom_error          = "1.9.2"
+derivative            = "2.2.0"
+diesel                = { version = "2.0.0-rc.0", features = [
+  "postgres",
+  "uuid",
+  "chrono",
+  "r2d2",
+] }
+diesel_migrations     = { version = "2.0.0-rc.0", features = ["postgres"] }
+dotenvy               = "0.15"
+futures               = "0.3.21"
+genco                 = "0.16.1"
+glob                  = "0.3.0"
+hashbrown             = "0.13"
+hex                   = "0.4.3"
+insta                 = { version = "1.26.0", features = ["redactions", "toml"] }
+iref                  = "2.1.2"
+iref-enum             = "2.0.0"
+json-ld               = "0.14"
+jsonschema            = "0.17.0"
+jwtk                  = { version = "0.2.4", features = ["remote-jwks"] }
+k256                  = { version = "0.11.3", features = [
+  "default",
+  "arithmetic",
+  "ecdsa",
+  "pkcs8",
+  "sha256",
+  "std",
+  "pem",
+] }
+lazy_static           = "1.4.0"
+locspan               = "0.7"
+mime                  = "0.3"
+opa                   = "0.9.0"
+openssl               = "0.10.38"
+opentelemetry         = { version = "0.18.0", features = ["rt-tokio"] }
+opentelemetry-jaeger  = { version = "0.17.0", features = [
+  "rt-tokio",
+  "reqwest_collector_client",
+  "collector_client",
+] }
+parking_lot           = "0.12.0"
+percent-encoding      = "2.1.0"
+pg-embed              = "0.7.1"
+pin-project           = "1.0.12"
+pkcs8                 = { version = "*", features = ["std", "alloc"] }
+poem                  = { version = "1.3.30", features = ["opentelemetry", "websocket"] }
+portpicker            = "0.1.1"
+proptest              = "1.0.0"
+prost                 = "0.11.3"  # common, sawtooth-protocol, sawtooth-tp: version = "0.10.0"
+prost-build           = "0.10.0"
+prost-types           = "0.11.2"
+protobuf              = "2.27.1"
+question              = "0.2.2"
+rand                  = { version = "0.8.5", features = ["getrandom"] }
+rand_core             = "0.6.3"
+rdf-types             = "0.14"
+reqwest               = "0.11.14"
+rust-embed            = { version = "6.6.0", features = ["debug-embed", "include-exclude"] }
+r2d2                  = "0.8.9"
+sawtooth-sdk          = "0.5.2"
+serde                 = "1.0.152"
+serde_cbor            = "0.11.2"
+serde_derive          = "1.0.152"
+serde_json            = "1.0.93"
+serde_yaml            = "0.9.14"
+shellexpand           = "3.0.0"
+static-iref           = "2.0.0"
+temp-dir              = "0.1.11"
+tempfile              = "3.4.0"
+thiserror             = "1.0.38"
+tokio                 = { version = "1.20.3", features = [
+  "time",
+  "macros",
+  "rt-multi-thread",
+] }
+tokio-stream          = "0.1.11"
+toml                  = "0.7.3"
+tracing               = "0.1.37"
+tracing-elastic-apm   = "3.2.3"
+tracing-log           = "0.1.3"
+tracing-opentelemetry = "0.18.0"
+tracing-subscriber    = { version = "0.3.15", features = [
+  "default",
+  "registry",
+  "env-filter",
+  "json",
+] }
+url                   = "2.3.1"
+user-error            = "1.2.8"
+uuid                  = "1.2.2"
+valico                = "3.6.0"
+zmq                   = "0.9.2"

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -6,70 +6,59 @@ version = "0.6.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-graphql = { features = [
+async-graphql                = { workspace = true, features = [
   "opentelemetry",
   "chrono",
   "unblock",
   "default",
   "uuid",
-], version = "4.0.9" }
-async-graphql-poem = "4.0.9"
-async-stream = "0.3.3"
-async-trait = "0.1.53"
-base64 = "0.21"
-cached = "0.42"
-chronicle-telemetry = { path = "../chronicle-telemetry" }
-chrono = "0.4.19"
-common = { path = "../common" }
-custom_error = "1.9.2"
-derivative = "2.2.0"
-diesel = { version = "2.0.0-rc.0", features = [
-  "postgres",
-  "uuid",
-  "chrono",
-  "r2d2",
 ] }
-diesel_migrations = { version = "2.0.0-rc.0", features = ["postgres"] }
-futures = "0.3.21"
-glob = "0.3.0"
-hex = "0.4.3"
-iref = "2.1.2"
-iref-enum = "2.0.0"
-json-ld = "0.14"
-jwtk = { version = "0.2.4", features = ["remote-jwks"] }
-opa = "0.9.0"
-open = "3.2.0"
-opentelemetry = { version = "0.18.0", features = ["rt-tokio"] }
-parking_lot = "0.12.0"
-poem = { version = "1.3.30", features = ["opentelemetry", "websocket"] }
-r2d2 = "0.8.9"
-rand = { version = "0.8.5", features = ["getrandom"] }
-rand_core = "0.6.3"
-reqwest = "0.11.14"
-serde = "1.0.136"
-serde_derive = "1.0.136"
-serde_json = "1.0.81"
-static-iref = "2.0.0"
-thiserror = "1.0.36"
-tokio = { version = "1.20.3", features = ["time", "macros", "rt-multi-thread"] }
-tracing = "0.1.32"
-url = "2.2.2"
-user-error = "1.2.8"
-uuid = { version = "0.8.2", features = ["v4"] }
+async-graphql-poem.workspace = true
+async-stream.workspace       = true
+async-trait.workspace        = true
+base64.workspace             = true
+cached.workspace             = true
+chronicle-telemetry          = { path = "../chronicle-telemetry" }
+chrono.workspace             = true
+common                       = { path = "../common" }
+custom_error.workspace       = true
+derivative.workspace         = true
+diesel.workspace             = true
+diesel_migrations.workspace  = true
+futures.workspace            = true
+glob.workspace               = true
+hex.workspace                = true
+iref.workspace               = true
+iref-enum.workspace          = true
+json-ld.workspace            = true
+jwtk.workspace               = true
+opa.workspace                = true
+opentelemetry.workspace      = true
+parking_lot.workspace        = true
+poem.workspace               = true
+r2d2.workspace               = true
+rand.workspace               = true
+rand_core.workspace          = true
+reqwest.workspace            = true
+serde.workspace              = true
+serde_derive.workspace       = true
+serde_json.workspace         = true
+static-iref.workspace        = true
+thiserror.workspace          = true
+tokio.workspace              = true
+tracing.workspace            = true
+url.workspace                = true
+user-error.workspace         = true
+uuid.workspace               = true
 
 [dev-dependencies]
-insta = { version = "1.14.0", features = [
-  "json",
-  "redactions",
-  "toml",
-  "yaml",
-] }
-tempfile = "3.4.0"
+insta              = { workspace = true, features = ["json", "yaml"] }
+tempfile.workspace = true
 
 [build-dependencies]
 
 [features]
 devmode = ["inmem"]
 # Use an in-memory stub ledger
-inmem  = []
-strict = []
+inmem   = []
+strict  = []

--- a/crates/async-sawtooth-sdk/Cargo.toml
+++ b/crates/async-sawtooth-sdk/Cargo.toml
@@ -10,38 +10,30 @@ path = "src/lib.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.68"
-async-trait = "0.1.61"
-chrono = { version = "0.4.19", features = ["serde"] }
-derivative = "2.2.0"
-futures = "0.3.21"
-hex = "0.4.3"
-k256 = { version = "0.11.3", features = [
-  "default",
-  "arithmetic",
-  "ecdsa",
-  "pkcs8",
-  "sha256",
-  "std",
-  "pem",
-] }
-lazy_static = "1.4.0"
-openssl = "0.10.38"
-prost = "0.11.3"
-prost-types = "0.11.2"
-protobuf = "2.27.1"
-rand = { version = "0.8.5", features = ["getrandom"] }
-rand_core = "0.6.3"
-sawtooth-sdk = "0.5.2"
-serde = { version = "1.0.150", features = ["derive"] }
-serde_json = "1.0.89"
-thiserror = "1.0.38"
-tokio = { version = "1.20.3", features = ["time", "macros", "rt-multi-thread"] }
-tracing = "0.1.37"
-url = "2.3.1"
-uuid = { version = "1.2.2", features = ["v4", "serde", "std"] }
-zmq = "0.9.2"
+anyhow.workspace       = true
+async-trait.workspace  = true
+chrono                 = { workspace = true, features = ["serde"] }
+derivative.workspace   = true
+futures.workspace      = true
+hex.workspace          = true
+k256.workspace         = true
+lazy_static.workspace  = true
+openssl.workspace      = true
+prost.workspace        = true
+prost-types.workspace  = true
+protobuf.workspace     = true
+rand.workspace         = true
+rand_core.workspace    = true
+sawtooth-sdk.workspace = true
+serde                  = { workspace = true, features = ["derive"] }
+serde_json.workspace   = true
+thiserror.workspace    = true
+tokio.workspace        = true
+tracing.workspace      = true
+url.workspace          = true
+uuid.workspace         = true
+zmq.workspace          = true
 
 [build-dependencies]
-glob        = "0.3.0"
-prost-build = "0.10.0"
+glob.workspace        = true
+prost-build.workspace = true

--- a/crates/chronicle-domain-lint/Cargo.toml
+++ b/crates/chronicle-domain-lint/Cargo.toml
@@ -4,5 +4,5 @@ name    = "chronicle-domain-lint"
 version = "0.6.0"
 
 [dependencies]
-chronicle = { path = "../chronicle" }
-clap      = "3.2.1"
+chronicle      = { path = "../chronicle" }
+clap.workspace = true

--- a/crates/chronicle-domain-test/Cargo.toml
+++ b/crates/chronicle-domain-test/Cargo.toml
@@ -11,11 +11,11 @@ path = "src/test.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-chronicle           = { path = "../chronicle" }
-chronicle-telemetry = { path = "../chronicle-telemetry" }
-tracing             = "0.1.34"
-tracing-log         = "0.1.3"
-uuid                = "1.0.0"
+chronicle             = { path = "../chronicle" }
+chronicle-telemetry   = { path = "../chronicle-telemetry" }
+tracing.workspace     = true
+tracing-log.workspace = true
+uuid.workspace        = true
 
 [build-dependencies]
 chronicle = { path = "../chronicle" }
@@ -24,9 +24,9 @@ chronicle = { path = "../chronicle" }
 devmode = ["inmem"]
 strict  = []
 # Use an in-memory stub ledger
-inmem = ["chronicle/inmem"]
+inmem   = ["chronicle/inmem"]
 
 [dev-dependencies]
-futures  = "0.3"
-insta    = { version = "1.14.0", features = ["json", "redactions", "toml"] }
-tempfile = "3.4.0"
+futures.workspace  = true
+insta              = { workspace = true, features = ["json"] }
+tempfile.workspace = true

--- a/crates/chronicle-domain/Cargo.toml
+++ b/crates/chronicle-domain/Cargo.toml
@@ -19,8 +19,8 @@ chronicle = { path = "../chronicle" }
 [features]
 strict = []
 # Use an in memory stub ledger
-inmem = ["chronicle/inmem"]
+inmem  = ["chronicle/inmem"]
 
 [dev-dependencies]
-insta    = { version = "1.14.0", features = ["redactions", "toml"] }
-tempfile = "3.4.0"
+insta.workspace    = true
+tempfile.workspace = true

--- a/crates/chronicle-telemetry/Cargo.toml
+++ b/crates/chronicle-telemetry/Cargo.toml
@@ -6,20 +6,11 @@ version = "0.6.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-opentelemetry = { version = "0.18.0", features = ["rt-tokio"] }
-opentelemetry-jaeger = { version = "0.17.0", features = [
-  "rt-tokio",
-  "collector_client",
-  "reqwest_collector_client",
-] }
-tracing = "0.1.36"
-tracing-elastic-apm = "3.2.3"
-tracing-log = "0.1.3"
-tracing-opentelemetry = "0.18.0"
-tracing-subscriber = { version = "0.3.15", features = [
-  "default",
-  "registry",
-  "env-filter",
-  "json",
-] }
-url = { version = "2.2.2", features = ["serde"] }
+opentelemetry.workspace         = true
+opentelemetry-jaeger.workspace  = true
+tracing.workspace               = true
+tracing-elastic-apm.workspace   = true
+tracing-log.workspace           = true
+tracing-opentelemetry.workspace = true
+tracing-subscriber.workspace    = true
+url                             = { workspace = true, features = ["serde"] }

--- a/crates/chronicle/Cargo.toml
+++ b/crates/chronicle/Cargo.toml
@@ -7,66 +7,56 @@ version = "0.6.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-Inflector = "0.11.4"
-api = { path = "../api" }
-async-graphql = "4.0.9"
-chrono = { version = "0.4.19", features = ["serde"] }
-clap = { version = "3.2.1", features = ["derive", "env"] }
-clap_complete = "3.1.1"
-colored_json = "3.0.1"
-common = { path = "../common" }
-diesel = { version = "2.0.0-rc.0", features = [
-  "postgres",
-  "uuid",
-  "chrono",
-  "r2d2",
-] }
-dotenvy = "0.15"
-futures = "0.3.21"
-genco = "0.16.1"
-hex = "0.4.3"
-iref = "2.1.2"
-jsonschema = "0.16"
-opa = "0.9.0"
-open = "3.2.0"
-opentelemetry = { version = "0.18.0", features = ["rt-tokio"] }
-opentelemetry-jaeger = { version = "0.17.0", features = [
-  "rt-tokio",
-  "collector_client",
-  "reqwest_collector_client",
-] }
-percent-encoding = "2.1.0"
-pg-embed = "0.7.1"
-proto = { path = "../sawtooth-protocol" }
-question = "0.2.2"
-rand = { version = "0.8.5", features = ["getrandom"] }
-rand_core = "0.6.3"
-serde = "1.0.136"
-serde_derive = "1.0.136"
-serde_json = "1.0.81"
-serde_yaml = "0.9.14"
-shellexpand = "3.0.0"
-chronicle-telemetry = { path = "../chronicle-telemetry" }
-thiserror = "1.0.38"
-tokio = { version = "1.20.3", features = ["time", "macros", "rt-multi-thread"] }
-toml = "0.5.8"
-tracing = "0.1.32"
-tracing-log = "0.1.2"
-url = { version = "2.2.2", features = ["serde"] }
-user-error = "1.2.8"
-uuid = "0.8.2"
-valico = "3.6.0"
+Inflector.workspace            = true
+api                            = { path = "../api" }
+async-graphql.workspace        = true
+chrono                         = { workspace = true, features = ["serde"] }
+clap                           = { workspace = true, features = ["derive", "env"] }
+clap_complete.workspace        = true
+colored_json.workspace         = true
+common                         = { path = "../common" }
+diesel.workspace               = true
+dotenvy.workspace              = true
+futures.workspace              = true
+genco.workspace                = true
+hex.workspace                  = true
+iref.workspace                 = true
+jsonschema.workspace           = true
+opa.workspace                  = true
+opentelemetry.workspace        = true
+opentelemetry-jaeger.workspace = true
+percent-encoding.workspace     = true
+pg-embed.workspace             = true
+proto                          = { path = "../sawtooth-protocol" }
+question.workspace             = true
+rand.workspace                 = true
+rand_core.workspace            = true
+serde.workspace                = true
+serde_derive.workspace         = true
+serde_json.workspace           = true
+serde_yaml.workspace           = true
+shellexpand.workspace          = true
+chronicle-telemetry            = { path = "../chronicle-telemetry" }
+thiserror.workspace            = true
+tokio.workspace                = true
+toml.workspace                 = true
+tracing.workspace              = true
+tracing-log.workspace          = true
+url                            = { workspace = true, features = ["serde"] }
+user-error.workspace           = true
+uuid.workspace                 = true
+valico.workspace               = true
 
 
 [features]
 devmode = ["inmem"]
 # Use an in-memory stub ledger
-inmem  = []
-strict = []
+inmem   = []
+strict  = []
 
 [build-dependencies]
 
 [dev-dependencies]
-assert_fs = "1.0"
-insta     = { version = "1.14.0", features = ["redactions", "toml", "yaml"] }
-tempfile  = "3.3.0"
+assert_fs.workspace = true
+insta               = { workspace = true, features = ["yaml"] }
+tempfile.workspace  = true

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -7,85 +7,71 @@ version = "0.6.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.68"
-async-graphql = { features = [
+anyhow.workspace           = true
+async-graphql              = { workspace = true, features = [
   "opentelemetry",
   "chrono",
   "unblock",
   "default",
   "uuid",
-], version = "4.0.9" }
-async-trait = "0.1.53"
-chrono = { version = "0.4.19", features = ["serde"] }
-custom_error = "1.9.2"
-derivative = "2.2.0"
-diesel = { version = "2.0.0-rc.0", features = [
-  "postgres",
-  "uuid",
-  "chrono",
-  "r2d2",
 ] }
-futures = "0.3.21"
-glob = "0.3.0"
-hashbrown = "0.13"
-hex = "0.4.3"
-iref = "2.1.2"
-iref-enum = "2.0.0"
-json-ld = "0.14"
-k256 = { version = "0.11.3", features = [
-  "default",
-  "arithmetic",
-  "ecdsa",
-  "pkcs8",
-  "serde",
-  "sha256",
-  "std",
-  "pem",
-] }
-lazy_static = "1.4.0"
-locspan = "0.7"
-mime = "0.3"
-opa = "0.9.0"
-opa-tp-protocol = { path = "../opa-tp-protocol" }
-percent-encoding = "2.1.0"
-pg-embed = "0.7.1"
-pkcs8 = { version = "*", features = ["std", "alloc"] }
-portpicker = "0.1.1"
-prost = "0.10.0"
-protobuf = "2.27.1"
-r2d2 = "0.8.9"
-rand = { version = "0.8.5", features = ["getrandom"] }
-rand_core = "0.6.3"
-rdf-types = "0.14"
-rust-embed = { version = "6.6.0", features = ["debug-embed", "include-exclude"] }
-sawtooth-sdk = "0.5.2"
-serde = "1.0.136"
-serde_derive = "1.0.136"
-serde_json = "1.0.93"
-static-iref = "2.0.0"
-temp-dir = "0.1.11"
-thiserror = "1.0.36"
-tokio = { version = "1.20.3", features = ["time", "macros", "rt-multi-thread"] }
-tracing = "0.1.32"
-url = { version = "2.2.2", features = ["serde"] }
-uuid = { version = "0.8.2", features = ["serde", "v4"] }
-zmq = "0.9.2"
+async-trait.workspace      = true
+chrono                     = { workspace = true, features = ["serde"] }
+custom_error.workspace     = true
+derivative.workspace       = true
+diesel.workspace           = true
+futures.workspace          = true
+glob.workspace             = true
+hashbrown.workspace        = true
+hex.workspace              = true
+iref.workspace             = true
+iref-enum.workspace        = true
+json-ld.workspace          = true
+k256                       = { workspace = true, features = ["serde"] }
+lazy_static.workspace      = true
+locspan.workspace          = true
+mime.workspace             = true
+opa.workspace              = true
+opa-tp-protocol            = { path = "../opa-tp-protocol" }
+percent-encoding.workspace = true
+pg-embed.workspace         = true
+pkcs8.workspace            = true
+portpicker.workspace       = true
+prost                      = "0.10.0"
+protobuf.workspace         = true
+r2d2.workspace             = true
+rand.workspace             = true
+rand_core.workspace        = true
+rdf-types.workspace        = true
+rust-embed.workspace       = true
+sawtooth-sdk.workspace     = true
+serde.workspace            = true
+serde_derive.workspace     = true
+serde_json.workspace       = true
+static-iref.workspace      = true
+temp-dir.workspace         = true
+thiserror.workspace        = true
+tokio.workspace            = true
+tracing.workspace          = true
+url                        = { workspace = true, features = ["serde"] }
+uuid.workspace             = true
+zmq.workspace              = true
 
 [build-dependencies]
-glob        = "0.3.0"
-lazy_static = "1.4.0"
-prost-build = "0.10.0"
-serde_json = "1.0.93"
+glob.workspace        = true
+lazy_static.workspace = true
+prost-build.workspace = true
+serde_json.workspace  = true
 
 [dev-dependencies]
-api = { path = "../api" }
-criterion = { version = "0.4.0", features = ["async_futures", "async_tokio"] }
-insta = { version = "1.14.0", features = ["json", "redactions", "toml"] }
-proptest = "1.0.0"
-sawtooth-sdk = "0.5.2"
+api                    = { path = "../api" }
+criterion.workspace    = true
+insta                  = { workspace = true, features = ["json"] }
+proptest.workspace     = true
+sawtooth-sdk.workspace = true
 
 [[bench]]
-name = "opa_executor"
+name    = "opa_executor"
 harness = false
 
 [features]

--- a/crates/opa-tp-protocol/Cargo.toml
+++ b/crates/opa-tp-protocol/Cargo.toml
@@ -7,39 +7,31 @@ version = "0.1.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.68"
-async-sawtooth-sdk = { path = "../async-sawtooth-sdk" }
-async-trait = "0.1.61"
-chrono = { version = "0.4.19", features = ["serde"] }
-derivative = "2.2.0"
-futures = "0.3.21"
-hex = "0.4.3"
-k256 = { version = "0.11.3", features = [
-  "default",
-  "arithmetic",
-  "ecdsa",
-  "pkcs8",
-  "sha256",
-  "std",
-  "pem",
-] }
-lazy_static = "1.4.0"
-openssl = "0.10.38"
-prost = "0.11.3"
-prost-types = "0.11.2"
-protobuf = "2.27.1"
-rand = { version = "0.8.5", features = ["getrandom"] }
-rand_core = "0.6.3"
-sawtooth-sdk = "0.5.2"
-serde = { version = "1.0.150", features = ["derive"] }
-serde_json = "1.0.89"
-thiserror = "1.0.38"
-tokio = { version = "1.20.3", features = ["time", "macros", "rt-multi-thread"] }
-tracing = "0.1.37"
-url = "2.3.1"
-uuid = { version = "1.2.2", features = ["v4", "serde", "std"] }
-zmq = "0.9.2"
+anyhow.workspace       = true
+async-sawtooth-sdk     = { path = "../async-sawtooth-sdk" }
+async-trait.workspace  = true
+chrono                 = { workspace = true, features = ["serde"] }
+derivative.workspace   = true
+futures.workspace      = true
+hex.workspace          = true
+k256.workspace         = true
+lazy_static.workspace  = true
+openssl.workspace      = true
+prost.workspace        = true
+prost-types.workspace  = true
+protobuf.workspace     = true
+rand.workspace         = true
+rand_core.workspace    = true
+sawtooth-sdk.workspace = true
+serde                  = { workspace = true, features = ["derive"] }
+serde_json.workspace   = true
+thiserror.workspace    = true
+tokio.workspace        = true
+tracing.workspace      = true
+url.workspace          = true
+uuid.workspace         = true
+zmq.workspace          = true
 
 [build-dependencies]
-glob        = "0.3.0"
-prost-build = "0.10.0"
+glob.workspace        = true
+prost-build.workspace = true

--- a/crates/opa-tp/Cargo.toml
+++ b/crates/opa-tp/Cargo.toml
@@ -15,13 +15,13 @@ path = "src/main.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-sawtooth-sdk = { path = "../async-sawtooth-sdk" }
-async-trait = "0.1.61"
-bytes = "1.3.0"
-chronicle-telemetry = { path = "../chronicle-telemetry" }
-chrono = "0.4.19"
-clap = { version = "3.2.1", features = ["derive", "env"] }
-k256 = { version = "0.11.3", features = [
+async-sawtooth-sdk     = { path = "../async-sawtooth-sdk" }
+async-trait.workspace  = true
+bytes.workspace        = true
+chronicle-telemetry    = { path = "../chronicle-telemetry" }
+chrono.workspace       = true
+clap                   = { workspace = true, features = ["derive", "env"] }
+k256                   = { workspace = true, features = [
   "default",
   "arithmetic",
   "ecdsa",
@@ -30,20 +30,20 @@ k256 = { version = "0.11.3", features = [
   "std",
   "pem",
 ] }
-opa-tp-protocol = { path = "../opa-tp-protocol" }
-prost = "0.11.3"
-proto = { path = "../sawtooth-protocol" }
-sawtooth-sdk = "0.5.2"
-serde_json = "1.0.79"
-thiserror = "1.0.36"
-tokio = { version = "1.17.0", features = ["time", "macros", "rt-multi-thread"] }
-tracing = "0.1.37"
-url = "2.3.1"
+opa-tp-protocol        = { path = "../opa-tp-protocol" }
+prost.workspace        = true
+proto                  = { path = "../sawtooth-protocol" }
+sawtooth-sdk.workspace = true
+serde_json.workspace   = true
+thiserror.workspace    = true
+tokio.workspace        = true
+tracing.workspace      = true
+url.workspace          = true
 
 [dev-dependencies]
 chronicle-telemetry = { path = "../chronicle-telemetry" }
-insta               = { version = "1.14.0", features = ["redactions", "toml", "yaml"] }
-protobuf            = "2.27.1"
-rand                = { version = "0.8.5", features = ["getrandom"] }
-rand_core           = "0.6.3"
-tempfile            = "3.4.0"
+insta               = { workspace = true, features = ["yaml"] }
+protobuf.workspace  = true
+rand.workspace      = true
+rand_core.workspace = true
+tempfile.workspace  = true

--- a/crates/opactl/Cargo.toml
+++ b/crates/opactl/Cargo.toml
@@ -6,38 +6,30 @@ version = "0.1.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-sawtooth-sdk = { path = "../async-sawtooth-sdk" }
-async-trait = "0.1.61"
-chronicle-telemetry = { path = "../chronicle-telemetry" }
-clap = { version = "4.1.1", features = ["env"] }
-futures = "0.3.21"
-k256 = { version = "0.11.3", features = [
-  "default",
-  "arithmetic",
-  "ecdsa",
-  "pkcs8",
-  "sha256",
-  "std",
-  "pem",
-] }
-opa-tp-protocol = { path = "../opa-tp-protocol" }
-pin-project = "1.0.12"
-rand = { version = "0.8.5", features = ["getrandom"] }
-rand_core = "0.6.3"
-sawtooth-sdk = "0.5.2"
-serde = "1.0.152"
-serde_derive = "1.0.152"
-serde_json = "1.0.93"
-thiserror = "1.0.38"
-tokio = { version = "1.20.3", features = ["time", "macros", "rt-multi-thread"] }
-tokio-stream = "0.1.11"
-tracing = "0.1.37"
-url = "2.3.1"
-user-error = "1.2.8"
+async-sawtooth-sdk     = { path = "../async-sawtooth-sdk" }
+async-trait.workspace  = true
+chronicle-telemetry    = { path = "../chronicle-telemetry" }
+clap                   = { version = "4.1.1", features = ["env"] }
+futures.workspace      = true
+k256.workspace         = true
+opa-tp-protocol        = { path = "../opa-tp-protocol" }
+pin-project.workspace  = true
+rand.workspace         = true
+rand_core.workspace    = true
+sawtooth-sdk.workspace = true
+serde.workspace        = true
+serde_derive.workspace = true
+serde_json.workspace   = true
+thiserror.workspace    = true
+tokio.workspace        = true
+tokio-stream.workspace = true
+tracing.workspace      = true
+url.workspace          = true
+user-error.workspace   = true
 
 [dev-dependencies]
-insta      = { version = "1.26.0", features = ["redactions", "toml", "yaml"] }
-opa-tp     = { path = "../opa-tp" }
-protobuf   = "2.27.1"
-serde_json = "1.0.79"
-tempfile   = "3.3.0"
+insta                = { workspace = true, features = ["yaml"] }
+opa-tp               = { path = "../opa-tp" }
+protobuf.workspace   = true
+serde_json.workspace = true
+tempfile.workspace   = true

--- a/crates/sawtooth-protocol/Cargo.toml
+++ b/crates/sawtooth-protocol/Cargo.toml
@@ -11,38 +11,38 @@ path = "src/lib.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-trait  = "0.1.53"
-backoff      = { version = "0.4.0", features = ["futures", "tokio"] }
-bytes        = "1.1.0"
-common       = { path = "../common" }
-custom_error = "1.9.2"
-derivative   = "2.2.0"
-futures      = "0.3.21"
-glob         = "0.3.0"
-hex          = "0.4.3"
-lazy_static  = "1.4.0"
-openssl      = "0.10.38"
-prost        = "0.10.0"
-prost-types  = "0.10.0"
-rand         = { version = "0.8.5", features = ["getrandom"] }
-rand_core    = "0.6.3"
-sawtooth-sdk = "0.5.2"
-serde        = "1.0.136"
-serde_cbor   = "0.11.2"
-serde_derive = "1.0.136"
-tokio        = { version = "1.20.3", features = ["time", "macros", "rt-multi-thread"] }
-tracing      = "0.1.32"
-url          = "2.2.2"
-uuid         = { version = "0.8.2", features = ["serde", "v4"] }
-zmq          = "0.9.2"
+async-trait.workspace  = true
+backoff.workspace      = true
+bytes.workspace        = true
+common                 = { path = "../common" }
+custom_error.workspace = true
+derivative.workspace   = true
+futures.workspace      = true
+glob.workspace         = true
+hex.workspace          = true
+lazy_static.workspace  = true
+openssl.workspace      = true
+prost                  = "0.10.0"
+prost-types.workspace  = true
+rand.workspace         = true
+rand_core.workspace    = true
+sawtooth-sdk.workspace = true
+serde.workspace        = true
+serde_cbor.workspace   = true
+serde_derive.workspace = true
+tokio.workspace        = true
+tracing.workspace      = true
+url.workspace          = true
+uuid.workspace         = true
+zmq.workspace          = true
 
 [build-dependencies]
-glob        = "0.3.0"
-prost-build = "0.10.0"
+glob.workspace        = true
+prost-build.workspace = true
 
 [dev-dependencies]
-protobuf = "2.27.1"
-tempfile  = "3.3.0"
+protobuf.workspace = true
+tempfile.workspace = true
 
 [features]
 default          = ["vendored-zmq", "vendored-openssl"]

--- a/crates/sawtooth-tp/Cargo.toml
+++ b/crates/sawtooth-tp/Cargo.toml
@@ -10,50 +10,46 @@ version = "0.6.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-trait = "0.1.53"
-backoff = { version = "0.4.0", features = ["futures", "tokio"] }
-bytes = "1.1.0"
-chronicle-telemetry = { path = "../chronicle-telemetry" }
-clap = "3.2.1"
-clap_generate = "3.0.3"
-common = { path = "../common" }
-crossbeam = "0.8.1"
-custom_error = "1.9.2"
-derivative = "2.2.0"
-futures = "0.3.21"
-glob = "0.3.0"
-hex = "0.4.3"
-lazy_static = "1.4.0"
-openssl = "0.10.38"
-opentelemetry = { version = "0.18.0", features = ["rt-tokio"] }
-opentelemetry-jaeger = { version = "0.17.0", features = [
-  "rt-tokio",
-  "reqwest_collector_client",
-  "collector_client",
-] }
-prost = "0.10.0"
-proto = { path = "../sawtooth-protocol" }
-rand = { version = "0.8.5", features = ["getrandom"] }
-rand_core = "0.6.3"
-sawtooth-sdk = "0.5.2"
-serde = "1.0.136"
-serde_cbor = "0.11.2"
-serde_derive = "1.0.136"
-serde_json = "1.0.89"
-tokio = { version = "1.20.3", features = ["time", "macros", "rt-multi-thread"] }
-tracing = "0.1.32"
-url = "2.2.2"
-uuid = { version = "0.8.2", features = ["serde", "v4"] }
-zmq = "0.9.2"
+async-trait.workspace          = true
+backoff.workspace              = true
+bytes.workspace                = true
+chronicle-telemetry            = { path = "../chronicle-telemetry" }
+clap.workspace                 = true
+clap_generate.workspace        = true
+common                         = { path = "../common" }
+crossbeam.workspace            = true
+custom_error.workspace         = true
+derivative.workspace           = true
+futures.workspace              = true
+glob.workspace                 = true
+hex.workspace                  = true
+lazy_static.workspace          = true
+openssl.workspace              = true
+opentelemetry.workspace        = true
+opentelemetry-jaeger.workspace = true
+prost                          = "0.10.0"
+proto                          = { path = "../sawtooth-protocol" }
+rand.workspace                 = true
+rand_core.workspace            = true
+sawtooth-sdk.workspace         = true
+serde.workspace                = true
+serde_cbor.workspace           = true
+serde_derive.workspace         = true
+serde_json.workspace           = true
+tokio.workspace                = true
+tracing.workspace              = true
+url.workspace                  = true
+uuid.workspace                 = true
+zmq.workspace                  = true
 
 [build-dependencies]
-glob        = "0.3.0"
-prost-build = "0.10.0"
+glob.workspace        = true
+prost-build.workspace = true
 
 [dev-dependencies]
-insta    = { version = "1.14.0", features = ["redactions", "toml", "yaml"] }
-protobuf = "2.27.1"
-tempfile = "3.4.0"
+insta              = { workspace = true, features = ["yaml"] }
+protobuf.workspace = true
+tempfile.workspace = true
 
 [features]
 default          = ["vendored-zmq", "vendored-openssl"]


### PR DESCRIPTION
- Adds a [dependencies table](https://doc.rust-lang.org/nightly/cargo/reference/workspaces.html#the-dependencies-table) to Chronicle's root Cargo.toml, defining dependencies to be inherited by members of the workspace
- Notes that we currently use different versions of `clap` and `prost` across the workspace
- Bumps dependency versions where no code changes necessary

--- 
[CHRON-273](https://blockchaintp.atlassian.net/browse/CHRON-273)

Signed-off-by: Joseph Livesey [joseph.livesey@btp.works](mailto:joseph.livesey@btp.works)

[CHRON-273]: https://blockchaintp.atlassian.net/browse/CHRON-273?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ