### PR TITLE
allow multiple JWT claims to determine ExternalId

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -946,6 +946,7 @@ dependencies = [
  "mime",
  "opa",
  "opa-tp-protocol",
+ "openssl",
  "percent-encoding",
  "pkcs8 0.10.2",
  "portpicker",

--- a/crates/chronicle/src/bootstrap/cli.rs
+++ b/crates/chronicle/src/bootstrap/cli.rs
@@ -1025,12 +1025,13 @@ impl SubCommand for CliModel {
                             .help("URI of the OIDC UserInfo endpoint")
                     }
                     ).arg(
-                        Arg::new("id-pointer")
-                            .long("id-pointer")
+                        Arg::new("id-claims")
+                            .long("id-claims")
                             .takes_value(true)
-                            .env("JWT_POINTER")
-                            .default_value("/sub")
-                            .help("JSON pointer into JWT claims for Chronicle ID"),
+                            .min_values(1)
+                            .default_values(&["iss", "sub"])
+                            .env("JWT_ID_CLAIMS")
+                            .help("JWT claims that determine Chronicle ID"),
                     )
                     .arg(
                         Arg::new("jwt-must-claim")

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -34,6 +34,7 @@ locspan = { workspace = true }
 mime = { workspace = true }
 opa = { workspace = true }
 opa-tp-protocol = { path = "../opa-tp-protocol" }
+openssl = { workspace = true }
 percent-encoding = { workspace = true }
 pkcs8 = { workspace = true }
 portpicker = { workspace = true }

--- a/crates/common/src/opa.rs
+++ b/crates/common/src/opa.rs
@@ -317,11 +317,10 @@ struct EmbeddedOpaPolicies;
 
 #[cfg(test)]
 mod tests {
-    use serde_json::Value;
-
-    use crate::identity::IdentityContext;
-
     use super::*;
+    use crate::identity::IdentityContext;
+    use serde_json::Value;
+    use std::collections::BTreeSet;
 
     fn chronicle_id() -> AuthId {
         AuthId::chronicle()
@@ -391,7 +390,7 @@ mod tests {
             .unwrap()
             .to_owned(),
         );
-        AuthId::from_jwt_claims(&claims, "/sub").unwrap()
+        AuthId::from_jwt_claims(&claims, &BTreeSet::from(["sub".to_string()])).unwrap()
     }
 
     fn jwt_user_opa_data() -> OpaData {

--- a/crates/sawtooth-tp/src/tp.rs
+++ b/crates/sawtooth-tp/src/tp.rs
@@ -337,7 +337,10 @@ impl TransactionHandler for ChronicleTransactionHandler {
 
 #[cfg(test)]
 pub mod test {
-    use std::{cell::RefCell, collections::BTreeMap};
+    use std::{
+        cell::RefCell,
+        collections::{BTreeMap, BTreeSet},
+    };
 
     use chronicle_protocol::{
         async_sawtooth_sdk::{ledger::LedgerTransaction, sawtooth::MessageBuilder},
@@ -673,7 +676,7 @@ pub mod test {
                 .unwrap()
                 .to_owned(),
             );
-            AuthId::from_jwt_claims(&claims, "/sub").unwrap()
+            AuthId::from_jwt_claims(&claims, &BTreeSet::from(["sub".to_string()])).unwrap()
         };
 
         let signed_identity = user_identity.signed_identity(&keystore).unwrap();

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -36,10 +36,10 @@ combined. This can be a means of including both OAuth scope (from an access
 token) and user identity (from the user info endpoint) among the resulting
 claims.
 
-For constructing the Chronicle identity from the claims, a
-[configured ID pointer](./cli.md#id-pointer-json-ptr) identifies the claim
-whose value should be accepted as the external ID of the Chronicle user who
-submitted the request.
+For constructing the Chronicle identity from the claims,
+[configured field names](./cli.md#id-claims-jwt-field-names) identify the
+claims whose values should be used in deriving the external ID of the
+Chronicle user who submitted the request.
 
 Omitting the `Authorization:` header means that the user is regarded as
 being anonymous and has no accompanying claims. Such requests may be
@@ -56,7 +56,7 @@ settings of your authorization server,
 chronicle serve-api \
   --jwks-address https://auth.example.com/.well-known/jwks.json \
   --userinfo-address https://auth.example.com/userinfo \
-  --id-pointer /nickname \
+  --id-claims nickname \
   --require-auth \
   --jwt-must-claim iss https://auth.example.com/ \
   --jwt-must-claim aud https://auth.example.com/chronicle-api/ \
@@ -68,8 +68,8 @@ This,
 - requires bearer tokens to be presented with API requests
 - uses the fetched `jwks.json` to verify JWT signatures
 - uses the `userinfo` endpoint to obtain claims associated with the token
-- uses value of the `"nickname"` field among the claims as the external ID of
-  the authenticated Chronicle user
+- uses value of the `"nickname"` field among the claims to derive the external
+  ID of the authenticated Chronicle user
 - rejects any requests that do not include an `Authorization:` header with a
   bearer token
 - rejects any tokens that lead to JWT claims that do not include those

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -24,11 +24,15 @@ Options are:
 
 ##### Authentication
 
-###### `--id-pointer <JSON ptr>`
+###### `--id-claims <JWT field names>`
 
-A JSON pointer into the JSON Web Token claims, specifying the location of
-a string value corresponding to the external ID that should be used in
-constructing the authenticated user's Chronicle identity.
+The names of the JSON Web Token claim fields whose values should be used to
+determine the external ID of the authenticated user's Chronicle identity. All
+listed fields must be present among the user's claims and their values must
+be strings.
+
+The order in which the fields are specified does not change the resulting
+external ID.
 
 ###### `--jwks-address <URI>`
 


### PR DESCRIPTION
Now, instead of `--id-pointer /sub`, can use `--id-claims iss sub` and the like. As specified in CHRON-246, external IDs are now a SHA-512 hash.