### PR TITLE
allow root to re-register user keys

### DIFF
--- a/crates/opa-tp-protocol/src/protos/submission.proto
+++ b/crates/opa-tp-protocol/src/protos/submission.proto
@@ -7,6 +7,7 @@ message BootstrapRoot { string public_key = 1; }
 message RegisterKey {
   string public_key = 1;
   string id = 2;
+  bool overwrite_existing = 3;
 }
 
 // Rotate the key with name to the new public key, the SignedOperation for this

--- a/crates/opa-tp-protocol/src/submission.rs
+++ b/crates/opa-tp-protocol/src/submission.rs
@@ -14,11 +14,16 @@ fn bootstrap_root(public_key: VerifyingKey) -> messages::BootstrapRoot {
     }
 }
 
-fn register_key(id: impl AsRef<str>, public_key: &VerifyingKey) -> messages::RegisterKey {
+fn register_key(
+    id: impl AsRef<str>,
+    public_key: &VerifyingKey,
+    overwrite_existing: bool,
+) -> messages::RegisterKey {
     let public_key: PublicKey = public_key.into();
     messages::RegisterKey {
         id: id.as_ref().to_string(),
         public_key: public_key.to_public_key_pem(LineEnding::CRLF).unwrap(),
+        overwrite_existing,
     }
 }
 
@@ -84,10 +89,11 @@ impl SubmissionBuilder {
         id: impl AsRef<str>,
         new_key: &VerifyingKey,
         root_key: &SigningKey,
+        overwrite_existing: bool,
     ) -> Self {
         let operation = messages::signed_operation::Payload {
             operation: Some(messages::signed_operation::payload::Operation::RegisterKey(
-                register_key(id, new_key),
+                register_key(id, new_key, overwrite_existing),
             )),
         };
 

--- a/crates/opa-tp-protocol/src/transaction.rs
+++ b/crates/opa-tp-protocol/src/transaction.rs
@@ -14,7 +14,7 @@ use crate::{
 pub enum OpaSubmitTransaction {
     BootstrapRoot(Submission, SigningKey),
     RotateRoot(Submission, SigningKey),
-    RegisterKey(Submission, SigningKey, String),
+    RegisterKey(Submission, SigningKey, String, bool),
     RotateKey(Submission, SigningKey, String),
     SetPolicy(Submission, SigningKey, String),
 }
@@ -32,11 +32,13 @@ impl OpaSubmitTransaction {
         name: impl AsRef<str>,
         submission: Submission,
         sawtooth_signer: &SigningKey,
+        overwrite_existing: bool,
     ) -> Self {
         Self::RegisterKey(
             submission,
             sawtooth_signer.to_owned(),
             name.as_ref().to_owned(),
+            overwrite_existing,
         )
     }
 
@@ -49,6 +51,7 @@ impl OpaSubmitTransaction {
             submission,
             sawtooth_signer.to_owned(),
             name.as_ref().to_owned(),
+            false,
         )
     }
 
@@ -71,7 +74,7 @@ impl LedgerTransaction for OpaSubmitTransaction {
         match self {
             Self::BootstrapRoot(_, signer) => signer,
             Self::RotateRoot(_, signer) => signer,
-            Self::RegisterKey(_, signer, _) => signer,
+            Self::RegisterKey(_, signer, _, _) => signer,
             Self::RotateKey(_, signer, _) => signer,
             Self::SetPolicy(_, signer, _) => signer,
         }
@@ -85,7 +88,7 @@ impl LedgerTransaction for OpaSubmitTransaction {
             Self::RotateRoot(_, _) => {
                 vec![key_address("root")]
             }
-            Self::RegisterKey(_, _, name) => {
+            Self::RegisterKey(_, _, name, _) => {
                 vec![key_address("root"), key_address(name.clone())]
             }
             Self::RotateKey(_, _, name) => {
@@ -113,7 +116,7 @@ impl LedgerTransaction for OpaSubmitTransaction {
                 match self {
                     Self::BootstrapRoot(submission, _) => submission,
                     Self::RotateRoot(submission, _) => submission,
-                    Self::RegisterKey(submission, _, _) => submission,
+                    Self::RegisterKey(submission, _, _, _) => submission,
                     Self::RotateKey(submission, _, _) => submission,
                     Self::SetPolicy(submission, _, _) => submission,
                 },

--- a/crates/opactl/src/cli.rs
+++ b/crates/opactl/src/cli.rs
@@ -1,7 +1,7 @@
 use clap::{
     builder::{NonEmptyStringValueParser, PathBufValueParser},
     parser::ValueSource,
-    Arg, ArgMatches, Command, ValueHint,
+    Arg, ArgAction, ArgMatches, Command, ValueHint,
 };
 use k256::{pkcs8::DecodePrivateKey, SecretKey};
 use rand::rngs::StdRng;
@@ -103,7 +103,7 @@ fn register_key() -> Command {
                     .required(true)
                     .num_args(1)
                     .value_hint(ValueHint::FilePath)
-                    .help("The path of a PEM encoded key to register"),
+                    .help("The path of a PEM-encoded key to register"),
             )
             .arg(
                 Arg::new("root-key")
@@ -123,7 +123,14 @@ fn register_key() -> Command {
                     .num_args(1)
                     .value_hint(ValueHint::Unknown)
                     .value_parser(NonEmptyStringValueParser::new())
-                    .help("The path of the new key to register as the root key"),
+                    .help("The id of the key"),
+            )
+            .arg(
+                Arg::new("overwrite")
+                    .short('o')
+                    .long("overwrite")
+                    .action(ArgAction::SetTrue)
+                    .help("Replace any existing non-root key"),
             )
             .arg(transactor_key()),
     )

--- a/crates/opactl/src/main.rs
+++ b/crates/opactl/src/main.rs
@@ -231,14 +231,24 @@ async fn dispatch_args<
             let new_key: SigningKey = load_key_from_match("new-key", matches).into();
             let id = matches.get_one::<String>("id").unwrap();
             let transactor_key: SigningKey = load_key_from_match("transactor-key", matches).into();
-            let register_key =
-                SubmissionBuilder::register_key(id, &new_key.verifying_key(), &current_root_key)
-                    .build(span_id);
+            let overwrite_existing = matches.get_flag("overwrite");
+            let register_key = SubmissionBuilder::register_key(
+                id,
+                &new_key.verifying_key(),
+                &current_root_key,
+                overwrite_existing,
+            )
+            .build(span_id);
             Ok(handle_wait(
                 matches,
                 reader,
                 writer,
-                OpaSubmitTransaction::register_key(id, register_key, &transactor_key),
+                OpaSubmitTransaction::register_key(
+                    id,
+                    register_key,
+                    &transactor_key,
+                    overwrite_existing,
+                ),
                 &transactor_key,
             )
             .await?)

--- a/docs/opa.md
+++ b/docs/opa.md
@@ -215,6 +215,9 @@ processor.
   the PEM-encoded private key to be used for signing the transaction. If not
   specified, an ephemeral key will be generated.
 
+- `--overwrite` (`-o`): An optional flag allowing re-registration of a
+  non-root key.
+
 #### `register-key` Example
 
 ```bash


### PR DESCRIPTION
Addresses CHRON-213 by adding `--overwrite` to ignore existing keys.

Especially check that the `tp.rs` tests actually test for the desired behavior correctly.