### PR TITLE
Chronicle operations as Synth schema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,6 +87,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "anstream"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -752,6 +761,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "chronicle-synth"
+version = "0.6.0"
+dependencies = [
+ "assert_fs",
+ "chronicle",
+ "insta",
+ "maplit",
+ "owo-colors",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "structopt",
+ "thiserror",
+]
+
+[[package]]
 name = "chronicle-telemetry"
 version = "0.6.0"
 dependencies = [
@@ -810,6 +835,21 @@ dependencies = [
 
 [[package]]
 name = "clap"
+version = "2.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+dependencies = [
+ "ansi_term",
+ "atty",
+ "bitflags",
+ "strsim 0.8.0",
+ "textwrap 0.11.0",
+ "unicode-width",
+ "vec_map",
+]
+
+[[package]]
+name = "clap"
 version = "3.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
@@ -820,9 +860,9 @@ dependencies = [
  "clap_lex 0.2.4",
  "indexmap",
  "once_cell",
- "strsim",
+ "strsim 0.10.0",
  "termcolor",
- "textwrap",
+ "textwrap 0.16.0",
 ]
 
 [[package]]
@@ -846,7 +886,7 @@ dependencies = [
  "anstyle",
  "bitflags",
  "clap_lex 0.4.1",
- "strsim",
+ "strsim 0.10.0",
 ]
 
 [[package]]
@@ -864,7 +904,7 @@ version = "3.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -877,7 +917,7 @@ version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9644cd56d6b87dbe899ef8b053e331c0637664e9e21a33dfcdc36093f5c5c4"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.15",
@@ -1407,7 +1447,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.10.0",
  "syn 1.0.109",
 ]
 
@@ -1421,7 +1461,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.10.0",
  "syn 1.0.109",
 ]
 
@@ -2099,6 +2139,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
 dependencies = [
  "http",
+]
+
+[[package]]
+name = "heck"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+dependencies = [
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -2823,6 +2872,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
 name = "matchers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3402,6 +3457,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
+name = "owo-colors"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
+
+[[package]]
 name = "parking"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3844,7 +3905,7 @@ dependencies = [
  "bytes",
  "cfg-if",
  "cmake",
- "heck",
+ "heck 0.4.1",
  "itertools",
  "lazy_static",
  "log",
@@ -4772,9 +4833,39 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "structopt"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
+dependencies = [
+ "clap 2.34.0",
+ "lazy_static",
+ "structopt-derive",
+]
+
+[[package]]
+name = "structopt-derive"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
+dependencies = [
+ "heck 0.3.3",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "subtle"
@@ -4870,6 +4961,15 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -5305,6 +5405,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5413,6 +5519,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
   "crates/chronicle-domain-lint",
   "crates/chronicle-domain-test",
   "crates/chronicle-protocol",
+  "crates/chronicle-synth",
   "crates/opa-tp-protocol",
   "crates/opactl",
   "crates/sawtooth-tp",
@@ -68,6 +69,7 @@ k256 = { version = "0.11.3", features = [
 ] }
 lazy_static = "1.4.0"
 locspan = "0.7"
+maplit = "1.0.2"
 mime = "0.3"
 opa = "0.9.0"
 openssl = "0.10.48"
@@ -77,6 +79,7 @@ opentelemetry-jaeger = { version = "0.17.0", features = [
   "reqwest_collector_client",
   "collector_client",
 ] }
+owo-colors = "3.5.0"
 parking_lot = "0.12.0"
 percent-encoding = "2.1.0"
 pin-project = "1.0.12"
@@ -106,6 +109,7 @@ serde_json = "1.0.93"
 serde_yaml = "0.9.14"
 shellexpand = "3.0.0"
 static-iref = "2.0.0"
+structopt = "0.3.26"
 temp-dir = "0.1.11"
 tempfile = "3.4.0"
 testcontainers = "0.14"

--- a/crates/chronicle-synth/.gitignore
+++ b/crates/chronicle-synth/.gitignore
@@ -1,0 +1,3 @@
+/collections
+/domain-schema
+/target

--- a/crates/chronicle-synth/Cargo.toml
+++ b/crates/chronicle-synth/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "chronicle-synth"
+version = "0.6.0"
+edition = "2021"
+
+[lib]
+name = "chronicle_synth"
+path = "src/lib.rs"
+
+[[bin]]
+name = "chronicle-synth"
+path = "src/generate.rs"
+
+[dependencies]
+chronicle = { path = "../chronicle" }
+maplit = {  workspace = true }
+owo-colors = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+serde_yaml = { workspace = true }
+structopt = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+assert_fs = { workspace = true }
+insta = { workspace = true, features = ["json"] }

--- a/crates/chronicle-synth/Makefile
+++ b/crates/chronicle-synth/Makefile
@@ -1,0 +1,4 @@
+clean:
+	rm -rf collections
+	rm -rf domain-schema
+	git checkout exclude_collections.json

--- a/crates/chronicle-synth/README.md
+++ b/crates/chronicle-synth/README.md
@@ -1,0 +1,96 @@
+# Chronicle Synth
+
+Chronicle Domain [Synth](https://www.getsynth.com/) is a program for
+generating Synth schema for Chronicle. It takes a YAML file as input,
+which contains information about the domain's name, attributes,
+entities, activities, agents, and roles, and generates Synth collections
+that can be used to generate the Chronicle operations available to a
+domain's users.
+
+If you just want to generate untyped Chronicle operations with `synth`
+the collections in `crates/chronicle-synth/synth/` are ready to go.
+
+The core functionality of Chronicle Synth is to generate the
+additional Synth schema specific to each individual Chronicle domain.
+Replace the `domain.yaml` file in `crates/chronicle-synth/` with your
+domain and run
+
+```bash
+cargo run --bin chronicle
+```
+
+Run the `generate` script to generate a set of each operation available
+to your domain:
+
+```bash
+cd crates/chronicle-synth && \
+./generate
+```
+
+## Prerequisites
+
+To use Chronicle Synth, you need to have Synth installed on
+your system. If you don't have it already installed, you can follow
+the [instructions](https://www.getsynth.com/docs/getting_started/installation)
+in the Synth documentation to install it.
+
+## Usage
+
+### Loading domain.yaml Chronicle Domain Definitions
+
+To use Chronicle Synth, you must have a YAML file that
+describes your domain. The file should have the following structure:
+
+```yaml
+name: DomainName
+attributes:
+  AttributeName:
+    type: AttributeType
+entities:
+  EntityName:
+    attributes:
+      - AttributeName1
+      - AttributeName2
+activities:
+  ActivityName:
+    attributes:
+      - AttributeName1
+      - AttributeName2
+agents:
+  AgentName:
+    attributes:
+      - AttributeName1
+roles:
+  - RoleName1
+  - RoleName2
+```
+
+Once you have your YAML file, you can generate Synth schema by running
+the following command:
+
+```bash
+chronicle-synth <path-to-yaml-file>
+```
+
+Or, since `<path-to-yaml-file>` defaults to ./crates/synth/domain.yaml,
+if your YAML file is named domain.yaml, you can simply run:
+
+```bash
+cargo run --bin chronicle-synth --
+```
+
+This will output the additional Synth schema required to generate
+synth data for your domain to the `domain_schema` directory, and collate
+the core Chronicle Synth collections along with the generated collections
+specific to your domain in `collections`.
+
+### Generating Your Domain's Synth Data
+
+Chronicle Synth includes a `generate` script, which will print
+a synth-example of each Chronicle operation in your domain.
+
+#### Example
+
+```bash
+./crates/chronicle-synth/generate | jq
+```

--- a/crates/chronicle-synth/collect
+++ b/crates/chronicle-synth/collect
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# This script collates Synth collections generated for
+# a Chronicle domain (which are writtent to 'domain-schema/')
+# with the core set of Chronicle Synth collections (found
+# in 'chronicle-synth/synth/') and copies them to the
+# 'chronicle-synth/collections/' directory.
+#
+# It is run as part of the 'Rust program' defined in the
+# 'chronicle-synth/src/generate.rs' binary.
+
+# Define the source directories
+source_dir1="./crates/chronicle-synth/synth"
+source_dir2="./crates/chronicle-synth/domain-schema"
+
+# Define the destination directory
+dest_dir="./crates/chronicle-synth/collections"
+
+# Create the destination directory if it doesn't exist
+if [ ! -d "${dest_dir}" ]; then
+    mkdir "${dest_dir}"
+fi
+
+# Copy files from source_dir1 to dest_dir
+for file in "${source_dir1}"/*; do
+    filename=$(basename "${file}")
+    if [ -f "${dest_dir}/${filename}" ]; then
+        echo "Replacing file: ${filename}"
+    fi
+    cp -f "${file}" "${dest_dir}"
+done
+
+# Copy files from source_dir2 to dest_dir
+for file in "${source_dir2}"/*; do
+    filename=$(basename "${file}")
+    if [ -f "${dest_dir}/${filename}" ]; then
+        echo "Replacing file: ${filename}"
+    else
+        echo "Copying file: ${filename}"
+    fi
+    cp -f "${file}" "${dest_dir}"
+done

--- a/crates/chronicle-synth/domain.yaml
+++ b/crates/chronicle-synth/domain.yaml
@@ -1,0 +1,6 @@
+name: "untyped"
+attributes: {}
+entities: {}
+activities: {}
+agents: {}
+roles: []

--- a/crates/chronicle-synth/exclude_collections.json
+++ b/crates/chronicle-synth/exclude_collections.json
@@ -1,0 +1,21 @@
+{
+    "exclude": [
+      "activity_name",
+      "agent_name",
+      "attribute",
+      "attributes",
+      "earlier_date_time",
+      "later_date_time",
+      "domain_type_id",
+      "entity_name",
+      "namespace",
+      "namespace_uuid",
+      "role",
+      "roles",
+      "same_namespace_name",
+      "same_namespace_uuid",
+      "second_activity_name",
+      "second_agent_name",
+      "second_entity_name"
+    ]
+  }

--- a/crates/chronicle-synth/generate
+++ b/crates/chronicle-synth/generate
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# This script generates a JSON array of Synth collections from
+# those found in the 'chronicle-synth/collections/' directory.
+#
+# It is not designed to be definitive, but rather to provide a
+# starting point for generating Synth data for Chronicle using
+# Chronicle Synth.
+
+# Populate an array of collections to exclude from a file
+# Exclude component Synth generators, while including collections
+# that generate Chronicle operations
+exclude_file="./exclude_collections.json"
+exclude_collections=$(jq -r '.exclude[]' "$exclude_file")
+
+# Initialize an empty array to store the collections
+collections=()
+
+# Get the list of .json files and exclude some collections
+for file in collections/*.json
+do
+  filename=$(basename "$file")
+  collection=${filename%.*}
+  if [[ ! " ${exclude_collections[*]} " =~ ${collection} ]]; then
+    collections+=("$collection")
+  fi
+done
+
+# Initialize an empty JSON array
+json_array="["
+
+# Loop through each collection
+for collection in "${collections[@]}"
+do
+  # Generate a JSON object using the 'synth' command and 'jq' utility
+  json_object=$(synth generate ./collections --collection "$collection" --size 1 --random | jq -c '.')
+
+  # Append the JSON object to the JSON array
+  json_array="${json_array}${json_object},"
+done
+
+# Remove the trailing comma and close the JSON array
+json_array="${json_array%?}]"
+
+# Output the JSON array
+echo "$json_array"

--- a/crates/chronicle-synth/src/collection.rs
+++ b/crates/chronicle-synth/src/collection.rs
@@ -1,0 +1,218 @@
+use std::{
+    fmt::Display,
+    fs::File,
+    path::{Path, PathBuf},
+};
+
+use serde_json::Value;
+
+use crate::error::ChronicleSynthError;
+
+/// Represents a Synth collection that generates a Chronicle operation or component-generator of an operation collection.
+#[derive(Debug)]
+pub enum Collection {
+    Operation(Operation),
+    Generator(Generator),
+}
+
+/// `Operation` refers to a Synth schema collection that generates a Chronicle operation.
+/// An `Operation` usually has dependencies in the form of component [`Generator`]s.
+#[derive(Debug)]
+pub enum Operation {
+    ActivityExists,
+    ActivityUses,
+    AgentActsOnBehalfOf,
+    AgentExists,
+    CreateNamespace,
+    EndActivity,
+    EntityDerive,
+    EntityExists,
+    SetActivityAttributes,
+    SetAgentAttributes,
+    SetEntityAttributes,
+    StartActivity,
+    WasAssociatedWith,
+    WasAssociatedWithHasRole,
+    WasAttributedTo,
+    WasGeneratedBy,
+    WasInformedBy,
+    DomainCollection(DomainCollection),
+}
+
+/// `Generator` refers to a Synth schema collection that generates a component of a Chronicle
+/// operation, as opposed to being an operation itself. A `Generator` should have no dependencies.
+#[derive(Debug)]
+pub enum Generator {
+    ActivityName,
+    SecondActivityName,
+    AgentName,
+    SecondAgentName,
+    Attribute,
+    Attributes,
+    DateTime,
+    DomainTypeId,
+    EntityName,
+    SecondEntityName,
+    Namespace,
+    NamespaceUuid,
+    Role,
+    Roles,
+    SameNamespaceName,
+    SameNamespaceUuid,
+    DomainCollection(DomainCollection),
+}
+
+/// Represents a Synth collection that is generated specifically for a Chronicle domain.
+#[derive(Debug)]
+pub struct DomainCollection {
+    pub name: String,
+    pub schema: Value,
+}
+
+impl DomainCollection {
+    pub fn new(name: impl Into<String>, schema: Value) -> Self {
+        let name = name.into();
+        Self { name, schema }
+    }
+}
+
+pub trait CollectionHandling {
+    fn name(&self) -> String
+    where
+        Self: Display,
+    {
+        self.to_string()
+    }
+
+    fn path(&self) -> PathBuf
+    where
+        Self: Display,
+    {
+        Path::new(&format!("{}.json", self)).to_path_buf()
+    }
+
+    fn json_schema(&self) -> Result<Value, ChronicleSynthError>
+    where
+        Self: Display;
+}
+
+impl From<Operation> for Collection {
+    fn from(operation: Operation) -> Self {
+        Self::Operation(operation)
+    }
+}
+
+impl From<Generator> for Collection {
+    fn from(generator: Generator) -> Self {
+        Self::Generator(generator)
+    }
+}
+
+impl Display for Collection {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Collection::Operation(operation) => write!(f, "{}", operation),
+            Collection::Generator(generator) => write!(f, "{}", generator),
+        }
+    }
+}
+
+impl CollectionHandling for Collection {
+    fn json_schema(&self) -> Result<Value, ChronicleSynthError> {
+        match self {
+            Collection::Operation(operation) => operation.json_schema(),
+            Collection::Generator(generator) => generator.json_schema(),
+        }
+    }
+}
+
+impl CollectionHandling for Operation {
+    fn json_schema(&self) -> Result<Value, ChronicleSynthError>
+    where
+        Self: Display,
+    {
+        match self {
+            Self::DomainCollection(domain_collection) => Ok(domain_collection.schema.to_owned()),
+            _ => {
+                let path = self.path();
+                let reader = File::open(path)?;
+                let schema: serde_json::Value = serde_json::from_reader(reader)?;
+                Ok(schema)
+            }
+        }
+    }
+}
+
+impl Display for Operation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::ActivityExists => "activity_exists",
+                Self::ActivityUses => "activity_uses",
+                Self::AgentActsOnBehalfOf => "agent_acts_on_behalf_of",
+                Self::AgentExists => "agent_exists",
+                Self::CreateNamespace => "create_namespace",
+                Self::EndActivity => "end_activity",
+                Self::EntityDerive => "entity_derive",
+                Self::EntityExists => "entity_exists",
+                Self::SetActivityAttributes => "set_activity_attributes",
+                Self::SetAgentAttributes => "set_agent_attributes",
+                Self::SetEntityAttributes => "set_entity_attributes",
+                Self::StartActivity => "start_activity",
+                Self::WasAssociatedWith => "was_associated_with",
+                Self::WasAssociatedWithHasRole => "was_associated_with_has_role",
+                Self::WasAttributedTo => "was_attributed_to",
+                Self::WasGeneratedBy => "was_generated_by",
+                Self::WasInformedBy => "was_informed_by",
+                Self::DomainCollection(domain_collection) => &domain_collection.name,
+            }
+        )
+    }
+}
+
+impl CollectionHandling for Generator {
+    fn json_schema(&self) -> Result<Value, ChronicleSynthError>
+    where
+        Self: Display,
+    {
+        match self {
+            Self::DomainCollection(domain_collection) => Ok(domain_collection.schema.to_owned()),
+            _ => {
+                let path = self.path();
+                let reader = File::open(path)?;
+                let schema: serde_json::Value = serde_json::from_reader(reader)?;
+                Ok(schema)
+            }
+        }
+    }
+}
+
+impl Display for Generator {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::ActivityName => "activity_name",
+                Self::SecondActivityName => "second_activity_name",
+                Self::AgentName => "agent_name",
+                Self::SecondAgentName => "second_agent_name",
+                Self::Attribute => "attribute",
+                Self::Attributes => "attributes",
+                Self::DateTime => "date_time",
+                Self::DomainTypeId => "domain_type_id",
+                Self::EntityName => "entity_name",
+                Self::SecondEntityName => "second_entity_name",
+                Self::Namespace => "namespace",
+                Self::NamespaceUuid => "namespace_uuid",
+                Self::Role => "role",
+                Self::Roles => "roles",
+                Self::SameNamespaceName => "same_namespace_name",
+                Self::SameNamespaceUuid => "same_namespace_uuid",
+                Self::DomainCollection(dc) => &dc.name,
+            }
+        )
+    }
+}

--- a/crates/chronicle-synth/src/domain.rs
+++ b/crates/chronicle-synth/src/domain.rs
@@ -1,0 +1,367 @@
+use std::{collections::BTreeMap, path::Path};
+
+use chronicle::codegen::model::PrimitiveType;
+use serde::Deserialize;
+use serde_json::json;
+
+use crate::{
+    collection::{Collection, DomainCollection, Generator, Operation},
+    error::ChronicleSynthError,
+};
+
+#[derive(Debug)]
+pub struct TypesAttributesRoles {
+    pub name: String,
+    entities: BTreeMap<ParsedDomainType, BTreeMap<AttributeType, SynthType>>,
+    agents: BTreeMap<ParsedDomainType, BTreeMap<AttributeType, SynthType>>,
+    activities: BTreeMap<ParsedDomainType, BTreeMap<AttributeType, SynthType>>,
+    roles: Vec<Role>,
+}
+
+impl TypesAttributesRoles {
+    /// Creates a new `TypesAttributesRoles` instance from a YAML file at the specified path.
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - The path to the YAML file.
+    ///
+    /// # Returns
+    ///
+    /// A `Result` containing the `TypesAttributesRoles` instance, or an error if the operation fails.
+    pub fn from_file(path: &Path) -> Result<Self, ChronicleSynthError> {
+        #[derive(Debug, Deserialize)]
+        struct ChronicleDomain {
+            #[serde(skip)]
+            _roles_doc: Option<String>,
+            roles: Vec<Role>,
+            name: String,
+            attributes: BTreeMap<AttributeType, ChroniclePrimitive>,
+            entities: BTreeMap<ParsedDomainType, Attributes>,
+            agents: BTreeMap<ParsedDomainType, Attributes>,
+            activities: BTreeMap<ParsedDomainType, Attributes>,
+        }
+
+        impl ChronicleDomain {
+            fn from_path(path: &Path) -> Result<Self, ChronicleSynthError> {
+                let yaml: String = std::fs::read_to_string(path)?;
+                let domain: ChronicleDomain = serde_yaml::from_str(&yaml)?;
+                Ok(domain)
+            }
+        }
+
+        impl From<ChronicleDomain> for TypesAttributesRoles {
+            fn from(value: ChronicleDomain) -> Self {
+                let mut attribute_types = BTreeMap::new();
+                attribute_types.extend(value.attributes.into_iter());
+
+                let entities = value
+                    .entities
+                    .into_iter()
+                    .map(|(entity_type, attributes)| {
+                        (
+                            entity_type,
+                            attributes.link_attribute_types(&mut attribute_types),
+                        )
+                    })
+                    .collect();
+                let agents = value
+                    .agents
+                    .into_iter()
+                    .map(|(agent_type, attributes)| {
+                        (
+                            agent_type,
+                            attributes.link_attribute_types(&mut attribute_types),
+                        )
+                    })
+                    .collect();
+                let activities = value
+                    .activities
+                    .into_iter()
+                    .map(|(activity_type, attributes)| {
+                        (
+                            activity_type,
+                            attributes.link_attribute_types(&mut attribute_types),
+                        )
+                    })
+                    .collect();
+
+                Self {
+                    name: value.name,
+                    entities,
+                    agents,
+                    activities,
+                    roles: value.roles,
+                }
+            }
+        }
+
+        let domain = ChronicleDomain::from_path(path)?;
+        Ok(domain.into())
+    }
+
+    pub fn generate_domain_collections(&self) -> Result<Vec<Collection>, ChronicleSynthError> {
+        let mut collections = vec![self.generate_roles()?];
+        collections.extend(self.generate_activity_schema()?);
+        collections.extend(self.generate_agent_schema()?);
+        collections.extend(self.generate_entity_schema()?);
+        Ok(collections)
+    }
+
+    fn generate_roles(&self) -> Result<Collection, ChronicleSynthError> {
+        generate_roles(&self.roles)
+    }
+
+    fn generate_activity_schema(&self) -> Result<Vec<Collection>, ChronicleSynthError> {
+        generate_schema(&self.activities)
+    }
+
+    fn generate_agent_schema(&self) -> Result<Vec<Collection>, ChronicleSynthError> {
+        generate_schema(&self.agents)
+    }
+
+    fn generate_entity_schema(&self) -> Result<Vec<Collection>, ChronicleSynthError> {
+        generate_schema(&self.entities)
+    }
+}
+
+#[derive(Debug, Deserialize, Eq, PartialEq, Hash, PartialOrd, Ord)]
+struct AttributeType(String);
+
+#[derive(Debug, Deserialize, Eq, PartialEq, Hash, PartialOrd, Ord)]
+struct ParsedDomainType(String);
+
+impl ParsedDomainType {
+    fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct Role(String);
+
+impl Role {
+    fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+#[derive(Debug)]
+enum SynthType {
+    String,
+    Object,
+    Number,
+    Bool,
+}
+
+impl From<&ChroniclePrimitive> for SynthType {
+    fn from(value: &ChroniclePrimitive) -> Self {
+        match value.r#type {
+            PrimitiveType::String => SynthType::String,
+            PrimitiveType::JSON => SynthType::Object,
+            PrimitiveType::Int => SynthType::Number,
+            PrimitiveType::Bool => SynthType::Bool,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct ChroniclePrimitive {
+    #[serde(skip)]
+    _doc: Option<String>,
+    #[serde(rename = "type")]
+    r#type: PrimitiveType,
+}
+
+#[derive(Debug, Deserialize)]
+struct Attributes {
+    #[serde(skip)]
+    _doc: Option<String>,
+    attributes: Vec<AttributeType>,
+}
+
+impl Attributes {
+    fn link_attribute_types(
+        self,
+        attribute_types: &mut BTreeMap<AttributeType, ChroniclePrimitive>,
+    ) -> BTreeMap<AttributeType, SynthType> {
+        let mut attr = BTreeMap::new();
+        for attr_type in self.attributes {
+            let r#type: SynthType = attribute_types.get(&attr_type).unwrap().into();
+            attr.insert(attr_type, r#type);
+        }
+        attr
+    }
+}
+
+fn generate_roles(roles: &[Role]) -> Result<Collection, ChronicleSynthError> {
+    let mut variants = vec![json!({
+        "type": "string",
+        "constant": "UNSPECIFIED"
+    })];
+
+    // Uppercase guaranteed by the Linter
+    for role in roles {
+        variants.push(json!({
+            "type": "string",
+            "constant": role.as_str()
+        }));
+    }
+
+    let roles = json!({
+        "type": "one_of",
+        "variants": variants
+    });
+
+    let domain_collection = DomainCollection::new("roles", roles);
+
+    Ok(Collection::Generator(Generator::DomainCollection(
+        domain_collection,
+    )))
+}
+
+fn domain_type_id_for_domain(ParsedDomainType(r#type): &ParsedDomainType) -> Collection {
+    let domain_type_id = json!({
+        "type": "string",
+        "constant": r#type
+    });
+
+    let collection_name = format!("{}_domain_type_id", r#type.to_lowercase());
+    let domain_collection = DomainCollection::new(collection_name, domain_type_id);
+
+    Collection::Generator(Generator::DomainCollection(domain_collection))
+}
+
+fn set_attributes(type_name_lower: &str) -> Collection {
+    let type_collection = format!("@{}_attributes", type_name_lower);
+    let type_domain_type = format!("@{}_domain_type_id", type_name_lower);
+    let type_attributes = json!({
+        "type": "object",
+        "@id": "_:n1",
+        "@type": {
+            "type": "array",
+            "length": 1,
+            "content": "http://btp.works/chronicleoperations/ns#SetAttributes"
+        },
+        "http://btp.works/chronicleoperations/ns#activityName": "@activity_name",
+        "http://btp.works/chronicleoperations/ns#attributes": {
+            "type": "array",
+            "length": 1,
+            "content": {
+                "type": "object",
+                "@type": {
+                    "type": "string",
+                    "constant": "@json"
+                },
+                "@value": type_collection
+            }
+        },
+        "http://btp.works/chronicleoperations/ns#domaintypeId": {
+            "type": "array",
+            "length": 1,
+            "content": {
+                "type": "object",
+                "@value": type_domain_type
+            }
+        },
+        "http://btp.works/chronicleoperations/ns#namespaceName": "@same_namespace_name",
+        "http://btp.works/chronicleoperations/ns#namespaceUuid": "@same_namespace_uuid"
+    });
+
+    let name = format!("set_{}_attributes", type_name_lower);
+    let domain_collection = DomainCollection::new(name, type_attributes);
+    Collection::Operation(Operation::DomainCollection(domain_collection))
+}
+
+fn type_attribute_variants(
+    type_name_lower: &str,
+    attributes: &BTreeMap<AttributeType, SynthType>,
+) -> Result<Collection, ChronicleSynthError> {
+    let mut type_attribute_variants: BTreeMap<String, serde_json::Value> = maplit::btreemap! {
+        "type".to_string() => json!("object"),
+    };
+
+    for (AttributeType(attribute), r#type) in attributes {
+        let type_attribute_variant = match r#type {
+            SynthType::String => {
+                json!({
+                    "type": "string",
+                    "faker": {
+                        "generator": "bs_noun"
+                    }
+                })
+            }
+            SynthType::Number => {
+                json!({
+                    "type": "number",
+                    "subtype": "u32"
+                })
+            }
+            SynthType::Bool => {
+                json!({
+                    "type": "bool",
+                    "frequency": 0.5
+                })
+            }
+            // Object will be an empty object.
+            // This is something that could be tweaked on a case by case basis given some domain knowledge
+            SynthType::Object => {
+                json!({
+                    "type": "object",
+                })
+            }
+        };
+
+        type_attribute_variants.insert(attribute.clone(), type_attribute_variant);
+    }
+
+    let name = format!("{}_attributes", type_name_lower);
+    let schema = serde_json::to_value(type_attribute_variants)?;
+    let collection = DomainCollection::new(name, schema);
+
+    Ok(Collection::Generator(Generator::DomainCollection(
+        collection,
+    )))
+}
+
+fn generate_schema(
+    types_attributes: &BTreeMap<ParsedDomainType, BTreeMap<AttributeType, SynthType>>,
+) -> Result<Vec<Collection>, ChronicleSynthError> {
+    let mut collections = Vec::new();
+
+    for (r#type, attributes) in types_attributes {
+        let collection1 = domain_type_id_for_domain(r#type);
+        collections.push(collection1);
+
+        let type_name_lower = r#type.as_str().to_lowercase();
+
+        let collection2 = set_attributes(&type_name_lower);
+        collections.push(collection2);
+
+        let collection3 = type_attribute_variants(&type_name_lower, attributes)?;
+        collections.push(collection3);
+    }
+    Ok(collections)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::collection::CollectionHandling;
+
+    use super::*;
+    use maplit::btreemap;
+
+    #[test]
+    fn test_type_attribute_variants() {
+        // Create a sample attribute map with two attributes
+        let attributes = btreemap! {
+            AttributeType("TestAttribute1".to_owned()) => SynthType::String,
+            AttributeType("TestAttribute2".to_owned()) => SynthType::Number,
+        };
+
+        // Call the function being tested
+        let result = type_attribute_variants("test_type", &attributes).unwrap();
+
+        // Assert that the function returns a Collection with the expected properties
+        insta::assert_json_snapshot!(result.json_schema().unwrap().to_string(), @r###""{\"TestAttribute1\":{\"faker\":{\"generator\":\"bs_noun\"},\"type\":\"string\"},\"TestAttribute2\":{\"subtype\":\"u32\",\"type\":\"number\"},\"type\":\"object\"}""###);
+    }
+}

--- a/crates/chronicle-synth/src/error.rs
+++ b/crates/chronicle-synth/src/error.rs
@@ -1,0 +1,16 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum ChronicleSynthError {
+    #[error("Chronicle domain parsing error: {0}")]
+    ModelError(#[from] chronicle::codegen::model::ModelError),
+
+    #[error("Invalid JSON: {0}")]
+    JsonError(#[from] serde_json::Error),
+
+    #[error("I/O error: {0}")]
+    IO(#[from] std::io::Error),
+
+    #[error("YAML parsing error: {0}")]
+    YamlError(#[from] serde_yaml::Error),
+}

--- a/crates/chronicle-synth/src/generate.rs
+++ b/crates/chronicle-synth/src/generate.rs
@@ -1,0 +1,243 @@
+//! A command-line interface for generating Chronicle Synth schema for a given domain.
+
+use std::{
+    fs::File,
+    io::{BufReader, Write},
+    path::{Path, PathBuf},
+};
+
+use chronicle::codegen::linter::check_files;
+use chronicle_synth::{
+    collection::{Collection, CollectionHandling},
+    domain::TypesAttributesRoles,
+    error::ChronicleSynthError,
+};
+use owo_colors::OwoColorize;
+use serde::{Deserialize, Serialize};
+use structopt::StructOpt;
+
+#[derive(StructOpt)]
+#[structopt(
+    name = "chronicle-domain-synth",
+    about = "Generate Chronicle Synth schema for your domain",
+    author = "Blockchain Technology Partners"
+)]
+struct Cli {
+    #[structopt(
+        value_name = "FILE",
+        help = "Chronicle domain definition file",
+        parse(from_os_str),
+        default_value = "crates/chronicle-synth/domain.yaml"
+    )]
+    domain_file: PathBuf,
+}
+
+const COLLECT_SCRIPT: &str = "./crates/chronicle-synth/collect";
+
+fn main() -> Result<(), ChronicleSynthError> {
+    let args = Cli::from_args();
+
+    let domain_file = args.domain_file.as_path();
+
+    // Use Chronicle Domain Linter to check the domain definition file
+    let filenames = vec![domain_file.to_str().ok_or_else(|| {
+        ChronicleSynthError::IO(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "Invalid path argument",
+        ))
+    })?];
+
+    check_files(filenames);
+
+    println!("{}", "No domain definition errors detected.".green());
+
+    generate_synth_collections(domain_file)?;
+
+    // Run the `collect` script to collate the complete set of Synth collections for the domain
+    let output = std::process::Command::new("bash")
+        .args([COLLECT_SCRIPT])
+        .output()
+        .expect("Failed to execute 'collect' command");
+
+    println!("{}", String::from_utf8_lossy(&output.stdout));
+
+    println!(
+        "{} contains the additional Synth collections generated for your domain.",
+        "crates/chronicle-synth/domain-schema/".underline()
+    );
+    println!(
+        "The complete set of Synth collections for your domain can be found in '{}'.",
+        "crates/chronicle-synth/collections/".underline()
+    );
+
+    Ok(())
+}
+
+/// Generates Synth collections for the given domain definition file.
+///
+/// This function takes a path to a domain definition file, generates Synth collections based on the
+/// definition, and writes the resulting schema files to the `domain-schema` directory. Collections marked
+/// as not being "chronicle operations" are written to a file called `exclude_collections.txt`.
+///
+/// # Arguments
+///
+/// * `domain_file` - A path to the domain definition file.
+///
+/// # Examples
+///
+/// ```
+/// use std::path::PathBuf;
+/// use chronicle_domain_synth::ChronicleSynthError;
+///
+/// let domain_file = PathBuf::from("domain.yaml");
+/// let result = generate_synth_collections(&domain_file);
+///
+/// match result {
+///     Ok(_) => println!("Synth collections generated successfully."),
+///     Err(e) => eprintln!("Error generating Synth collections: {}", e),
+/// }
+/// ```
+fn generate_synth_collections(domain_file: &Path) -> Result<(), ChronicleSynthError> {
+    let generator = TypesAttributesRoles::from_file(domain_file)?;
+    println!(
+        "Generating schema for domain: {}.",
+        generator.name.underline()
+    );
+
+    let dir_path = PathBuf::from(DOMAIN_SCHEMA_TARGET_DIRECTORY);
+    std::fs::create_dir_all(&dir_path)?;
+
+    let collections = generator.generate_domain_collections()?;
+    for collection in collections {
+        write_collection(&collection, &dir_path)?;
+
+        match collection {
+            Collection::Operation(_) => {}
+            Collection::Generator(collection) => {
+                append_to_exclude_list(EXCLUDE_LIST, &collection.name())?;
+            }
+        }
+    }
+    Ok(())
+}
+
+const DOMAIN_SCHEMA_TARGET_DIRECTORY: &str = "./crates/chronicle-synth/domain-schema";
+
+const EXCLUDE_LIST: &str = "./crates/chronicle-synth/exclude_collections.json";
+
+#[derive(Deserialize, Serialize)]
+struct ExcludeCollections {
+    exclude: Vec<String>,
+}
+
+impl ExcludeCollections {
+    fn from_file(filename: impl AsRef<Path>) -> Result<ExcludeCollections, ChronicleSynthError> {
+        let file = File::open(filename)?;
+        let reader = BufReader::new(file);
+        let exclude_collections = serde_json::from_reader(reader)?;
+        Ok(exclude_collections)
+    }
+}
+
+fn write_collection(collection: &Collection, dir_path: &Path) -> Result<(), ChronicleSynthError> {
+    let file_path = dir_path.join(collection.path());
+    let mut file = File::create(file_path)?;
+    let schema = collection.json_schema()?;
+    file.write_all(serde_json::to_string(&schema)?.as_bytes())?;
+    Ok(())
+}
+
+/// Appends a collection name to the "exclude list" file, a list of collection files to be ignored
+/// when generating the domain schema. See `generate` script in this repository for more information.
+fn append_to_exclude_list(
+    path: impl AsRef<Path>,
+    collection: &str,
+) -> Result<(), ChronicleSynthError> {
+    let collection = collection.to_string();
+    let mut list = ExcludeCollections::from_file(&path)?;
+
+    if list.exclude.contains(&collection) {
+        return Ok(());
+    } else {
+        list.exclude.push(collection);
+    }
+
+    let mut file = File::create(&path)?;
+    file.write_all(serde_json::to_string_pretty(&list)?.as_bytes())?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::File;
+    use std::io::BufReader;
+
+    use assert_fs::prelude::*;
+
+    const PATH: &str = "test_exclude_collections.json";
+
+    fn create_test_exclude_collections(
+    ) -> Result<assert_fs::NamedTempFile, Box<dyn std::error::Error>> {
+        let file = assert_fs::NamedTempFile::new(PATH)?;
+
+        file.write_str(
+            r#"
+            {
+                "exclude": [
+                    "already_ignore_this"
+                ]
+            }
+            "#,
+        )?;
+
+        Ok(file)
+    }
+
+    #[test]
+    fn test_append_to_exclude_list() -> Result<(), ChronicleSynthError> {
+        let file = create_test_exclude_collections().unwrap();
+
+        // Call the function to append to the exclude list
+        append_to_exclude_list(file.path(), "ignore_this_collection_when_printing")?;
+
+        // Read the contents of the file and check if the collection was added
+        let file = File::open(file.path())?;
+        let reader = BufReader::new(file);
+        let exclude_collections: ExcludeCollections = serde_json::from_reader(reader)?;
+
+        insta::assert_json_snapshot!(exclude_collections, @r###"
+        {
+          "exclude": [
+            "already_ignore_this",
+            "ignore_this_collection_when_printing"
+          ]
+        }"###);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_append_to_exclude_list_skips_collections_already_on_list(
+    ) -> Result<(), ChronicleSynthError> {
+        let file = create_test_exclude_collections().unwrap();
+
+        // Call the function to append to the exclude list
+        append_to_exclude_list(file.path(), "already_ignore_this")?;
+
+        // Read the contents of the file and check if the collection was added
+        let file = File::open(file.path())?;
+        let reader = BufReader::new(file);
+        let exclude_collections: ExcludeCollections = serde_json::from_reader(reader)?;
+
+        insta::assert_json_snapshot!(exclude_collections, @r###"
+        {
+          "exclude": [
+            "already_ignore_this"
+          ]
+        }"###);
+
+        Ok(())
+    }
+}

--- a/crates/chronicle-synth/src/lib.rs
+++ b/crates/chronicle-synth/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod collection;
+pub mod domain;
+pub mod error;

--- a/crates/chronicle-synth/synth/activity_exists.json
+++ b/crates/chronicle-synth/synth/activity_exists.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "@id": "_:n1",
+  "@type": {
+    "type": "array",
+    "length": 1,
+    "content": "http://btp.works/chronicleoperations/ns#ActivityExists"
+  },
+  "http://btp.works/chronicleoperations/ns#activityName": "@activity_name",
+  "http://btp.works/chronicleoperations/ns#namespaceName": "@same_namespace_name",
+  "http://btp.works/chronicleoperations/ns#namespaceUuid": "@same_namespace_uuid"
+}

--- a/crates/chronicle-synth/synth/activity_name.json
+++ b/crates/chronicle-synth/synth/activity_name.json
@@ -1,0 +1,13 @@
+{
+  "type": "array",
+  "length": 1,
+  "content": {
+    "type": "object",
+    "@value": {
+      "type": "string",
+      "faker": {
+        "generator": "bs_verb"
+      }
+    }
+  }
+}

--- a/crates/chronicle-synth/synth/activity_uses.json
+++ b/crates/chronicle-synth/synth/activity_uses.json
@@ -1,0 +1,13 @@
+{
+    "type": "object",
+    "@id": "_:n1",
+    "@type": {
+        "type": "array",
+        "length": 1,
+        "content": "http://btp.works/chronicleoperations/ns#ActivityUses"
+    },
+    "http://btp.works/chronicleoperations/ns#activityName": "@activity_name",
+    "http://btp.works/chronicleoperations/ns#entityName": "@entity_name",
+    "http://btp.works/chronicleoperations/ns#namespaceName": "@same_namespace_name",
+    "http://btp.works/chronicleoperations/ns#namespaceUuid": "@same_namespace_uuid"
+}

--- a/crates/chronicle-synth/synth/agent_acts_on_behalf_of.json
+++ b/crates/chronicle-synth/synth/agent_acts_on_behalf_of.json
@@ -1,0 +1,14 @@
+{
+    "type": "object",
+    "@id": "_:n1",
+    "@type": {
+        "type": "array",
+        "length": 1,
+        "content": "http://btp.works/chronicleoperations/ns#AgentActsOnBehalfOf"
+    },
+    "http://btp.works/chronicleoperations/ns#activityName": "@activity_name",
+    "http://btp.works/chronicleoperations/ns#delegateId": "@agent_name",
+    "http://btp.works/chronicleoperations/ns#namespaceName": "@same_namespace_name",
+    "http://btp.works/chronicleoperations/ns#namespaceUuid": "@same_namespace_uuid",
+    "http://btp.works/chronicleoperations/ns#responsibleId": "@second_agent_name"
+}

--- a/crates/chronicle-synth/synth/agent_exists.json
+++ b/crates/chronicle-synth/synth/agent_exists.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "@id": "_:n1",
+  "@type": {
+    "type": "array",
+    "length": 1,
+    "content": "http://btp.works/chronicleoperations/ns#AgentExists"
+  },
+  "http://btp.works/chronicleoperations/ns#agentName": "@agent_name",
+  "http://btp.works/chronicleoperations/ns#namespaceName": "@same_namespace_name",
+  "http://btp.works/chronicleoperations/ns#namespaceUuid": "@same_namespace_uuid"
+}

--- a/crates/chronicle-synth/synth/agent_name.json
+++ b/crates/chronicle-synth/synth/agent_name.json
@@ -1,0 +1,13 @@
+{
+  "type": "array",
+  "length": 1,
+  "content": {
+    "type": "object",
+    "@value": {
+      "type": "string",
+      "faker": {
+        "generator": "name"
+      }
+    }
+  }
+}

--- a/crates/chronicle-synth/synth/attribute.json
+++ b/crates/chronicle-synth/synth/attribute.json
@@ -1,0 +1,3 @@
+{
+    "type": "object"
+}

--- a/crates/chronicle-synth/synth/attributes.json
+++ b/crates/chronicle-synth/synth/attributes.json
@@ -1,0 +1,12 @@
+{
+    "type": "array",
+    "length": 1,
+    "content": {
+        "type": "object",
+        "@type": {
+            "type": "string",
+            "constant": "@json"
+        },
+        "@value": "@attribute"
+    }
+}

--- a/crates/chronicle-synth/synth/create_namespace.json
+++ b/crates/chronicle-synth/synth/create_namespace.json
@@ -1,0 +1,11 @@
+{
+    "type": "object",
+    "@id": "_:n1",
+    "@type": {
+        "type": "array",
+        "length": 1,
+        "content": "http://btp.works/chronicleoperations/ns#CreateNamespace"
+    },
+    "http://btp.works/chronicleoperations/ns#namespaceName": "@same_namespace_name",
+    "http://btp.works/chronicleoperations/ns#namespaceUuid": "@same_namespace_uuid"
+}

--- a/crates/chronicle-synth/synth/domain_type_id.json
+++ b/crates/chronicle-synth/synth/domain_type_id.json
@@ -1,0 +1,13 @@
+{
+    "type": "array",
+    "length": 1,
+    "content": {
+        "type": "object",
+        "@value": {
+            "type": "string",
+            "faker": {
+                "generator": "bs_noun"
+            }
+        }
+    }
+}

--- a/crates/chronicle-synth/synth/earlier_date_time.json
+++ b/crates/chronicle-synth/synth/earlier_date_time.json
@@ -1,0 +1,13 @@
+{
+    "type": "array",
+    "length": 1,
+    "content": {
+        "type": "object",
+        "@value": {
+            "type": "date_time",
+            "format": "%+",
+            "begin": "2000-07-08T00:34:60.026490+09:30",
+            "end": "2000-07-08T00:34:60.026490+09:30"
+        }
+    }
+}

--- a/crates/chronicle-synth/synth/end_activity.json
+++ b/crates/chronicle-synth/synth/end_activity.json
@@ -1,0 +1,13 @@
+{
+    "type": "object",
+    "@id": "_:n1",
+    "@type": {
+        "type": "array",
+        "length": 1,
+        "content": "http://btp.works/chronicleoperations/ns#EndActivity"
+    },
+    "http://btp.works/chronicleoperations/ns#activityName": "@activity_name",
+    "http://btp.works/chronicleoperations/ns#namespaceName": "@same_namespace_name",
+    "http://btp.works/chronicleoperations/ns#namespaceUuid": "@same_namespace_uuid",
+    "http://btp.works/chronicleoperations/ns#endActivityTime": "@later_date_time"
+}

--- a/crates/chronicle-synth/synth/entity_derive.json
+++ b/crates/chronicle-synth/synth/entity_derive.json
@@ -1,0 +1,13 @@
+{
+    "type": "object",
+    "@id": "_:n1",
+    "@type": {
+        "type": "array",
+        "length": 1,
+        "content": "http://btp.works/chronicleoperations/ns#EntityDerive"
+    },
+    "http://btp.works/chronicleoperations/ns#entityName": "@entity_name",
+    "http://btp.works/chronicleoperations/ns#namespaceName": "@same_namespace_name",
+    "http://btp.works/chronicleoperations/ns#namespaceUuid": "@same_namespace_uuid",
+    "http://btp.works/chronicleoperations/ns#usedEntityName": "@second_entity_name"
+}

--- a/crates/chronicle-synth/synth/entity_exists.json
+++ b/crates/chronicle-synth/synth/entity_exists.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "@id": "_:n1",
+  "@type": {
+    "type": "array",
+    "length": 1,
+    "content": "http://btp.works/chronicleoperations/ns#EntityExists"
+  },
+  "http://btp.works/chronicleoperations/ns#entityName": "@entity_name",
+  "http://btp.works/chronicleoperations/ns#namespaceName": "@same_namespace_name",
+  "http://btp.works/chronicleoperations/ns#namespaceUuid": "@same_namespace_uuid"
+}

--- a/crates/chronicle-synth/synth/entity_name.json
+++ b/crates/chronicle-synth/synth/entity_name.json
@@ -1,0 +1,13 @@
+{
+  "type": "array",
+  "length": 1,
+  "content": {
+    "type": "object",
+    "@value": {
+      "type": "string",
+      "faker": {
+        "generator": "bs_noun"
+      }
+    }
+  }
+}

--- a/crates/chronicle-synth/synth/later_date_time.json
+++ b/crates/chronicle-synth/synth/later_date_time.json
@@ -1,0 +1,13 @@
+{
+    "type": "array",
+    "length": 1,
+    "content": {
+        "type": "object",
+        "@value": {
+            "type": "date_time",
+            "format": "%+",
+            "begin": "2001-07-08T00:34:60.026490+09:30",
+            "end": "2001-07-08T00:34:60.026490+09:30"
+        }
+    }
+}

--- a/crates/chronicle-synth/synth/namespace.json
+++ b/crates/chronicle-synth/synth/namespace.json
@@ -1,0 +1,13 @@
+{
+  "type": "array",
+  "length": 1,
+  "content": {
+    "type": "object",
+    "@value": {
+      "type": "string",
+      "faker": {
+        "generator": "name"
+      }
+    }
+  }
+}

--- a/crates/chronicle-synth/synth/namespace_uuid.json
+++ b/crates/chronicle-synth/synth/namespace_uuid.json
@@ -1,0 +1,11 @@
+{
+    "type": "array",
+    "length": 1,
+    "content": {
+        "type": "object",
+        "@value": {
+            "type": "string",
+            "uuid": {}
+        }
+    }
+}

--- a/crates/chronicle-synth/synth/role.json
+++ b/crates/chronicle-synth/synth/role.json
@@ -1,0 +1,5 @@
+{
+    "type": "array",
+    "length": 1,
+    "content": "@roles"
+}

--- a/crates/chronicle-synth/synth/roles.json
+++ b/crates/chronicle-synth/synth/roles.json
@@ -1,0 +1,9 @@
+{
+    "type": "one_of",
+    "variants": [
+        {
+            "type": "string",
+            "constant": "UNSPECIFIED"
+        }
+    ]
+}

--- a/crates/chronicle-synth/synth/same_namespace_name.json
+++ b/crates/chronicle-synth/synth/same_namespace_name.json
@@ -1,0 +1,11 @@
+{
+    "type": "array",
+    "length": 1,
+    "content": {
+        "type": "object",
+        "@value": {
+            "type": "string",
+            "pattern": "testns"
+        }
+    }
+}

--- a/crates/chronicle-synth/synth/same_namespace_uuid.json
+++ b/crates/chronicle-synth/synth/same_namespace_uuid.json
@@ -1,0 +1,11 @@
+{
+    "type": "array",
+    "length": 1,
+    "content": {
+        "type": "object",
+        "@value": {
+            "type": "string",
+            "pattern": "60976119-adc6-3826-a57b-3ccb0580e7bd"
+        }
+    }
+}

--- a/crates/chronicle-synth/synth/second_activity_name.json
+++ b/crates/chronicle-synth/synth/second_activity_name.json
@@ -1,0 +1,13 @@
+{
+    "type": "array",
+    "length": 1,
+    "content": {
+        "type": "object",
+        "@value": {
+            "type": "string",
+            "faker": {
+                "generator": "bs_verb"
+            }
+        }
+    }
+}

--- a/crates/chronicle-synth/synth/second_agent_name.json
+++ b/crates/chronicle-synth/synth/second_agent_name.json
@@ -1,0 +1,13 @@
+{
+    "type": "array",
+    "length": 1,
+    "content": {
+        "type": "object",
+        "@value": {
+            "type": "string",
+            "faker": {
+                "generator": "name"
+            }
+        }
+    }
+}

--- a/crates/chronicle-synth/synth/second_entity_name.json
+++ b/crates/chronicle-synth/synth/second_entity_name.json
@@ -1,0 +1,13 @@
+{
+    "type": "array",
+    "length": 1,
+    "content": {
+        "type": "object",
+        "@value": {
+            "type": "string",
+            "faker": {
+                "generator": "bs_noun"
+            }
+        }
+    }
+}

--- a/crates/chronicle-synth/synth/set_activity_attributes.json
+++ b/crates/chronicle-synth/synth/set_activity_attributes.json
@@ -1,0 +1,13 @@
+{
+    "type": "object",
+    "@id": "_:n1",
+    "@type": {
+        "type": "array",
+        "length": 1,
+        "content": "http://btp.works/chronicleoperations/ns#SetAttributes"
+    },
+    "http://btp.works/chronicleoperations/ns#activityName": "@activity_name",
+    "http://btp.works/chronicleoperations/ns#attributes": "@attributes",
+    "http://btp.works/chronicleoperations/ns#namespaceName": "@same_namespace_name",
+    "http://btp.works/chronicleoperations/ns#namespaceUuid": "@same_namespace_uuid"
+}

--- a/crates/chronicle-synth/synth/set_agent_attributes.json
+++ b/crates/chronicle-synth/synth/set_agent_attributes.json
@@ -1,0 +1,13 @@
+{
+    "type": "object",
+    "@id": "_:n1",
+    "@type": {
+        "type": "array",
+        "length": 1,
+        "content": "http://btp.works/chronicleoperations/ns#SetAttributes"
+    },
+    "http://btp.works/chronicleoperations/ns#agentName": "@agent_name",
+    "http://btp.works/chronicleoperations/ns#attributes": "@attributes",
+    "http://btp.works/chronicleoperations/ns#namespaceName": "@same_namespace_name",
+    "http://btp.works/chronicleoperations/ns#namespaceUuid": "@same_namespace_uuid"
+}

--- a/crates/chronicle-synth/synth/set_entity_attributes.json
+++ b/crates/chronicle-synth/synth/set_entity_attributes.json
@@ -1,0 +1,13 @@
+{
+    "type": "object",
+    "@id": "_:n1",
+    "@type": {
+        "type": "array",
+        "length": 1,
+        "content": "http://btp.works/chronicleoperations/ns#SetAttributes"
+    },
+    "http://btp.works/chronicleoperations/ns#entityName": "@entity_name",
+    "http://btp.works/chronicleoperations/ns#attributes": "@attributes",
+    "http://btp.works/chronicleoperations/ns#namespaceName": "@same_namespace_name",
+    "http://btp.works/chronicleoperations/ns#namespaceUuid": "@same_namespace_uuid"
+}

--- a/crates/chronicle-synth/synth/start_activity.json
+++ b/crates/chronicle-synth/synth/start_activity.json
@@ -1,0 +1,13 @@
+{
+    "type": "object",
+    "@id": "_:n1",
+    "@type": {
+        "type": "array",
+        "length": 1,
+        "content": "http://btp.works/chronicleoperations/ns#StartActivity"
+    },
+    "http://btp.works/chronicleoperations/ns#activityName": "@activity_name",
+    "http://btp.works/chronicleoperations/ns#namespaceName": "@same_namespace_name",
+    "http://btp.works/chronicleoperations/ns#namespaceUuid": "@same_namespace_uuid",
+    "http://btp.works/chronicleoperations/ns#startActivityTime": "@earlier_date_time"
+}

--- a/crates/chronicle-synth/synth/was_associated_with.json
+++ b/crates/chronicle-synth/synth/was_associated_with.json
@@ -1,0 +1,13 @@
+{
+    "type": "object",
+    "@id": "_:n1",
+    "@type": {
+        "type": "array",
+        "length": 1,
+        "content": "http://btp.works/chronicleoperations/ns#WasAssociatedWith"
+    },
+    "http://btp.works/chronicleoperations/ns#activityName": "@activity_name",
+    "http://btp.works/chronicleoperations/ns#agentName": "@agent_name",
+    "http://btp.works/chronicleoperations/ns#namespaceName": "@same_namespace_name",
+    "http://btp.works/chronicleoperations/ns#namespaceUuid": "@same_namespace_uuid"
+}

--- a/crates/chronicle-synth/synth/was_associated_with_has_role.json
+++ b/crates/chronicle-synth/synth/was_associated_with_has_role.json
@@ -1,0 +1,14 @@
+{
+    "type": "object",
+    "@id": "_:n1",
+    "@type": {
+        "type": "array",
+        "length": 1,
+        "content": "http://btp.works/chronicleoperations/ns#WasAssociatedWith"
+    },
+    "http://btp.works/chronicleoperations/ns#activityName": "@activity_name",
+    "http://btp.works/chronicleoperations/ns#agentName": "@agent_name",
+    "http://btp.works/chronicleoperations/ns#namespaceName": "@same_namespace_name",
+    "http://btp.works/chronicleoperations/ns#namespaceUuid": "@same_namespace_uuid",
+    "http://btp.works/chronicleoperations/ns#role": "@role"
+}

--- a/crates/chronicle-synth/synth/was_attributed_to.json
+++ b/crates/chronicle-synth/synth/was_attributed_to.json
@@ -1,0 +1,13 @@
+{
+    "type": "object",
+    "@id": "_:n1",
+    "@type": {
+        "type": "array",
+        "length": 1,
+        "content": "http://btp.works/chronicleoperations/ns#WasAttributedTo"
+    },
+    "http://btp.works/chronicleoperations/ns#agentName": "@agent_name",
+    "http://btp.works/chronicleoperations/ns#entityName": "@entity_name",
+    "http://btp.works/chronicleoperations/ns#namespaceName": "@same_namespace_name",
+    "http://btp.works/chronicleoperations/ns#namespaceUuid": "@same_namespace_uuid"
+}

--- a/crates/chronicle-synth/synth/was_generated_by.json
+++ b/crates/chronicle-synth/synth/was_generated_by.json
@@ -1,0 +1,13 @@
+{
+    "type": "object",
+    "@id": "_:n1",
+    "@type": {
+        "type": "array",
+        "length": 1,
+        "content": "http://btp.works/chronicleoperations/ns#WasGeneratedBy"
+    },
+    "http://btp.works/chronicleoperations/ns#activityName": "@activity_name",
+    "http://btp.works/chronicleoperations/ns#entityName": "@entity_name",
+    "http://btp.works/chronicleoperations/ns#namespaceName": "@same_namespace_name",
+    "http://btp.works/chronicleoperations/ns#namespaceUuid": "@same_namespace_uuid"
+}

--- a/crates/chronicle-synth/synth/was_informed_by.json
+++ b/crates/chronicle-synth/synth/was_informed_by.json
@@ -1,0 +1,13 @@
+{
+    "type": "object",
+    "@id": "_:n1",
+    "@type": {
+        "type": "array",
+        "length": 1,
+        "content": "http://btp.works/chronicleoperations/ns#WasInformedBy"
+    },
+    "http://btp.works/chronicleoperations/ns#activityName": "@activity_name",
+    "http://btp.works/chronicleoperations/ns#informingActivityName": "@second_activity_name",
+    "http://btp.works/chronicleoperations/ns#namespaceName": "@same_namespace_name",
+    "http://btp.works/chronicleoperations/ns#namespaceUuid": "@same_namespace_uuid"
+}


### PR DESCRIPTION
# Chronicle Synth

Chronicle [Synth](https://www.getsynth.com/) is a tool for generating Synth schema for Chronicle. It takes a YAML file as input, which contains information about the domain's name, attributes, entities, activities, agents, and roles, and generates Synth collections that can be used to generate the Chronicle operations available to a domain's users.

If you just want to generate untyped Chronicle operations with `synth` the collections in `chronicle-synth/synth/` are ready to go. Use the `./crates/chronicle-synth/collect` and `./crates/chronicle-synth/generate` scripts to generate a set of synthetic Chronicle operations.

The core functionality of the `chronicle-synth` `--bin` target (`cargo run --bin chronicle-synth`) is to generate the additional Synth schema specific to each individual Chronicle domain.

Since it's up to the user to determine how they want to use Synth to generate data, the `crates/chronicle-synth/generate` script is there to show *one* way to get going with generating data from the collections.

## Prerequisites

To use Chronicle Synth, you need to have Synth installed on your system. If you don't have it already installed, you can follow the [instructions](https://www.getsynth.com/docs/getting_started/installation) in the Synth documentation to install it.

## Usage

### Loading domain.yaml Chronicle Domain Definitions

To use Chronicle Synth, you must have a YAML file that describes your domain. The file should have the following structure:

```yaml
name: DomainName
attributes:
  AttributeName:
    type: AttributeType
entities:
  EntityName:
    attributes:
      - AttributeName1
      - AttributeName2
activities:
  ActivityName:
    attributes:
      - AttributeName1
      - AttributeName2
agents:
  AgentName:
    attributes:
      - AttributeName1
roles:
  - RoleName1
  - RoleName2
```

Once you have your YAML file, you can generate Synth schema by running the following command:

```bash
chronicle-synth <path-to-yaml-file>
```

Or, since `<path-to-yaml-file>` defaults to domain.yaml, if your YAML file is named domain.yaml, you can simply run:

```bash
cargo run --bin chronicle-synth
```

This will output the additional Synth schema required to generate synth data for your domain to the `domain_schema` directory, and collate the core Chronicle Synth collections along with the generated collections specific to your domain in `collections`.

### Generating Your Domain's Synth Data

Chronicle Synth includes a `generate` script, which will print a synth-example of each Chronicle operation in your domain.

#### Example

```bash
cd crates/chronicle-synth && \
./generate | jq
```

---
Signed-off-by: Joseph Livesey [joseph.livesey@btp.works](mailto:joseph.livesey@btp.works)

[CHRON-305](https://blockchaintp.atlassian.net/browse/CHRON-305)
(subtask of: [CHRON-283](https://blockchaintp.atlassian.net/browse/CHRON-283))

[CHRON-305]: https://blockchaintp.atlassian.net/browse/CHRON-305?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CHRON-283]: https://blockchaintp.atlassian.net/browse/CHRON-283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ