### PR TITLE
fix order of delegation participants

### DIFF
--- a/crates/api/src/chronicle_graphql/agent.rs
+++ b/crates/api/src/chronicle_graphql/agent.rs
@@ -52,8 +52,8 @@ pub async fn acted_on_behalf_of<'a>(
     let mut connection = store.pool.get()?;
 
     Ok(delegation::table
-        .filter(dsl::responsible_id.eq(id))
-        .inner_join(agentdsl::table.on(dsl::delegate_id.eq(agentdsl::id)))
+        .filter(dsl::delegate_id.eq(id))
+        .inner_join(agentdsl::table.on(dsl::responsible_id.eq(agentdsl::id)))
         .order(agentdsl::external_id)
         .select((Agent::as_select(), dsl::role))
         .load::<(Agent, Role)>(&mut connection)?

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -1753,6 +1753,7 @@ mod test {
         association: {}
         derivation: {}
         delegation: {}
+        acted_on_behalf_of: {}
         generation: {}
         usage: {}
         was_informed_by: {}

--- a/crates/api/src/persistence/mod.rs
+++ b/crates/api/src/persistence/mod.rs
@@ -1080,9 +1080,9 @@ impl Store {
         );
 
         for (responsible, activity, role) in schema::delegation::table
-            .filter(schema::delegation::responsible_id.eq(agent.id))
+            .filter(schema::delegation::delegate_id.eq(agent.id))
             .inner_join(
-                schema::agent::table.on(schema::delegation::delegate_id.eq(schema::agent::id)),
+                schema::agent::table.on(schema::delegation::responsible_id.eq(schema::agent::id)),
             )
             .inner_join(
                 schema::activity::table
@@ -1098,8 +1098,8 @@ impl Store {
         {
             model.qualified_delegation(
                 namespaceid,
-                &AgentId::from_external_id(&agent.external_id),
                 &AgentId::from_external_id(responsible),
+                &AgentId::from_external_id(&agent.external_id),
                 {
                     if activity.contains("hidden entry for Option None") {
                         None

--- a/crates/chronicle-domain-test/src/test.rs
+++ b/crates/chronicle-domain-test/src/test.rs
@@ -183,7 +183,7 @@ mod test {
           .execute(Request::new(
               r#"
           query {
-              agentById(id: { id: "chronicle:agent:testagent" }) {
+              agentById(id: { id: "chronicle:agent:testdelegate" }) {
                   ... on ProvAgent {
                       id
                       externalId
@@ -203,12 +203,12 @@ mod test {
           .await.data, @r###"
         {
           "agentById": {
-            "id": "chronicle:agent:testagent",
-            "externalId": "testagent",
+            "id": "chronicle:agent:testdelegate",
+            "externalId": "testdelegate",
             "actedOnBehalfOf": [
               {
                 "agent": {
-                  "id": "chronicle:agent:testdelegate"
+                  "id": "chronicle:agent:testagent"
                 },
                 "role": "MANUFACTURER"
               }
@@ -1354,7 +1354,7 @@ mod test {
           .execute(Request::new(
               r#"
           query {
-              agentById(id: { id: "chronicle:agent:testagent" }) {
+              agentById(id: { id: "chronicle:agent:testdelegate" }) {
                   ... on ProvAgent {
                       id
                       externalId
@@ -1374,12 +1374,12 @@ mod test {
           .await.data, @r###"
         {
           "agentById": {
-            "id": "chronicle:agent:testagent",
-            "externalId": "testagent",
+            "id": "chronicle:agent:testdelegate",
+            "externalId": "testdelegate",
             "actedOnBehalfOf": [
               {
                 "agent": {
-                  "id": "chronicle:agent:testdelegate"
+                  "id": "chronicle:agent:testagent"
                 },
                 "role": "MANUFACTURER"
               }

--- a/crates/chronicle/src/bootstrap/mod.rs
+++ b/crates/chronicle/src/bootstrap/mod.rs
@@ -798,6 +798,7 @@ pub mod test {
         association: {}
         derivation: {}
         delegation: {}
+        acted_on_behalf_of: {}
         generation: {}
         usage: {}
         was_informed_by: {}

--- a/crates/common/src/prov/model/from_json_ld.rs
+++ b/crates/common/src/prov/model/from_json_ld.rs
@@ -267,21 +267,21 @@ impl ProvModel {
             .ok()
             .and_then(|x| x.as_str().map(Role::from));
 
-        let responsible_id = extract_reference_ids(&Prov::Responsible, delegation)?
-            .into_iter()
-            .next()
-            .ok_or_else(|| ProcessorError::MissingProperty {
-                object: as_json(delegation),
-                iri: Prov::Responsible.as_iri().to_string(),
-            })
-            .and_then(|x| Ok(AgentId::try_from(x.as_iri())?))?;
-
-        let delegate_id = extract_reference_ids(&Prov::ActedOnBehalfOf, delegation)?
+        let responsible_id = extract_reference_ids(&Prov::ActedOnBehalfOf, delegation)?
             .into_iter()
             .next()
             .ok_or_else(|| ProcessorError::MissingProperty {
                 object: as_json(delegation),
                 iri: Prov::ActedOnBehalfOf.as_iri().to_string(),
+            })
+            .and_then(|x| Ok(AgentId::try_from(x.as_iri())?))?;
+
+        let delegate_id = extract_reference_ids(&Prov::Delegate, delegation)?
+            .into_iter()
+            .next()
+            .ok_or_else(|| ProcessorError::MissingProperty {
+                object: as_json(delegation),
+                iri: Prov::Delegate.as_iri().to_string(),
             })
             .and_then(|x| Ok(AgentId::try_from(x.as_iri())?))?;
 

--- a/crates/common/src/prov/model/to_json_ld.rs
+++ b/crates/common/src/prov/model/to_json_ld.rs
@@ -113,14 +113,14 @@ impl ToJson for ProvModel {
                 }
 
                 if let Some(delegation) = self
-                    .delegation
+                    .acted_on_behalf_of
                     .get(&(agent.namespaceid.to_owned(), id.to_owned()))
                 {
                     let mut ids = Vec::new();
                     let mut qualified_ids = Vec::new();
 
                     for delegation in delegation.iter() {
-                        ids.push(json!({"@id": delegation.delegate_id.de_compact()}));
+                        ids.push(json!({"@id": delegation.responsible_id.de_compact()}));
                         qualified_ids.push(json!({"@id": delegation.id.de_compact()}));
                     }
 
@@ -274,7 +274,7 @@ impl ToJson for ProvModel {
                     );
 
                     delegationdoc.insert(
-                        Iri::from(Prov::Responsible).to_string(),
+                        Iri::from(Prov::ActedOnBehalfOf).to_string(),
                         Value::Array(responsible_ids),
                     );
 
@@ -283,7 +283,7 @@ impl ToJson for ProvModel {
                         .push(json!({ "@id": Value::String(delegation.delegate_id.de_compact())}));
 
                     delegationdoc.insert(
-                        Iri::from(Prov::ActedOnBehalfOf).to_string(),
+                        Iri::from(Prov::Delegate).to_string(),
                         Value::Array(delegate_ids),
                     );
 

--- a/crates/common/src/prov/vocab.rs
+++ b/crates/common/src/prov/vocab.rs
@@ -106,6 +106,8 @@ pub enum Prov {
     Association,
     #[iri("prov:Attribution")]
     Attribution,
+    #[iri("prov:agent")]
+    Responsible,
     #[iri("prov:wasGeneratedBy")]
     WasGeneratedBy,
     #[iri("prov:used")]
@@ -131,7 +133,7 @@ pub enum Prov {
     #[iri("prov:Delegation")]
     Delegation,
     #[iri("prov:agent")]
-    Responsible,
+    Delegate,
     #[iri("prov:hadRole")]
     HadRole,
     #[iri("prov:hadActivity")]

--- a/crates/sawtooth-tp/src/tp.rs
+++ b/crates/sawtooth-tp/src/tp.rs
@@ -588,23 +588,23 @@ pub mod test {
                     value: {}
                   - "@id": "chronicle:agent:test%5Fagent"
                     "@type": "prov:Agent"
-                    actedOnBehalfOf:
-                      - "chronicle:agent:test%5Fdelegate"
                     externalId: test_agent
+                    namespace: "chronicle:ns:testns:5a0ab5b8-eeb7-4812-9fe3-6dd69bd20cea"
+                    value: {}
+                  - "@id": "chronicle:agent:test%5Fdelegate"
+                    "@type": "prov:Agent"
+                    actedOnBehalfOf:
+                      - "chronicle:agent:test%5Fagent"
+                    externalId: test_delegate
                     namespace: "chronicle:ns:testns:5a0ab5b8-eeb7-4812-9fe3-6dd69bd20cea"
                     "prov:qualifiedDelegation":
                       "@id": "chronicle:delegation:test%5Fdelegate:test%5Fagent:role=test%5Frole:activity=test%5Factivity"
                     value: {}
-                  - "@id": "chronicle:agent:test%5Fdelegate"
-                    "@type": "prov:Agent"
-                    externalId: test_delegate
-                    namespace: "chronicle:ns:testns:5a0ab5b8-eeb7-4812-9fe3-6dd69bd20cea"
-                    value: {}
                   - "@id": "chronicle:delegation:test%5Fdelegate:test%5Fagent:role=test%5Frole:activity=test%5Factivity"
                     "@type": "prov:Delegation"
                     actedOnBehalfOf:
-                      - "chronicle:agent:test%5Fdelegate"
-                    agent: "chronicle:agent:test%5Fagent"
+                      - "chronicle:agent:test%5Fagent"
+                    agent: "chronicle:agent:test%5Fdelegate"
                     namespace: "chronicle:ns:testns:5a0ab5b8-eeb7-4812-9fe3-6dd69bd20cea"
                     "prov:hadActivity":
                       "@id": "chronicle:activity:test%5Factivity"
@@ -618,8 +618,12 @@ pub mod test {
             - - 43a52b235b2c3e3735c87de6688c5e30596cd12fa3bc9d013c616035292f842fed5077
               - "@id": "chronicle:agent:test%5Fdelegate"
                 "@type": "prov:Agent"
+                actedOnBehalfOf:
+                  - "chronicle:agent:test%5Fagent"
                 externalId: test_delegate
                 namespace: "chronicle:ns:testns:5a0ab5b8-eeb7-4812-9fe3-6dd69bd20cea"
+                "prov:qualifiedDelegation":
+                  "@id": "chronicle:delegation:test%5Fdelegate:test%5Fagent:role=test%5Frole:activity=test%5Factivity"
                 value: {}
             - - 43a52b23e8079f2f7d6e21587c560d0d3e665c94adcbb3aed368b04eb73fcce3dc15a9
               - "@id": "chronicle:activity:test%5Factivity"
@@ -631,8 +635,8 @@ pub mod test {
               - "@id": "chronicle:delegation:test%5Fdelegate:test%5Fagent:role=test%5Frole:activity=test%5Factivity"
                 "@type": "prov:Delegation"
                 actedOnBehalfOf:
-                  - "chronicle:agent:test%5Fdelegate"
-                agent: "chronicle:agent:test%5Fagent"
+                  - "chronicle:agent:test%5Fagent"
+                agent: "chronicle:agent:test%5Fdelegate"
                 namespace: "chronicle:ns:testns:5a0ab5b8-eeb7-4812-9fe3-6dd69bd20cea"
                 "prov:hadActivity":
                   "@id": "chronicle:activity:test%5Factivity"
@@ -640,12 +644,8 @@ pub mod test {
             - - 43a52be8b6d53163d3edd7e93e139a5f9adddb39e5481ee73a1b0326f26cf9abe90930
               - "@id": "chronicle:agent:test%5Fagent"
                 "@type": "prov:Agent"
-                actedOnBehalfOf:
-                  - "chronicle:agent:test%5Fdelegate"
                 externalId: test_agent
                 namespace: "chronicle:ns:testns:5a0ab5b8-eeb7-4812-9fe3-6dd69bd20cea"
-                "prov:qualifiedDelegation":
-                  "@id": "chronicle:delegation:test%5Fdelegate:test%5Fagent:role=test%5Frole:activity=test%5Factivity"
                 value: {}
             - - 43a52bfdc37432b62f2f32862673fbbd3b7dbd1574c441fee886c5f80be47854c3a06e
               - "@id": "chronicle:ns:testns:5a0ab5b8-eeb7-4812-9fe3-6dd69bd20cea"


### PR DESCRIPTION
CHRON-282: the delegate acts on behalf of the responsible agent.

To `ProvModel` this adds `acted_on_behalf` indexed by delegates, complementing `delegation` indexed by responsible agents.