### PR TITLE
expand documentation on identity and evidence

### DIFF
--- a/.mdlrc.rb
+++ b/.mdlrc.rb
@@ -1,2 +1,3 @@
 all
-rule "MD013", :ignore_code_blocks => true, :code_blocks => false
+rule "MD009", :br_spaces => 2
+rule "MD013", :ignore_code_blocks => true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,6 +29,7 @@ repos:
           - --pattern
           - '^(?!((fix|feature|refactor)\/[a-zA-Z0-9\-]+)$).*'
       - id: trailing-whitespace
+        args: [--markdown-linebreak-ext=md]
         exclude: "docs/docs/diagrams/out/.*"
   - repo: https://github.com/commitizen-tools/commitizen
     rev: v2.42.0

--- a/docs/chronicle_vocabulary.md
+++ b/docs/chronicle_vocabulary.md
@@ -14,20 +14,20 @@ signing identity via `chronicle:hasIdentity` and historical identities via
 
 A value containing a hex-encoded ECDSA public key.
 
-Domain: Identity
+Domain: `chronicle:Identity`
 
 ## chronicle:hasIdentity
 
 The current cryptographic identity of a `prov:Agent`.
 
-Domain: prov:Agent
-Range: chronicle:Identity
+Domain: `prov:Agent`  
+Range: `chronicle:Identity`
 
 ## chronicle:hadIdentity
 
 A historical cryptographic identity for a `prov:Agent`.
 
-Domain: `prov:Agent`
+Domain: `prov:Agent`  
 Range: `chronicle:Identity`
 
 ## chronicle:Namespace
@@ -35,6 +35,8 @@ Range: `chronicle:Identity`
 An IRI containing an external id and uuid part, used for disambiguation.
 In order to work on the same namespace discrete Chronicle instances must share
 the uuid part.
+
+Domain: All prov and Chronicle resources
 
 ## chronicle:hasNamespace
 
@@ -52,37 +54,37 @@ signed by an agent.
 
 The current attachment for a `prov:Entity`.
 
-Domain: prov:Entity
-Range: chronicle:Attachment
+Domain: `prov:Entity`  
+Range: `chronicle:Attachment`
 
 ## chronicle:hadAttachment
 
 A historical attachment for a `prov:Entity`.
 
-Domain: `prov:Entity`
+Domain: `prov:Entity`  
 Range: `chronicle:Attachment`
 
 ## chronicle:entitySignature
 
 A hex-encoded ECDSA signature for the resource represented by an attachment.
 
-Domain: Attachment
+Domain: `chronicle:Attachment`
 
 ## chronicle:entityLocator
 
 An arbitrary value describing the attachment, likely an external IRI.
 
-Domain: Attachment
+Domain: `chronicle:Attachment`
 
 ## chronicle:signedAtTime
 
 The date / time when an attachment was created.
 
-Domain: chronicle:Attachment
+Domain: `chronicle:Attachment`
 
 ## chronicle:signedBy
 
 The chronicle:Identity (and by inference, prov:Agent) that signed an attachment.
 
-Domain: `chronicle:Attachment`
+Domain: `chronicle:Attachment`  
 Range: `chronicle:Identity`

--- a/docs/querying_provenance.md
+++ b/docs/querying_provenance.md
@@ -330,7 +330,42 @@ A DomainTypeID derived from the Entity subtype. The built-in GraphQL field
 
 #### Entity: evidence
 
-See [chronicle evidence](#chronicle-evidence)
+Still in development, see
+[attachments](./chronicle_vocabulary.md#chronicleattachment) and discussion
+of [planned behavior](./recording_provenance.md#evidence). Querying presently
+takes the form:
+
+```graphql
+query {
+  entityById(id: { externalId: "anaphylaxis-evidence-12114" }) {
+    ... on ExperimentEntity {
+      evidence {
+        signature
+        signatureTime
+        locator
+      }
+    }
+  }
+}
+```
+
+#### Entity: identity
+
+Still in development, see discussion of
+[planned behavior](./recording_provenance.md#identity). Querying presently
+takes the form:
+
+```graphql
+query {
+  agentById(id: { externalId: "homer" }) {
+    ... on PersonAgent {
+      identity {
+        publicKey
+      }
+    }
+  }
+}
+```
 
 #### Entity: wasGeneratedBy
 

--- a/docs/recording_provenance.md
+++ b/docs/recording_provenance.md
@@ -842,12 +842,36 @@ mutation {
 }
 ```
 
-### Chronicle-specific Cryptographic Operations
+### Chronicle-Specific Cryptographic Operations
 
-#### Has Identity
+#### Background
 
-#### Had Evidence
+The following operations are prototypes. They should not yet be used nor be
+expected to be usable. Nonetheless, they are already part of Chronicle so
+they are documented, even just as a tentative preview of coming features.
 
-Evidence is a Chronicle-specific provenance feature that simplifies the
-association of a cryptographic signature with an Entity. You will need a GraphQL
-client with multipart support for the attachment to sign.
+#### Identity
+
+Identity is planned to be a Chronicle-specific provenance feature that allows
+a cryptographic key to be associated with an agent. An agent's identity cannot
+yet be set via a mutation.
+
+When it can be updated, agents' previous identities will remain recorded,
+along with the corresponding public keys.
+
+#### Evidence
+
+Evidence is planned to be a Chronicle-specific provenance feature that
+simplifies the association of a cryptographic signature with an entity.
+A user would need a GraphQL client with multipart support for submitting the
+attachment.
+
+The signature will be recorded. If an entity's evidence is updated
+subsequently, details of the previous evidence and their signatures will remain
+recorded, just like above wherein agents' past identities remain recorded.
+
+The attachment itself is not preserved, just the details of its location
+and signing.
+
+The current `hasAttachment` mutation is intended for recording but is not yet
+usable.


### PR DESCRIPTION
Neither identity nor evidence are ready for documenting properly so this PR merely papers over some obvious holes highlighted by CHRON-159 and CHRON-177.

It also loosens CI to permit Python markdown linebreaks.