### PR TITLE
fix docs warnings

### DIFF
--- a/crates/chronicle-domain/Cargo.toml
+++ b/crates/chronicle-domain/Cargo.toml
@@ -7,6 +7,9 @@ version = "0.6.0"
 [[bin]]
 name = "chronicle"
 path = "src/main.rs"
+# same output filename as lib target
+doc = false
+
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/opa-tp/Cargo.toml
+++ b/crates/opa-tp/Cargo.toml
@@ -10,6 +10,8 @@ path = "src/lib.rs"
 [[bin]]
 name = "opa-tp"
 path = "src/main.rs"
+# same output filename as lib target
+doc = false
 
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
Placate `cargo checkmate doc` for CHRON-180.

Picked away at these in previous PRs, this fixes remainder, guided by https://github.com/rust-lang/cargo/issues/8898.