### PR TITLE
fix(bootstrap): fix import command handling of no input piped to stdin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -645,6 +645,7 @@ dependencies = [
  "assert_fs",
  "async-graphql",
  "async-sawtooth-sdk",
+ "atty",
  "cfg-if",
  "chronicle-protocol",
  "chronicle-telemetry",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ async-graphql = "5.0.6"
 async-graphql-poem = "5.0.6"
 async-stream = "0.3.3"
 async-trait = "0.1.61"
+atty = "0.2.14"
 backoff = { version = "0.4.0", features = ["futures", "tokio"] }
 base64 = "0.21"
 bytes = "1.3.0"

--- a/crates/chronicle/Cargo.toml
+++ b/crates/chronicle/Cargo.toml
@@ -10,6 +10,7 @@ version = "0.6.0"
 Inflector            = { workspace = true }
 api                  = { path = "../api" }
 async-graphql        = { workspace = true }
+atty                 = { workspace = true }
 cfg-if               = { workspace = true }
 chronicle-protocol   = { path = "../chronicle-protocol" }
 chronicle-telemetry  = { path = "../chronicle-telemetry" }


### PR DESCRIPTION
Improve information around stdin not being readable, quit if if it's not and standard in is not a tty. 
[CHRON-323](https://blockchaintp.atlassian.net/browse/CHRON-323)

[CHRON-323]: https://blockchaintp.atlassian.net/browse/CHRON-323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ