### PR TITLE
Import Chronicle operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,6 +145,7 @@ checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
 name = "api"
 version = "0.6.0"
 dependencies = [
+ "assert_fs",
  "async-graphql",
  "async-graphql-poem",
  "async-sawtooth-sdk",

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -59,6 +59,7 @@ uuid = { workspace = true }
 
 [dev-dependencies]
 chronicle-protocol = { path = "../chronicle-protocol" }
+assert_fs          = { workspace = true }
 insta              = { workspace = true, features = ["json", "yaml"] }
 opa-tp-protocol    = { path = "../opa-tp-protocol" }
 tempfile           = { workspace = true }

--- a/crates/chronicle/src/bootstrap/cli.rs
+++ b/crates/chronicle/src/bootstrap/cli.rs
@@ -1060,7 +1060,29 @@ impl SubCommand for CliModel {
                         .help("which API endpoints to offer")
                     ),
             )
-            .subcommand(Command::new("verify-keystore").about("Initialize and verify keystore, then exit"));
+            .subcommand(Command::new("verify-keystore").about("Initialize and verify keystore, then exit"))
+            .subcommand(
+                Command::new("import")
+                    .about("Import and apply Chronicle operations, then exit")
+                    .arg(
+                        Arg::new("namespace-id")
+                            .value_name("NAMESPACE_ID")
+                            .help("External ID of the namespace to import into")
+                            .required(true)
+                    )
+                    .arg(
+                        Arg::new("namespace-uuid")
+                            .value_name("NAMESPACE_UUID")
+                            .help("UUID of the namespace to import into")
+                            .required(true)
+                    )
+                    .arg(
+                        Arg::new("path")
+                            .value_name("PATH")
+                            .help("Path to data import file")
+                            .value_hint(ValueHint::FilePath)
+                    )
+            );
 
         for agent in self.agents.iter() {
             app = app.subcommand(agent.as_cmd());

--- a/crates/common/src/commands.rs
+++ b/crates/common/src/commands.rs
@@ -9,8 +9,9 @@ use serde::{Deserialize, Serialize};
 use crate::{
     attributes::Attributes,
     prov::{
-        operations::DerivationType, ActivityId, AgentId, ChronicleIri, ChronicleTransactionId,
-        EntityId, ExternalId, ProvModel, Role,
+        operations::{ChronicleOperation, DerivationType},
+        ActivityId, AgentId, ChronicleIri, ChronicleTransactionId, EntityId, ExternalId,
+        NamespaceId, ProvModel, Role,
     },
 };
 
@@ -311,12 +312,19 @@ pub struct QueryCommand {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ImportCommand {
+    pub namespace: NamespaceId,
+    pub operations: Vec<ChronicleOperation>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ApiCommand {
     NameSpace(NamespaceCommand),
     Agent(AgentCommand),
     Activity(ActivityCommand),
     Entity(EntityCommand),
     Query(QueryCommand),
+    Import(ImportCommand),
 }
 
 #[derive(Debug)]
@@ -336,6 +344,11 @@ pub enum ApiResponse {
     },
     /// The api has successfully executed the query
     QueryReply { prov: Box<ProvModel> },
+    /// The api has submitted the import transactions to a ledger
+    ImportSubmitted {
+        prov: Box<ProvModel>,
+        tx_id: ChronicleTransactionId,
+    },
 }
 
 impl ApiResponse {
@@ -365,6 +378,13 @@ impl ApiResponse {
         ApiResponse::AlreadyRecorded {
             subject: subject.into(),
             prov: Box::new(prov),
+        }
+    }
+
+    pub fn import_submitted(prov: ProvModel, tx_id: ChronicleTransactionId) -> Self {
+        ApiResponse::ImportSubmitted {
+            prov: Box::new(prov),
+            tx_id,
         }
     }
 }

--- a/crates/common/src/prov/operations.rs
+++ b/crates/common/src/prov/operations.rs
@@ -318,6 +318,34 @@ pub enum ChronicleOperation {
     WasInformedBy(WasInformedBy),
 }
 
+impl ChronicleOperation {
+    /// Returns a reference to the `NamespaceId` of the `ChronicleOperation`
+    pub fn namespace(&self) -> &NamespaceId {
+        match self {
+            ChronicleOperation::ActivityExists(o) => &o.namespace,
+            ChronicleOperation::AgentExists(o) => &o.namespace,
+            ChronicleOperation::AgentActsOnBehalfOf(o) => &o.namespace,
+            ChronicleOperation::CreateNamespace(o) => &o.id,
+            ChronicleOperation::RegisterKey(o) => &o.namespace,
+            ChronicleOperation::StartActivity(o) => &o.namespace,
+            ChronicleOperation::EndActivity(o) => &o.namespace,
+            ChronicleOperation::ActivityUses(o) => &o.namespace,
+            ChronicleOperation::EntityExists(o) => &o.namespace,
+            ChronicleOperation::WasGeneratedBy(o) => &o.namespace,
+            ChronicleOperation::EntityDerive(o) => &o.namespace,
+            ChronicleOperation::EntityHasEvidence(o) => &o.namespace,
+            ChronicleOperation::SetAttributes(o) => match o {
+                SetAttributes::Activity { namespace, .. } => namespace,
+                SetAttributes::Agent { namespace, .. } => namespace,
+                SetAttributes::Entity { namespace, .. } => namespace,
+            },
+            ChronicleOperation::WasAssociatedWith(o) => &o.namespace,
+            ChronicleOperation::WasAttributedTo(o) => &o.namespace,
+            ChronicleOperation::WasInformedBy(o) => &o.namespace,
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use chrono::{TimeZone, Utc};

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -80,6 +80,44 @@ Write the GraphQL SDL for Chronicle to stdout and exit.
 
 Installs shell completions for bash, zsh, or fish.
 
+### `import` <`namespace-id`> <`namespace-uuid`> <`path`>
+
+The import command is used to load data from a JSON-LD file containing an
+array of Chronicle Operations. This command requires two arguments:
+`namespace-id` and `namespace-uuid`, which are used to create a unique
+identifier for the namespace that the data is being imported to. The
+`NamespaceId` is a required argument for the import command because it
+allows the program to differentiate between different namespaces and avoid
+conflicts when importing data.
+
+By default, `import` will use standard input as its data source. Users can
+also use an optional `path` argument to specify the file path of a JSON-LD
+file to be imported.
+
+Once the data has been successfully imported, the Chronicle Operations will
+be added to the Chronicle database under the specified namespace.
+
+To import to namespace `testns`, UUID 6803790d-5891-4dfa-b773-41827d2c630b
+from standard input:
+
+```bash
+< import.json cargo run --bin chronicle \
+    -- import \
+    testns \
+    6803790d-5891-4dfa-b773-41827d2c630b
+```
+
+To import from a file named import.json, run the following command:
+
+```bash
+chronicle \
+    --bin chronicle \
+    -- import \
+    testns \
+    6803790d-5891-4dfa-b773-41827d2c630b \
+    import.json
+```
+
 ## Other Subcommands
 
 Chronicle will also generate subcommands for recording provenance, derived from

--- a/docs/recording_provenance.md
+++ b/docs/recording_provenance.md
@@ -875,3 +875,152 @@ and signing.
 
 The current `hasAttachment` mutation is intended for recording but is not yet
 usable.
+
+## Importing Data into Chronicle
+
+Chronicle provides a CLI command `import` to load data from a JSON-LD file that
+contains an array of Chronicle Operations. These operations can be used to
+create agents, namespaces, and other resources in the Chronicle database.
+
+To import data into Chronicle, follow these steps:
+
+- Create a JSON-LD file with an array of Chronicle Operations.
+- Save the file in the Chronicle root directory with a unique name, for example,
+  `import.json`.
+- Run the following command:
+
+  ```bash
+  chronicle --bin chronicle -- import <namespace-id> <namespace-uuid> <path-to-json-file>
+  ```
+
+  where:
+
+  `<namespace-id>`: the name of the namespace to which the data will be imported.
+  `<namespace-uuid>`: the UUID of the namespace to which the data will be imported.
+  `<path-to-json-file>`: the path to the JSON-LD file containing the Chronicle Operations.
+
+- If the data is successfully imported, the Chronicle Operations will be added
+  to the Chronicle database.
+
+For example, suppose you want to create a new agent with the name `testagent`
+and a new namespace with the name `testns`. You can add the following
+operations to your JSON-LD file:
+
+```json
+[
+    {
+        "@id": "_:n1",
+        "@type": [
+        "http://btp.works/chronicleoperations/ns#SetAttributes"
+        ],
+        "http://btp.works/chronicleoperations/ns#agentName": [
+        {
+            "@value": "testagent"
+        }
+        ],
+        "http://btp.works/chronicleoperations/ns#attributes": [
+        {
+            "@type": "@json",
+            "@value": {}
+        }
+        ],
+        "http://btp.works/chronicleoperations/ns#domaintypeId": [
+        {
+            "@value": "type"
+        }
+        ],
+        "http://btp.works/chronicleoperations/ns#namespaceName": [
+        {
+            "@value": "testns"
+        }
+        ],
+        "http://btp.works/chronicleoperations/ns#namespaceUuid": [
+        {
+            "@value": "6803790d-5891-4dfa-b773-41827d2c630b"
+        }
+        ]
+    },
+    {
+        "@id": "_:n1",
+        "@type": [
+        "http://btp.works/chronicleoperations/ns#CreateNamespace"
+        ],
+        "http://btp.works/chronicleoperations/ns#namespaceName": [
+        {
+            "@value": "testns"
+        }
+        ],
+        "http://btp.works/chronicleoperations/ns#namespaceUuid": [
+        {
+            "@value": "6803790d-5891-4dfa-b773-41827d2c630b"
+        }
+        ]
+    },
+    {
+        "@id": "_:n1",
+        "@type": [
+        "http://btp.works/chronicleoperations/ns#AgentExists"
+        ],
+        "http://btp.works/chronicleoperations/ns#agentName": [
+        {
+            "@value": "testagent"
+        }
+        ],
+        "http://btp.works/chronicleoperations/ns#namespaceName": [
+        {
+            "@value": "testns"
+        }
+        ],
+        "http://btp.works/chronicleoperations/ns#namespaceUuid": [
+        {
+            "@value": "6803790d-5891-4dfa-b773-41827d2c630b"
+        }
+        ]
+    }
+]
+```
+
+To import data into Chronicle using the `import` command, you need to provide
+the `namespace-id` and `namespace-uuid` arguments. These arguments are required
+to specify the namespace to which the imported data will be imported.
+
+The `namespace-id` argument is a string that specifies the name of the namespace
+to which the data will be imported. This value should match the value of the
+`http://btp.works/chronicleoperations/ns#namespaceName` property in the JSON-LD
+file.
+
+The `namespace-uuid` argument is a string that specifies the UUID of the
+namespace to which the data will be imported. This value should match the value
+of the `http://btp.works/chronicleoperations/ns#namespaceUuid` property in the
+JSON-LD file.
+
+Once you have provided the `namespace-id` and `namespace-uuid` arguments, you
+can run the `import` command using the JSON-LD file containing the Chronicle
+operations as the data source. If the data is successfully imported, the
+Chronicle Operations will be added to the Chronicle database.
+
+In the example provided, the `import` command imports data from the `import.json`
+file into the namespace with the name `testns` and the UUID
+`6803790d-5891-4dfa-b773-41827d2c630b`. The JSON-LD file contains three
+Chronicle Operations that set the attributes of a new agent with the name
+`testagent`, create a new namespace with the name `testns`, and create the new
+agent `testagent` in the namespace `testns`.
+
+To run the transaction described above, run the following command:
+
+```bash
+chronicle --bin chronicle -- import testns 6803790d-5891-4dfa-b773-41827d2c630b import.json
+```
+
+`import` uses standard input as its data source by default. To import data from
+standard input run the `import` command like this:
+
+```bash
+< import.json cargo run --bin chronicle \
+    -- import \
+    testns \
+    6803790d-5891-4dfa-b773-41827d2c630b
+```
+
+If the `import` command is executed successfully, the agent `testagent` and
+the namespace `testns` will be created in the Chronicle database.


### PR DESCRIPTION
Using Chronicle operations' JSON-LD serialization as an ETL format, this adds an `import` command to Chronicle's CLI that can import Chronicle data stored as a JSON-LD array. For example, here's import data for importing a `CreateNamespace` operation:

```json
[
    {
        "@id": "_:n1",
        "@type": [
        "http://btp.works/chronicleoperations/ns#CreateNamespace"
        ],
        "http://btp.works/chronicleoperations/ns#namespaceName": [
        {
            "@value": "testns"
        }
        ],
        "http://btp.works/chronicleoperations/ns#namespaceUuid": [
        {
            "@value": "6803790d-5891-4dfa-b773-41827d2c630b"
        }
        ]
    }
]
```
To try this (assuming you have Postgres set up) copy the above to a file called `import.json` in the Chronicle root directory and run

```bash
cargo run --bin chronicle \
    --features inmem \
    -- import \
    testns \
    6803790d-5891-4dfa-b773-41827d2c630b \
    import.json
```
or

```bash
< import.json cargo run --bin chronicle \
    --features inmem \
    -- import \
    testns \
    6803790d-5891-4dfa-b773-41827d2c630b
```

We import data to Chronicle by namespace. If import data consists of data for multiple namespaces, we can run multiple imports specifying a different namespace for each run as necessary.

---

Signed-off-by: Joseph Livesey [joseph.livesey@btp.works](mailto:joseph.livesey@btp.works)

[CHRON-304](https://blockchaintp.atlassian.net/browse/CHRON-304)
(subtask of: [CHRON-283](https://blockchaintp.atlassian.net/browse/CHRON-283))

[CHRON-304]: https://blockchaintp.atlassian.net/browse/CHRON-304?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CHRON-283]: https://blockchaintp.atlassian.net/browse/CHRON-283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ