### PR TITLE
fix: bump openssl to fix RUSTSEC-2023-0022

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3163,9 +3163,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.45"
+version = "0.10.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b102428fd03bc5edf97f62620f7298614c45cedf287c271e7ed450bbaf83f2e1"
+checksum = "518915b97df115dd36109bfa429a48b8f737bd05508cf9588977b599648926d2"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -3204,9 +3204,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.80"
+version = "0.9.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23bbbf7854cd45b83958ebe919f0e8e516793727652e27fda10a8384cfc790b7"
+checksum = "666416d899cf077260dac8698d60a60b435a46d57e82acb1be3d0dad87284e5b"
 dependencies = [
  "autocfg",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ lazy_static           = "1.4.0"
 locspan               = "0.7"
 mime                  = "0.3"
 opa                   = "0.9.0"
-openssl               = "0.10.38"
+openssl               = "0.10.48"
 opentelemetry         = { version = "0.18.0", features = ["rt-tokio"] }
 opentelemetry-jaeger  = { version = "0.17.0", features = [
   "rt-tokio",


### PR DESCRIPTION
Fixes [RUSTSEC-2023-0022](https://rustsec.org/advisories/RUSTSEC-2023-0022), flagged by `cargo audit` in CI and causing the check to fail.

Signed-off-by: Joseph Livesey [joseph.livesey@btp.works](mailto:joseph.livesey@btp.works)