### PR TITLE
fix: Combine reader/writer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -488,9 +488,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.12.1"
+version = "3.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b1ce199063694f33ffb7dd4e0ee620741495c32833cde5aa08f02a0bf96f0c8"
+checksum = "3c6ed94e98ecff0c12dd1b04c15ec0d7d9458ca8fe806cea6f12954efe74c63b"
 
 [[package]]
 name = "bytecount"
@@ -646,9 +646,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.2.5"
+version = "4.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a1f23fa97e1d1641371b51f35535cb26959b8e27ab50d167a8b996b5bada819"
+checksum = "34d21f9bf1b425d2968943631ec91202fe5e837264063503708b83013f8fc938"
 dependencies = [
  "clap_builder",
  "clap_derive 4.2.0",
@@ -657,9 +657,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.2.5"
+version = "4.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fdc5d93c358224b4d6867ef1356d740de2303e9892edc06c5340daeccd96bab"
+checksum = "914c8c79fb560f238ef6429439a30023c862f7a28e688c58f7203f12b29970bd"
 dependencies = [
  "anstream",
  "anstyle",
@@ -787,7 +787,7 @@ dependencies = [
  "lazy_static",
  "percent-encoding",
  "pg-embed",
- "pkcs8",
+ "pkcs8 0.10.2",
  "portpicker",
  "proptest",
  "prost",
@@ -1093,6 +1093,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05e58dffcdcc8ee7b22f0c1f71a69243d7c2d9ad87b5a14361f2424a1565c219"
+dependencies = [
+ "const-oid",
+ "zeroize",
+]
+
+[[package]]
 name = "derivative"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1227,7 +1237,7 @@ version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
 dependencies = [
- "der",
+ "der 0.6.1",
  "elliptic-curve",
  "rfc6979",
  "serdect",
@@ -1248,13 +1258,13 @@ checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "der",
+ "der 0.6.1",
  "digest",
  "ff",
  "generic-array",
  "group",
  "pem-rfc7468",
- "pkcs8",
+ "pkcs8 0.9.0",
  "rand_core 0.6.4",
  "sec1",
  "serdect",
@@ -2014,9 +2024,9 @@ checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "js-sys"
-version = "0.3.61"
+version = "0.3.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
+checksum = "68c16e1bfd491478ab155fd8b4896b86f9ede344949b641e61501e07c2b8b4d5"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2061,7 +2071,7 @@ dependencies = [
  "anyhow",
  "base64 0.13.1",
  "bytecount",
- "clap 4.2.5",
+ "clap 4.2.7",
  "fancy-regex",
  "fraction",
  "iso8601",
@@ -2075,7 +2085,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "time 0.3.20",
+ "time 0.3.21",
  "url",
  "uuid 1.3.2",
 ]
@@ -2117,9 +2127,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.142"
+version = "0.2.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
+checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
 
 [[package]]
 name = "libm"
@@ -2144,9 +2154,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b64f40e5e03e0d54f03845c8197d0291253cdbedfb1cb46b13c2c117554a9f4c"
+checksum = "ece97ea872ece730aed82664c424eb4c8291e1ff2480247ccf7409044bc6479f"
 
 [[package]]
 name = "lock_api"
@@ -2911,15 +2921,25 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
 dependencies = [
- "der",
- "spki",
+ "der 0.6.1",
+ "spki 0.6.0",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der 0.7.5",
+ "spki 0.7.2",
 ]
 
 [[package]]
 name = "pkg-config"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
+checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
 name = "poem"
@@ -3243,9 +3263,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
+checksum = "8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500"
 dependencies = [
  "proc-macro2",
 ]
@@ -3492,9 +3512,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.18"
+version = "0.37.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bbfc1d1c7c40c01715f47d71444744a81669ca84e8b63e25a55e169b1f86433"
+checksum = "acf8729d8542766f1b2cf77eb034d52f40d375bb8b615d0b147089946e16613d"
 dependencies = [
  "bitflags",
  "errno",
@@ -3653,9 +3673,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
 dependencies = [
  "base16ct",
- "der",
+ "der 0.6.1",
  "generic-array",
- "pkcs8",
+ "pkcs8 0.9.0",
  "serdect",
  "subtle",
  "zeroize",
@@ -3704,9 +3724,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.160"
+version = "1.0.162"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2f3770c8bce3bcda7e149193a069a0f4365bda1fa5cd88e03bca26afc1216c"
+checksum = "71b2f6e1ab5c2b98c05f0f35b236b22e8df7ead6ffbf51d7808da7f8817e7ab6"
 dependencies = [
  "serde_derive",
 ]
@@ -3723,9 +3743,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.160"
+version = "1.0.162"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
+checksum = "a2a0814352fd64b58489904a44ea8d90cb1a91dcb6b4f5ebabc32c8318e93cb6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3904,7 +3924,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.6.1",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1e996ef02c474957d681f1b05213dfb0abab947b446a62d37770b23500184a"
+dependencies = [
+ "base64ct",
+ "der 0.7.5",
 ]
 
 [[package]]
@@ -4199,9 +4229,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.20"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
+checksum = "8f3403384eaacbca9923fa06940178ac13e4edb725486d70e8e15881d0c836cc"
 dependencies = [
  "serde",
  "time-core",
@@ -4210,15 +4240,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
+checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
 
 [[package]]
 name = "time-macros"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd80a657e71da814b8e5d60d3374fc6d35045062245d80224748ae522dd76f36"
+checksum = "372950940a5f07bf38dbe211d7283c9e6d7327df53794992d293e534c733d09b"
 dependencies = [
  "time-core",
 ]
@@ -4240,9 +4270,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.28.0"
+version = "1.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c786bf8134e5a3a166db9b29ab8f48134739014a3eca7bc6bfa95d673b136f"
+checksum = "0aa32867d44e6f2ce3385e89dceb990188b8bb0fb25b0cf576647a6f98ac5105"
 dependencies = [
  "autocfg",
  "bytes",
@@ -4532,9 +4562,9 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "uncased"
-version = "0.9.7"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09b01702b0fd0b3fadcf98e098780badda8742d4f4a7676615cad90e8ac73622"
+checksum = "9b9bc53168a4be7402ab86c3aad243a84dd7381d09be0eddc81280c1da95ca68"
 dependencies = [
  "version_check",
 ]
@@ -4762,9 +4792,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.84"
+version = "0.2.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
+checksum = "5b6cb788c4e39112fbe1822277ef6fb3c55cd86b95cb3d3c4c1c9597e4ac74b4"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -4772,24 +4802,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.84"
+version = "0.2.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
+checksum = "35e522ed4105a9d626d885b35d62501b30d9666283a5c8be12c14a8bdafe7822"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.15",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.34"
+version = "0.4.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f219e0d211ba40266969f6dbdd90636da12f75bee4fc9d6c23d1260dadb51454"
+checksum = "083abe15c5d88556b77bdf7aef403625be9e327ad37c62c4e4129af740168163"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -4799,9 +4829,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.84"
+version = "0.2.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
+checksum = "358a79a0cb89d21db8120cbfb91392335913e4890665b1a7981d9e956903b434"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4809,28 +4839,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.84"
+version = "0.2.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
+checksum = "4783ce29f09b9d93134d41297aded3a712b7b979e9c6f28c32cb88c973a94869"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.15",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.84"
+version = "0.2.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
+checksum = "a901d592cafaa4d711bc324edfaff879ac700b19c3dfd60058d2b445be2691eb"
 
 [[package]]
 name = "web-sys"
-version = "0.3.61"
+version = "0.3.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
+checksum = "16b5f940c7edfdc6d12126d98c9ef4d1b3d470011c47c76a6581df47ad9ba721"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/crates/api/src/chronicle_graphql/activity.rs
+++ b/crates/api/src/chronicle_graphql/activity.rs
@@ -22,9 +22,7 @@ pub async fn was_associated_with<'a>(
     id: i32,
     ctx: &Context<'a>,
 ) -> async_graphql::Result<Vec<(Agent, Option<Role>, Option<Agent>, Option<Role>)>> {
-    use crate::persistence::schema::agent;
-    use crate::persistence::schema::association;
-    use crate::persistence::schema::delegation;
+    use crate::persistence::schema::{agent, association, delegation};
 
     #[derive(Queryable)]
     struct DelegationAgents {

--- a/crates/api/src/chronicle_graphql/mod.rs
+++ b/crates/api/src/chronicle_graphql/mod.rs
@@ -304,7 +304,7 @@ impl Subscription {
                       }
                     }
                     Ok(SubmissionStage::Committed(Err((commit,contradiction)))) =>
-                      yield CommitNotification::from_contradiction(&commit, &*contradiction.to_string()),
+                      yield CommitNotification::from_contradiction(&commit, &contradiction.to_string()),
                     Ok(SubmissionStage::Submitted(Err(e))) => {
                       error!("Failed to submit: {:?}", e);
                       yield CommitNotification::from_submission_failed(&e);

--- a/crates/common/src/ledger.rs
+++ b/crates/common/src/ledger.rs
@@ -161,6 +161,7 @@ impl SubmissionStage {
     pub fn submitted_error(r: &SubmissionError) -> Self {
         SubmissionStage::Submitted(Err(r.clone()))
     }
+
     pub fn submitted(r: &ChronicleTransactionId) -> Self {
         SubmissionStage::Submitted(Ok(r.clone()))
     }

--- a/crates/common/src/prov/model/contradiction.rs
+++ b/crates/common/src/prov/model/contradiction.rs
@@ -66,6 +66,7 @@ impl Contradiction {
             contradiction: vec![ContradictionDetail::StartAlteration { value, attempted }],
         }
     }
+
     pub fn end_date_alteration(
         id: ChronicleIri,
         namespace: NamespaceId,

--- a/crates/common/src/prov/model/from_json_ld.rs
+++ b/crates/common/src/prov/model/from_json_ld.rs
@@ -1,8 +1,7 @@
 use chrono::{DateTime, Utc};
 use futures::{future::BoxFuture, FutureExt, TryFutureExt};
 use iref::{AsIri, Iri, IriBuf, IriRefBuf};
-use json::object;
-use json::JsonValue;
+use json::{object, JsonValue};
 use json_ld::{
     syntax::Term, util::AsJson, Document, Indexed, JsonContext, Loader, Node, Reference,
     RemoteDocument,
@@ -102,6 +101,7 @@ impl ProvModel {
 
         Ok(())
     }
+
     pub async fn apply_json_ld_bytes(&mut self, buf: &[u8]) -> Result<(), ProcessorError> {
         self.apply_json_ld(json::parse(std::str::from_utf8(buf)?)?)
             .await?;

--- a/crates/common/src/prov/model/mod.rs
+++ b/crates/common/src/prov/model/mod.rs
@@ -193,6 +193,7 @@ impl IdToSign {
             },
         }
     }
+
     fn to_sign(&self) -> Result<Vec<u8>, ProcessorError> {
         Ok(serde_json::to_string(self)?.as_bytes().to_vec())
     }

--- a/crates/sawtooth-protocol/src/messaging.rs
+++ b/crates/sawtooth-protocol/src/messaging.rs
@@ -1,40 +1,21 @@
-use std::{collections::HashSet, sync::Arc};
+use std::collections::HashSet;
 
 use crate::{
-    address::{SawtoothAddress, FAMILY, VERSION},
+    address::SawtoothAddress,
     messages::MessageBuilder,
-    sawtooth::{Batch, ClientBatchSubmitRequest, ClientBatchSubmitResponse, Transaction},
+    sawtooth::{Batch, Transaction},
 };
 
 use common::{
     k256::ecdsa::SigningKey,
-    ledger::{LedgerWriter, SubmissionError},
     protocol::ProtocolError,
     prov::{ChronicleTransaction, ChronicleTransactionId, ProcessorError},
 };
 use custom_error::*;
-use derivative::Derivative;
-use prost::Message as ProstMessage;
 
-use sawtooth_sdk::{
-    messages::validator::Message_MessageType,
-    messaging::{
-        stream::{MessageConnection, MessageReceiver, MessageSender, ReceiveError, SendError},
-        zmq_stream::{ZmqMessageConnection, ZmqMessageSender},
-    },
-};
+use sawtooth_sdk::messaging::stream::{ReceiveError, SendError};
 use tokio::task::JoinError;
-use tracing::{debug, instrument, trace};
-
-#[derive(Derivative)]
-#[derivative(Debug)]
-pub struct SawtoothSubmitter {
-    #[derivative(Debug = "ignore")]
-    tx: ZmqMessageSender,
-    rx: MessageReceiver,
-    builder: OperationMessageBuilder,
-    address: String,
-}
+use tracing::debug;
 
 #[derive(Debug)]
 pub struct OperationMessageBuilder {
@@ -95,104 +76,4 @@ custom_error! {pub SawtoothSubmissionError
     Join{source: JoinError}                                 = "Submission blocking thread pool",
     Ld{source: ProcessorError}                              = "Json LD processing",
     Protocol{source: ProtocolError}                         = "Protocol {source}",
-}
-
-/// The sawtooth futures and their sockets are not controlled by a compatible reactor
-impl SawtoothSubmitter {
-    #[allow(dead_code)]
-    pub fn new(address: &url::Url, signer: &SigningKey) -> Self {
-        let builder = OperationMessageBuilder::new(signer, FAMILY, VERSION);
-        let (tx, rx) = ZmqMessageConnection::new(address.as_str()).create();
-        SawtoothSubmitter {
-            tx,
-            rx,
-            builder,
-            address: address.to_string(),
-        }
-    }
-
-    #[instrument(
-        name = "submit_sawtooth_tx",
-        level = "info",
-        skip(self, transactions),
-        ret(Debug)
-    )]
-    async fn submit(
-        &mut self,
-        transactions: &ChronicleTransaction,
-    ) -> Result<ChronicleTransactionId, (ChronicleTransactionId, SawtoothSubmissionError)> {
-        // Practically, a protobuf serialization error here is probably a crash
-        // loop level fault, but we will handle it without panic for now
-        let (sawtooth_transaction, tx_id) = self
-            .builder
-            .make_tx(transactions)
-            .await
-            .map_err(|e| (ChronicleTransactionId::from(""), e.into()))?;
-
-        let ret_tx_id = tx_id.clone();
-
-        let res = async move {
-            let batch = self.builder.wrap_tx_as_sawtooth_batch(sawtooth_transaction);
-
-            trace!(?batch, "Validator request");
-
-            let request = ClientBatchSubmitRequest {
-                batches: vec![batch],
-            };
-
-            let mut future = loop {
-                let future = self.tx.send(
-                    Message_MessageType::CLIENT_BATCH_SUBMIT_REQUEST,
-                    &tx_id.to_string(),
-                    &request.encode_to_vec(),
-                );
-
-                // Force reconnection on any send error that's not a timeout -
-                // disconnect can actually mean a dead Zmq Thread
-                if let Err(SendError::UnknownError) | Err(SendError::DisconnectedError) = future {
-                    debug!("Send error, re-initialise ZMQ");
-                    let (tx, rx) = ZmqMessageConnection::new(self.address.as_str()).create();
-                    self.tx = tx;
-                    self.rx = rx;
-                    continue;
-                }
-
-                break future.unwrap();
-            };
-
-            debug!(submit_transaction=%tx_id);
-
-            let result = future.get_timeout(std::time::Duration::from_secs(10))?;
-
-            let response =
-                ClientBatchSubmitResponse::decode(&*result.content).map_err(ProtocolError::from)?;
-
-            debug!(validator_response=?response);
-
-            if response.status == 1 {
-                Ok(tx_id)
-            } else {
-                Err(SawtoothSubmissionError::UnexpectedStatus {
-                    status: response.status,
-                })
-            }
-        }
-        .await;
-
-        res.map_err(|e| (ret_tx_id, e))
-    }
-}
-
-#[async_trait::async_trait(?Send)]
-impl LedgerWriter for SawtoothSubmitter {
-    /// TODO: This blocks on a bunch of non tokio / futures 'futures' in the sawtooth rust SDK,
-    /// which also exposes a bunch of non clonable types so we probably need another dispatch / join mpsc here
-    async fn submit(
-        &mut self,
-        tx: &ChronicleTransaction,
-    ) -> Result<ChronicleTransactionId, SubmissionError> {
-        self.submit(tx)
-            .await
-            .map_err(|(tx_id, e)| SubmissionError::implementation(&tx_id, Arc::new(e.into())))
-    }
 }

--- a/crates/sawtooth-tp/src/abstract_tp.rs
+++ b/crates/sawtooth-tp/src/abstract_tp.rs
@@ -91,8 +91,8 @@ impl TPSideEffects {
 }
 
 impl IntoIterator for TPSideEffects {
-    type Item = TPSideEffect;
     type IntoIter = std::vec::IntoIter<Self::Item>;
+    type Item = TPSideEffect;
 
     fn into_iter(self) -> Self::IntoIter {
         self.effects.into_iter()

--- a/crates/sawtooth-tp/src/tp.rs
+++ b/crates/sawtooth-tp/src/tp.rs
@@ -91,6 +91,7 @@ impl TP for ChronicleTransactionHandler {
 
         Ok(state)
     }
+
     async fn tp_operations(submission: Submission) -> Result<ChronicleTransaction, ApplyError> {
         let identity = chronicle_identity_from_submission(submission.identity)
             .await


### PR DESCRIPTION
Observable behaviour from 0-6 logs is a deadlock during mutation after a long idle period.

Deadlock could be reproduced quickly with a chronicle build using a branch of sawtooth-sdk that has a small SyncSender buffer size - the default is 128.

Tokio console indicated that the write task was hung.

sawtooth-sdk-rust will block while attempting to send a message to a saturated SyncSender, holding open a lock which will in turn block the call to send().

The best fix for this scenario is to bring this in line with main - the same ZmqMessageConnection is used for read and write, as the read end will process the unsolicited messages.

* Share the underlying connection via Arc/Mutex , ensuring we empty the SyncStream buffer using the reader side
* Use uuid for correlation id, handles the full type range of SendError (even though SendError::Timeout is not emitted by the SDK)

This does not apply to main, where consolidating and refactoring the sawtooth networking had already addressed this.
