### PR TITLE
fix: Stream completion for opactl / async-sawtooth-sdk

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -282,7 +282,7 @@ where
         let start_from_block = if let Ok(Some(start_from_block)) = last_seen_block {
             FromBlock::BlockId(start_from_block)
         } else {
-            FromBlock::Genesis //Full catch up, as we have no last seen block
+            FromBlock::First //Full catch up, as we have no last seen block
         };
 
         debug!(start_from_block = ?start_from_block, "Starting from block");

--- a/crates/async-sawtooth-sdk/src/sawtooth.rs
+++ b/crates/async-sawtooth-sdk/src/sawtooth.rs
@@ -91,7 +91,7 @@ impl MessageBuilder {
             })
             .into(),
             sorting: vec![ClientSortControls {
-                reverse: true,
+                reverse: false,
                 keys: vec!["block_num".to_string()].into(),
                 ..Default::default()
             }]
@@ -100,9 +100,9 @@ impl MessageBuilder {
         }
     }
 
-    pub fn get_genesis_block_id_request(&self) -> ClientBlockGetByNumRequest {
+    pub fn get_first_block_id_request(&self) -> ClientBlockGetByNumRequest {
         ClientBlockGetByNumRequest {
-            block_num: 0,
+            block_num: 1,
             ..Default::default()
         }
     }
@@ -181,7 +181,7 @@ impl MessageBuilder {
         batch
     }
 
-    #[instrument]
+    #[instrument(skip(payload, signer), level = "trace")]
     pub async fn make_sawtooth_transaction<P: TransactionPayload + std::fmt::Debug>(
         &self,
         input_addresses: Vec<String>,

--- a/crates/async-sawtooth-sdk/src/zmq_client.rs
+++ b/crates/async-sawtooth-sdk/src/zmq_client.rs
@@ -222,8 +222,8 @@ impl RequestResponseSawtoothChannel for ZmqRequestResponseSawtoothChannel {
                         .rx
                         .lock()
                         .unwrap()
-                        .recv_timeout(Duration::from_secs(30));
-                    debug!(?response);
+                        .recv_timeout(Duration::from_secs(10));
+                    debug!(have_response=?response);
                     (channel, response)
                 })
                 .await;

--- a/crates/opactl/src/main.rs
+++ b/crates/opactl/src/main.rs
@@ -1,4 +1,6 @@
-use async_sawtooth_sdk::zmq_client::ZmqRequestResponseSawtoothChannel;
+use async_sawtooth_sdk::zmq_client::{
+    RequestResponseSawtoothChannel, ZmqRequestResponseSawtoothChannel,
+};
 use clap::ArgMatches;
 use cli::{load_key_from_match, Wait};
 use futures::{channel::oneshot, Future, StreamExt};
@@ -360,6 +362,7 @@ async fn main() {
         .map_err(|opactl| {
             error!(?opactl);
             opactl.into_ufe().print();
+            client.close();
             std::process::exit(1);
         })
         .map(|waited| {
@@ -371,6 +374,8 @@ async fn main() {
             }
         })
         .ok();
+
+    client.close();
 }
 
 // Use as much of the opa-tp as possible, by using a simulated `RequestResponseSawtoothChannel`


### PR DESCRIPTION
* Ensure Shutdown is sent to ZmqMessageConnection before shutting down tasks to avoid panic
* Use select! and join! to simplify task waiting
* Calculate number of blocks remaining before timeout correctly, and log it
  in a readable way
* Log stream completion, no need to handle none with the select!
* Various instrumentation improvements
* Blockid width, warn on parse failiures
* Tested with high concurrency to induce overlapped transaction writes /
  waits in multiple clients

Ref: CHRON-358

# PR Checklist

## Please complete this checklist after opening your PR

* [x] I have updated documentation as necessary
* [x] I have updated helm chart(s) if needed
* [x] I have added tests if needed
* [x] All new and existing tests are passing
* [x] Any breaking changes are clearly flagged and documented
* [x] I’ve included a link to any relevant ticket(s)
