### PR TITLE
fix register-key CLI

### DIFF
--- a/crates/chronicle/src/bootstrap/cli.rs
+++ b/crates/chronicle/src/bootstrap/cli.rs
@@ -416,7 +416,7 @@ impl SubCommand for AgentCliModel {
                     })
                 } else {
                     KeyRegistration::ImportVerifying(KeyImport::FromPath {
-                        path: matches.get_one::<PathBuf>("privatekey").unwrap().to_owned(),
+                        path: matches.get_one::<PathBuf>("publickey").unwrap().to_owned(),
                     })
                 }
             };


### PR DESCRIPTION
If no private key offered, take public key arg instead for key registration, fits with verifying instead of signing, and with the use of CLAP's `required_unless_present_any`. Fixes CHRON-317.