### PR TITLE
add endpoint that offers JSON by IRI

### DIFF
--- a/charts/chronicle/templates/statefulset.yaml
+++ b/charts/chronicle/templates/statefulset.yaml
@@ -72,7 +72,7 @@ spec:
               -c /etc/chronicle/config/config.toml \
               --console-logging json \
               --sawtooth tcp://{{ include "chronicle.sawtooth.service" . }}:{{ include "chronicle.sawtooth.sawcomp" . }} \
-              serve-graphql --interface 0.0.0.0:{{ .Values.port}} {{ if .Values.webUi }} --open {{ end }}
+              serve-api --interface 0.0.0.0:{{ .Values.port}} {{ if .Values.webUi }} --open {{ end }}
           env: {{ include "lib.safeToYaml" .Values.env | nindent 12 }}
             - name: RUST_LOG
               value: {{ .Values.logLevel }}

--- a/crates/api/src/persistence/query.rs
+++ b/crates/api/src/persistence/query.rs
@@ -80,7 +80,8 @@ pub struct Identity {
     pub public_key: String,
 }
 
-#[derive(Debug, Queryable)]
+#[derive(Debug, Queryable, Selectable)]
+#[diesel(table_name = activity)]
 pub struct Activity {
     pub id: i32,
     pub external_id: String,

--- a/crates/chronicle/src/bootstrap/cli.rs
+++ b/crates/chronicle/src/bootstrap/cli.rs
@@ -989,14 +989,15 @@ impl SubCommand for CliModel {
             )
             .subcommand(Command::new("export-schema").about("Print SDL and exit"))
             .subcommand(
-                Command::new("serve-graphql")
-                    .about("Start a graphql server")
+                Command::new("serve-api")
+                    .alias("serve-graphql")
+                    .about("Start an API server")
                     .arg(
                         Arg::new("interface")
                             .long("interface")
                             .takes_value(true)
                             .default_value("127.0.0.1:9982")
-                            .help("The graphql server address (default 127.0.0.1:9982)"),
+                            .help("The API server address (default 127.0.0.1:9982)"),
                     ).arg(
                         Arg::new("playground")
                             .long("playground")
@@ -1038,6 +1039,15 @@ impl SubCommand for CliModel {
                         .multiple_values(true)
                         .number_of_values(2)
                         .help("claim name and value that must be present for accepting a JWT")
+                    )
+                    .arg(
+                        Arg::new("offer-endpoints")
+                        .long("offer-endpoints")
+                        .takes_value(true)
+                        .min_values(1)
+                        .value_parser(["data", "graphql"])
+                        .default_values(&["data", "graphql"])
+                        .help("which API endpoints to offer")
                     ),
             )
             .subcommand(Command::new("verify-keystore").about("Initialize and verify keystore, then exit"));

--- a/crates/common/src/prov/id/mod.rs
+++ b/crates/common/src/prov/id/mod.rs
@@ -20,9 +20,9 @@ use super::vocab::Chronicle;
 
 custom_error::custom_error! {pub ParseIriError
     NotAnIri {source: iref::Error } = "Invalid IRI",
-    UnparsableIri {iri: IriRefBuf} = "Unparsable chronicle IRI",
+    UnparsableIri {iri: IriRefBuf} = "Unparsable Chronicle IRI",
     UnparsableUuid {source: uuid::Error } = "Unparsable UUID",
-    IncorrectIriKind = "Unexpected Iri type",
+    IncorrectIriKind = "Unexpected IRI type",
     MissingComponent{component: String} = "Expected {component}",
 }
 

--- a/docker/chronicle.yaml
+++ b/docker/chronicle.yaml
@@ -103,7 +103,7 @@ services:
           -c /etc/chronicle/config/config.toml \
           --console-logging pretty \
           --sawtooth tcp://validator:4004 \
-          serve-graphql \
+          serve-api \
           --interface 0.0.0.0:9982
     volumes:
       - type: bind

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -57,7 +57,7 @@ instead, prefix each variable name with `JWT_MUST_CLAIM_`.
 Which endpoints to listen at for serving requests. By default, all are served.
 Options are:
 
-- `data` for IRIs encoded in URIs (at `/data`)
+- `data` for IRIs encoded in URIs (at `/context` and `/data`)
 - `graphql` for GraphQL requests (at `/` and `/ws`)
 
 ### `export-schema`

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -2,9 +2,9 @@
 
 ## Subcommands
 
-### `serve-graphql`
+### `serve-api`
 
-Run Chronicle as a GraphQL server.
+Run Chronicle as an API server.
 
 #### Arguments
 
@@ -51,6 +51,14 @@ expected in the JWTs issued by the authorization server.
 
 This option may be given multiple times. To set via environment variables
 instead, prefix each variable name with `JWT_MUST_CLAIM_`.
+
+##### `--offer-endpoints name name ...`
+
+Which endpoints to listen at for serving requests. By default, all are served.
+Options are:
+
+- `data` for IRIs encoded in URIs (at `/data`)
+- `graphql` for GraphQL requests (at `/` and `/ws`)
 
 ### `export-schema`
 


### PR DESCRIPTION
With `serve-graphql` visit http://localhost:9982/data/chronicle:agent:my-agent-id and see JSON summarizing it. (Pipe through `jq .` for prettiness.) Same for activities and entities. Resolves CHRON-277 and CHRON-280.

Substituting `data` with `data/default` works, one may use other namespace IDs for `default`.

Notice that the subcommand has now become `serve-api` with a new `--offer-endpoints` option.

I opted for fairly minimal adjustment of `prov_model_for_namespace` code.