### PR TITLE
have --interface option use ToSocketAddrs

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -96,8 +96,8 @@ pub enum ApiError {
     #[error("Connection pool: {0}")]
     ConnectionPool(#[from] r2d2::Error),
 
-    #[error("File upload: {0}")]
-    FileUpload(#[from] std::io::Error),
+    #[error("IO error: {0}")]
+    InputOutput(#[from] std::io::Error),
 
     #[error("Blocking thread pool: {0}")]
     Join(#[from] JoinError),
@@ -1139,7 +1139,7 @@ where
                     .unwrap()
                     .read_to_end(&mut buf)
                     .await
-                    .map_err(ApiError::FileUpload)?;
+                    .map_err(ApiError::InputOutput)?;
 
                 Ok(buf)
             }

--- a/crates/chronicle/src/bootstrap/cli.rs
+++ b/crates/chronicle/src/bootstrap/cli.rs
@@ -66,8 +66,8 @@ pub enum CliError {
     #[error("Key storage: {0}")]
     Keys(#[from] SignerError),
 
-    #[error("Cannot locate configuration file: {0}")]
-    FileSystem(#[from] std::io::Error),
+    #[error("IO error: {0}")]
+    InputOutput(#[from] std::io::Error),
 
     #[error("Invalid configuration file: {0}")]
     ConfigInvalid(#[from] toml::de::Error),
@@ -996,8 +996,10 @@ impl SubCommand for CliModel {
                         Arg::new("interface")
                             .long("interface")
                             .takes_value(true)
-                            .default_value("127.0.0.1:9982")
-                            .help("The API server address (default 127.0.0.1:9982)"),
+                            .min_values(1)
+                            .default_values(&["localhost:9982"])
+                            .env("API_LISTEN_SOCKET")
+                            .help("The API server address"),
                     ).arg(
                         Arg::new("playground")
                             .long("playground")

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -10,9 +10,10 @@ Run Chronicle as an API server.
 
 ##### Client Connection Settings
 
-###### `--interface <interface>`
+###### `--interface <interface> ...`
 
-The API server socket address - defaults to 127.0.0.1:9982.
+The API server socket address. If more than one value is provided then the
+Chronicle API will listen on all the specified sockets.
 
 ###### `--offer-endpoints <name> <name> ...`
 


### PR DESCRIPTION
Resolves CHRON-258.

Allows Chronicle to resolve `localhost` etc. as listening socket(s).

If any of the sockets cannot be bound, the server quits with an error, "Address already in use" or "Permission denied" or whichever is appropriate.