### PR TITLE
fix(vocab): make ChronicleOperations IRI casing consistent

### DIFF
--- a/crates/common/src/prov/vocab.rs
+++ b/crates/common/src/prov/vocab.rs
@@ -37,7 +37,7 @@ pub enum ChronicleOperations {
     StartActivity,
     #[iri("chronicleop:startActivityTime")]
     StartActivityTime,
-    #[iri("chronicleop:endactivity")]
+    #[iri("chronicleop:EndActivity")]
     EndActivity,
     #[iri("chronicleop:endActivityTime")]
     EndActivityTime,
@@ -83,7 +83,7 @@ pub enum ChronicleOperations {
     WasInformedBy,
     #[iri("chronicleop:informingActivityName")]
     InformingActivityName,
-    #[iri("chronicleop:generated")]
+    #[iri("chronicleop:Generated")]
     Generated,
 }
 


### PR DESCRIPTION
This came up as a bug during the [work](https://blockchaintp.atlassian.net/browse/CHRON-283) on generating Synth schema. 

Signed-off-by: Joseph Livesey [joseph.livesey@btp.works](mailto:joseph.livesey@btp.works)