### PR TITLE
build authentication server image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,3 +8,4 @@
 !docker/chronicle-config
 !docker/chronicle-test
 !docker/chronicle-helm-test
+!docker/id-provider-settings.yml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2257,6 +2257,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
+dependencies = [
+ "http",
+ "hyper",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+]
+
+[[package]]
 name = "hyper-tls"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3008,7 +3021,7 @@ dependencies = [
  "log",
  "memchr",
  "mime",
- "spin",
+ "spin 0.9.8",
  "version_check",
 ]
 
@@ -3168,6 +3181,35 @@ checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
  "hermit-abi 0.2.6",
  "libc",
+]
+
+[[package]]
+name = "oauth-token"
+version = "0.7.0"
+dependencies = [
+ "anyhow",
+ "oauth2",
+ "url",
+]
+
+[[package]]
+name = "oauth2"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50df55a3cc0374df91ef8da8741542d9e0b9e6581481ed1cffe84f64d2f5fc3d"
+dependencies = [
+ "base64 0.13.1",
+ "chrono",
+ "getrandom 0.2.9",
+ "http",
+ "rand 0.8.5",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "sha2",
+ "thiserror",
+ "url",
 ]
 
 [[package]]
@@ -4305,6 +4347,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
+ "hyper-rustls",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -4314,16 +4357,20 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
  "winreg",
 ]
 
@@ -4345,6 +4392,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "087317b3cf7eb481f13bd9025d729324b7cd068d6f470e2d76d049e191f5ba47"
 dependencies = [
  "uncased",
+]
+
+[[package]]
+name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin 0.5.2",
+ "untrusted",
+ "web-sys",
+ "winapi",
 ]
 
 [[package]]
@@ -4414,6 +4476,27 @@ dependencies = [
  "libc",
  "linux-raw-sys 0.3.7",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "rustls"
+version = "0.20.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fff78fc74d175294f4e83b28343315ffcfb114b156f0185e9741cb5570f50e2f"
+dependencies = [
+ "log",
+ "ring",
+ "sct",
+ "webpki",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
+dependencies = [
+ "base64 0.21.0",
 ]
 
 [[package]]
@@ -4544,6 +4627,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
+name = "sct"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
 name = "sec1"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4637,6 +4730,15 @@ checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
 dependencies = [
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7f05c1d5476066defcdfacce1f52fc3cae3af1d3089727100c02ae92e5abbe0"
+dependencies = [
  "serde",
 ]
 
@@ -4816,6 +4918,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"
@@ -5166,6 +5274,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
+dependencies = [
+ "rustls",
+ "tokio",
+ "webpki",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5462,6 +5581,12 @@ name = "unsafe-libyaml"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1865806a559042e51ab5414598446a5871b561d21b6764f2eabb0dd481d880a6"
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "uritemplate-next"
@@ -5870,6 +5995,25 @@ checksum = "3bdd9ef4e984da1187bf8110c5cf5b845fbc87a23602cdf912386a76fcd3a7c2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
+dependencies = [
+ "webpki",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
   "crates/chronicle-domain-test",
   "crates/chronicle-protocol",
   "crates/chronicle-synth",
+  "crates/id-provider",
   "crates/opa-tp-protocol",
   "crates/opactl",
   "crates/sawtooth-tp",
@@ -74,6 +75,7 @@ locspan = "0.7"
 maplit = "1.0.2"
 mime = "0.3"
 mockito = "1.0.2"
+oauth2 = "4.4"
 opa = "0.9.0"
 openssl = "0.10.48"
 opentelemetry = { version = "0.18.0", features = ["rt-tokio"] }

--- a/crates/id-provider/Cargo.toml
+++ b/crates/id-provider/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+edition = "2021"
+name = "oauth-token"
+version = "0.7.0"
+
+[dependencies]
+anyhow = { workspace = true }
+oauth2 = { workspace = true }
+url = { workspace = true }

--- a/crates/id-provider/src/main.rs
+++ b/crates/id-provider/src/main.rs
@@ -1,0 +1,70 @@
+use oauth2::basic::BasicClient;
+use oauth2::reqwest::http_client;
+use oauth2::{
+    AuthUrl, AuthorizationCode, ClientId, ClientSecret, CsrfToken, PkceCodeChallenge, RedirectUrl,
+    Scope, TokenResponse, TokenUrl,
+};
+use std::process::Command;
+use url::Url;
+
+fn main() -> Result<(), anyhow::Error> {
+    // construct OAuth query: authorization code flow with PKCE
+
+    let oauth_client = BasicClient::new(
+        ClientId::new("client-id".to_string()),
+        Some(ClientSecret::new("client-secret".to_string())),
+        AuthUrl::new("http://localhost:8090/authorize".to_string())?,
+        Some(TokenUrl::new("http://localhost:8090/token".to_string())?),
+    )
+    .set_redirect_uri(RedirectUrl::new("http://example.com/callback".to_string())?);
+
+    let (pkce_challenge, pkce_verifier) = PkceCodeChallenge::new_random_sha256();
+
+    let (auth_url, csrf_token) = oauth_client
+        .authorize_url(CsrfToken::new_random)
+        .add_scope(Scope::new("openid".to_string()))
+        .add_scope(Scope::new("profile".to_string()))
+        .add_scope(Scope::new("email".to_string()))
+        .set_pkce_challenge(pkce_challenge)
+        .url();
+
+    // use curl to handle HTTP basic authentication
+
+    let args = vec![
+        "-w".to_string(),
+        "%{redirect_url}\n".to_string(),
+        "-u".to_string(),
+        "rmalina1:test-password".to_string(),
+        auth_url.to_string(),
+    ];
+
+    let curl_output = Command::new("curl").args(args).output()?;
+
+    // parse URL from redirect to callback with authorization code
+
+    let url = Url::parse(std::str::from_utf8(&curl_output.stdout)?.trim())?;
+
+    let mut query_state = None;
+    let mut query_code = None;
+
+    for (key, value) in url.query_pairs() {
+        match key.to_string().as_str() {
+            "state" => query_state = Some(value),
+            "code" => query_code = Some(value),
+            _ => {}
+        }
+    }
+
+    assert_eq!(*csrf_token.secret(), query_state.unwrap().to_string());
+
+    // exchange authorization code for access token
+
+    let auth_code = query_code.unwrap();
+    let token_response = oauth_client
+        .exchange_code(AuthorizationCode::new(auth_code.to_string()))
+        .set_pkce_verifier(pkce_verifier)
+        .request(http_client)?;
+
+    println!("{}", token_response.access_token().secret());
+    Ok(())
+}

--- a/docker/id-provider-settings.yml
+++ b/docker/id-provider-settings.yml
@@ -1,0 +1,11 @@
+server:
+  port: 8090
+oidc:
+  tokenExpirationSeconds: 36000
+  users:
+    rmalina1:
+      password: "test-password"
+      sub: "user-525"
+      given_name: "Ruairidh"
+      family_name: "Malina"
+      email: "r.malina@example.com"

--- a/docker/unified-builder
+++ b/docker/unified-builder
@@ -125,7 +125,8 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
   && mv -f target/${CARGO_BUILD_TARGET}/release/chronicle_sawtooth_tp /artifacts/${TARGETARCH} \
   && mv -f target/${CARGO_BUILD_TARGET}/release/chronicle-domain-lint /artifacts/${TARGETARCH} \
   && mv -f target/${CARGO_BUILD_TARGET}/release/opactl /artifacts/${TARGETARCH} \
-  && mv -f target/${CARGO_BUILD_TARGET}/release/opa-tp /artifacts/${TARGETARCH}
+  && mv -f target/${CARGO_BUILD_TARGET}/release/opa-tp /artifacts/${TARGETARCH} \
+  && mv -f target/${CARGO_BUILD_TARGET}/release/oauth-token /artifacts/${TARGETARCH}
 
 
 FROM crossbuild AS testbase
@@ -183,13 +184,20 @@ WORKDIR /app
 RUN cargo fetch --locked
 
 
-FROM --platform=${TARGETPLATFORM} debian:bullseye-slim AS final-base
+FROM --platform=${TARGETPLATFORM} debian:bullseye-slim AS debian-upgraded
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update \
+    && apt-get upgrade -y
+
+
+FROM debian-upgraded AS final-base
 ARG TARGETARCH
 
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   --mount=type=cache,target=/var/lib/apt,sharing=locked \
-  apt-get update \
-  && apt-get install -y --no-install-recommends \
+  apt-get install -y --no-install-recommends \
   ca-certificates \
   libpq5
 
@@ -241,3 +249,52 @@ ARG TARGETARCH
 COPY --from=artifacts /artifacts/${TARGETARCH}/opactl /usr/local/bin/opactl
 
 USER chronicle
+
+
+# Now to build the id-provider image
+FROM --platform=${TARGETPLATFORM} debian-upgraded AS auth-server-requirements
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get install --no-install-recommends -y \
+        curl \
+        openjdk-17-jre-headless
+
+
+FROM --platform=${TARGETPLATFORM} auth-server-requirements AS auth-server-build-requirements
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get install --no-install-recommends -y \
+        git \
+        maven \
+        openjdk-17-jdk-headless
+
+
+FROM --platform=${TARGETPLATFORM} auth-server-build-requirements AS auth-server-artifacts
+
+RUN useradd -m builder
+USER builder
+RUN mkdir /home/builder/fake-oidc-server/
+WORKDIR /home/builder/fake-oidc-server/
+
+RUN git init
+RUN git remote add origin https://github.com/CESNET/fake-oidc-server.git
+RUN git fetch origin 586a884d217e1eee7be2cc5951907745d4112165
+RUN git reset --hard FETCH_HEAD
+COPY docker/id-provider-settings.yml src/main/resources/application.yml
+RUN mvn package
+
+
+FROM --platform=${TARGETPLATFORM} auth-server-requirements AS authentication-server
+ARG TARGETARCH
+
+RUN useradd -m runner
+USER runner
+
+COPY --from=artifacts /artifacts/${TARGETARCH}/oauth-token /usr/local/bin/
+COPY --from=auth-server-artifacts /home/builder/fake-oidc-server/target/fake_oidc_server.jar /home/runner/
+
+CMD java -jar fake_oidc_server.jar
+
+EXPOSE 8090


### PR DESCRIPTION
For the JWKS-enabled Helm testing in CHRON-330 we need a source of verifiable authorization tokens. This PR isn't a proposal for how to include this with Chronicle's testing, it's more a current means to provide the authentication server side for the testing.

Notes on actually using this with `curl` and Chronicle:

1. While the container is running (e.g., during a part of `make test` for this PR) one may `docker exec <container> oauth-token` to obtain a new bearer token arbitrarily many times.
2. Add this token to API requests with some equivalent of curl's `-H "Authorization: Bearer <token>"` filling in the provided token.
3. Forward a local port in Chronicle's container into this new container. That is, Chronicle's `http://localhost:8090/` should reach this container's exposed TCP 8090. (I didn't string that together for this PR because I figure we're using helm, not docker compose, anyway.)
4. Chronicle's settings may then include `--require-auth --id-claims email --jwks-address http://localhost:8090/jwks --userinfo-address http://localhost:8090/userinfo` where we are using the `email` field to make doubly sure that the `/userinfo` endpoint is being used. If you try your oauth-token at https://jwt.io/ then you will see it doesn't have `email` already.