### PR TITLE
fix: bump crate versions to 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,7 +152,7 @@ checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
 
 [[package]]
 name = "api"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "assert_fs",
  "async-graphql",
@@ -343,7 +343,7 @@ dependencies = [
 
 [[package]]
 name = "async-sawtooth-sdk"
-version = "0.1.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -638,7 +638,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chronicle"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "Inflector",
  "api",
@@ -690,7 +690,7 @@ dependencies = [
 
 [[package]]
 name = "chronicle-domain"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "chronicle",
  "insta",
@@ -699,7 +699,7 @@ dependencies = [
 
 [[package]]
 name = "chronicle-domain-lint"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "chronicle",
  "clap 3.2.23",
@@ -707,7 +707,7 @@ dependencies = [
 
 [[package]]
 name = "chronicle-example"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "chronicle",
  "chronicle-protocol",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "chronicle-protocol"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "async-sawtooth-sdk",
  "async-trait",
@@ -763,7 +763,7 @@ dependencies = [
 
 [[package]]
 name = "chronicle-synth"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "assert_fs",
  "chronicle",
@@ -779,7 +779,7 @@ dependencies = [
 
 [[package]]
 name = "chronicle-telemetry"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "opentelemetry",
  "opentelemetry-jaeger",
@@ -988,7 +988,7 @@ dependencies = [
 
 [[package]]
 name = "common"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "api",
@@ -3203,7 +3203,7 @@ dependencies = [
 
 [[package]]
 name = "opa-tp"
-version = "0.1.0"
+version = "0.7.0"
 dependencies = [
  "async-sawtooth-sdk",
  "async-trait",
@@ -3230,7 +3230,7 @@ dependencies = [
 
 [[package]]
 name = "opa-tp-protocol"
-version = "0.1.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-sawtooth-sdk",
@@ -3262,7 +3262,7 @@ dependencies = [
 
 [[package]]
 name = "opactl"
-version = "0.1.0"
+version = "0.7.0"
 dependencies = [
  "async-sawtooth-sdk",
  "async-trait",
@@ -4449,7 +4449,7 @@ dependencies = [
 
 [[package]]
 name = "sawtooth_tp"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "async-sawtooth-sdk",
  "async-trait",

--- a/charts/chronicle/app-readme.md
+++ b/charts/chronicle/app-readme.md
@@ -8,5 +8,5 @@ You can find example domains and further instructions at https://examples.btp.wo
 
 ## *Important*
 
-*As Chronicle uses Sawtooth as it backing ledger, a minimum of 4 nodes is required for deployment.*
+*As Chronicle uses Sawtooth as its backing ledger, a minimum of 4 nodes is required for deployment.*
 *This helm chart will deploy and configure a 4 node Sawtooth network on your target cluster, so less than 4 nodes will result in the deployment failing.*

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -2,7 +2,7 @@
 build   = "build.rs"
 edition = "2021"
 name    = "api"
-version = "0.6.0"
+version = "0.7.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/crates/async-sawtooth-sdk/Cargo.toml
+++ b/crates/async-sawtooth-sdk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name    = "async-sawtooth-sdk"
-version = "0.1.0"
+version = "0.7.0"
 
 [lib]
 name = "async_sawtooth_sdk"

--- a/crates/chronicle-domain-lint/Cargo.toml
+++ b/crates/chronicle-domain-lint/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name    = "chronicle-domain-lint"
-version = "0.6.0"
+version = "0.7.0"
 
 [dependencies]
 chronicle = { path = "../chronicle" }

--- a/crates/chronicle-domain-test/Cargo.toml
+++ b/crates/chronicle-domain-test/Cargo.toml
@@ -2,7 +2,7 @@
 build   = "build.rs"
 edition = "2021"
 name    = "chronicle-example"
-version = "0.6.0"
+version = "0.7.0"
 
 [[bin]]
 name = "chronicle-example"

--- a/crates/chronicle-domain/Cargo.toml
+++ b/crates/chronicle-domain/Cargo.toml
@@ -2,7 +2,7 @@
 build   = "build.rs"
 edition = "2021"
 name    = "chronicle-domain"
-version = "0.6.0"
+version = "0.7.0"
 
 [[bin]]
 name = "chronicle"

--- a/crates/chronicle-protocol/Cargo.toml
+++ b/crates/chronicle-protocol/Cargo.toml
@@ -2,7 +2,7 @@
 build   = "build.rs"
 edition = "2021"
 name    = "chronicle-protocol"
-version = "0.6.0"
+version = "0.7.0"
 
 [lib]
 name = "chronicle_protocol"

--- a/crates/chronicle-synth/Cargo.toml
+++ b/crates/chronicle-synth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chronicle-synth"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 
 [lib]

--- a/crates/chronicle-telemetry/Cargo.toml
+++ b/crates/chronicle-telemetry/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name    = "chronicle-telemetry"
-version = "0.6.0"
+version = "0.7.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/chronicle/Cargo.toml
+++ b/crates/chronicle/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name    = "chronicle"
-version = "0.6.0"
+version = "0.7.0"
 
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -2,7 +2,7 @@
 build   = "build.rs"
 edition = "2021"
 name    = "common"
-version = "0.6.0"
+version = "0.7.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/opa-tp-protocol/Cargo.toml
+++ b/crates/opa-tp-protocol/Cargo.toml
@@ -2,7 +2,7 @@
 build   = "build.rs"
 edition = "2021"
 name    = "opa-tp-protocol"
-version = "0.1.0"
+version = "0.7.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/opa-tp/Cargo.toml
+++ b/crates/opa-tp/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name    = "opa-tp"
-version = "0.1.0"
+version = "0.7.0"
 
 [lib]
 name = "opa_tp"

--- a/crates/opactl/Cargo.toml
+++ b/crates/opactl/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name    = "opactl"
-version = "0.1.0"
+version = "0.7.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/sawtooth-tp/Cargo.toml
+++ b/crates/sawtooth-tp/Cargo.toml
@@ -9,7 +9,7 @@ path = "src/lib.rs"
 [package]
 edition = "2021"
 name    = "sawtooth_tp"
-version = "0.6.0"
+version = "0.7.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
api@0.7.0
async-sawtooth-sdk@0.7.0
chronicle@0.7.0
chronicle-domain@0.7.0
chronicle-domain-lint@0.7.0
chronicle-example@0.7.0
chronicle-protocol@0.7.0
chronicle-synth@0.7.0
chronicle-telemetry@0.7.0
common@0.7.0
opa-tp@0.7.0
opa-tp-protocol@0.7.0
opactl@0.7.0
sawtooth_tp@0.7.0

Generated by cargo-workspaces

Signed-off-by: Joseph Livesey [joseph.livesey@btp.works](mailto:joseph.livesey@btp.works)

[CHRON-326](https://blockchaintp.atlassian.net/browse/CHRON-326)

[CHRON-326]: https://blockchaintp.atlassian.net/browse/CHRON-326?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ