### PR TITLE
fix: Connectivity / startup robustness

### DIFF
--- a/crates/async-sawtooth-sdk/src/error.rs
+++ b/crates/async-sawtooth-sdk/src/error.rs
@@ -10,17 +10,20 @@ pub enum SawtoothCommunicationError {
     #[error("ZMQ error: {0}")]
     ZMQ(#[from] zmq::Error),
 
-    #[error("Send error {0}")]
-    Send(#[from] SendError),
+    #[error("Send error: {0}")]
+    SendChannel(#[from] SendError),
 
-    #[error("Receive error {0}")]
-    Receive(#[from] ReceiveError),
+    #[error("Sawtooth receive error: {0}")]
+    ReceiveSawtooth(#[from] ReceiveError),
 
-    #[error("Protobuf error {0}")]
+    #[error("Sawtooth send error: {0}")]
+    SendSawtooth(#[from] sawtooth_sdk::messaging::stream::SendError),
+
+    #[error("Protobuf error: {0}")]
     Protobuf(#[from] ProtobufError),
-    #[error("Protobuf decode error {0}")]
+    #[error("Protobuf decode error: {0}")]
     ProtobufProst(#[from] prost::DecodeError),
-    #[error("Unexpected Status {status:?}")]
+    #[error("Unexpected Status: {status:?}")]
     UnexpectedStatus { status: i32 },
     #[error("No transaction id for event")]
     MissingTransactionId,
@@ -28,18 +31,18 @@ pub enum SawtoothCommunicationError {
     MissingBlockNum,
     #[error("Unexpected message structure")]
     MalformedMessage,
-    #[error("Json {0}")]
+    #[error("Json: {0}")]
     Json(#[from] serde_json::Error),
-    #[error("Subscribe error {code}")]
+    #[error("Subscribe error: {code}")]
     SubscribeError { code: i32 },
-    #[error("Block number is not number {source}")]
+    #[error("Block number is not number: {source}")]
     BlockNumNotNumber {
         #[from]
         source: std::num::ParseIntError,
     },
     #[error("No blocks returned when searching for current block")]
     NoBlocksReturned,
-    #[error("Ledger event parse error {source}")]
+    #[error("Ledger event parse error: {source}")]
     LedgerEventParse {
         #[from]
         source: Box<dyn std::error::Error + Send + Sync>,

--- a/crates/async-sawtooth-sdk/src/sawtooth.rs
+++ b/crates/async-sawtooth-sdk/src/sawtooth.rs
@@ -137,8 +137,8 @@ impl MessageBuilder {
             ..Default::default()
         };
 
-        if let Some(offset) = block_id {
-            request.last_known_block_ids = vec![offset.to_string()].into();
+        if let Some(block_id) = block_id {
+            request.last_known_block_ids = vec![block_id.to_string()].into();
         }
 
         operation_subscriptions.push(block_subscription);

--- a/crates/common/src/prov/model/from_json_ld.rs
+++ b/crates/common/src/prov/model/from_json_ld.rs
@@ -9,7 +9,7 @@ use mime::Mime;
 use rdf_types::{vocabulary::no_vocabulary_mut, BlankIdBuf, IriVocabularyMut};
 use serde_json::json;
 use std::collections::BTreeMap;
-use tracing::{instrument, trace};
+use tracing::{error, instrument, trace};
 
 use crate::{
     attributes::{Attribute, Attributes},
@@ -1070,6 +1070,7 @@ impl ChronicleOperation {
                     informing_activity,
                 }))
             } else {
+                error!("Unknown operation: {:?}", o.type_entry());
                 unreachable!()
             }
         } else {

--- a/docker/chronicle.yaml
+++ b/docker/chronicle.yaml
@@ -119,7 +119,6 @@ services:
     command:
       - -exc
       - |
-        sleep 30
         /usr/local/bin/chronicle \
           -c /etc/chronicle/config/config.toml \
           --console-logging pretty verify-keystore


### PR DESCRIPTION
* Retry loops (simple poll) for settings reading and OPA policy load
* Error level traces for timeout / loop
* Ensure we call reconnect on ZmgConnection after timeout or it can
  become unusable
* Similar retry loop on event subscription
