### PR TITLE
improve opactl whitespace handling with keys

### DIFF
--- a/crates/opactl/src/cli.rs
+++ b/crates/opactl/src/cli.rs
@@ -311,11 +311,11 @@ pub(crate) fn load_key_from_match(name: &str, matches: &ArgMatches) -> SecretKey
             let path: &String = matches.get_one(name).unwrap();
             let key = std::fs::read_to_string(path)
                 .unwrap_or_else(|_| panic!("Unable to read file {path}"));
-            SecretKey::from_pkcs8_pem(&key).unwrap()
+            SecretKey::from_pkcs8_pem(key.trim()).unwrap()
         }
         ValueSource::EnvVariable => {
             let key: &String = matches.get_one(name).unwrap();
-            SecretKey::from_pkcs8_pem(key).unwrap()
+            SecretKey::from_pkcs8_pem(key.trim()).unwrap()
         }
         _ => unreachable!(),
     }

--- a/crates/opactl/src/main.rs
+++ b/crates/opactl/src/main.rs
@@ -200,7 +200,7 @@ async fn dispatch_args<
                 let mut file = File::create(path).unwrap();
                 file.write_all(key.as_bytes()).unwrap();
             } else {
-                println!("{}", *key);
+                print!("{}", *key);
             }
 
             Ok(Waited::NoWait)
@@ -305,7 +305,7 @@ async fn dispatch_args<
                 let mut file = File::create(path).unwrap();
                 file.write_all(key.as_bytes()).unwrap();
             } else {
-                println!("{key}");
+                print!("{key}");
             }
 
             Ok(Waited::NoWait)


### PR DESCRIPTION
Has `opactl` not add a blank line if printing new keys to stdout, and not mind trailing blank lines on reading. Previously, `generate` could write data that `register-key` could not read.