### PR TITLE
fix: Ensure event subscription is set up before commit

### DIFF
--- a/crates/opactl/src/cli.rs
+++ b/crates/opactl/src/cli.rs
@@ -341,11 +341,9 @@ pub(crate) enum Wait {
 
 impl Wait {
     pub(crate) fn from_matches(matches: &ArgMatches) -> Self {
-        if matches.get_one::<u64>("wait").is_some() {
-            let blocks = matches.get_one::<u64>("wait").unwrap();
-            Wait::NumberOfBlocks(*blocks)
-        } else {
-            Wait::NoWait
+        match matches.get_one::<u64>("wait") {
+            Some(blocks) if *blocks > 0 => Wait::NumberOfBlocks(*blocks),
+            _ => Wait::NoWait,
         }
     }
 }


### PR DESCRIPTION
Ordering could allow catch up from the commit that opa just sent Now uses a channel to wait the ambient_transactions call until a successful event subscription

--wait 0 now corresponds to NoWait

Ref: CHRON-355