### PR TITLE
provide simple tool for authenticated graphql subscriptions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1503,6 +1503,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2e66c9d817f1720209181c316d28635c050fa304f9c79e47a520882661b7308"
+
+[[package]]
 name = "decoded-char"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2049,6 +2055,18 @@ dependencies = [
  "bitflags",
  "ignore",
  "walkdir",
+]
+
+[[package]]
+name = "gq-ws"
+version = "0.7.0"
+dependencies = [
+ "anyhow",
+ "clap 3.2.25",
+ "http",
+ "rand 0.8.5",
+ "serde_json",
+ "tungstenite 0.19.0",
 ]
 
 [[package]]
@@ -5304,7 +5322,7 @@ dependencies = [
  "futures-util",
  "log",
  "tokio",
- "tungstenite",
+ "tungstenite 0.18.0",
 ]
 
 [[package]]
@@ -5500,6 +5518,25 @@ dependencies = [
  "base64 0.13.1",
  "byteorder",
  "bytes",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "sha1",
+ "thiserror",
+ "url",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15fba1a6d6bb030745759a9a2a588bfe8490fc8b4751a277db3a0be1c9ebbf67"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
  "http",
  "httparse",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
   "crates/chronicle-domain-test",
   "crates/chronicle-protocol",
   "crates/chronicle-synth",
+  "crates/gq-subscribe",
   "crates/id-provider",
   "crates/opa-tp-protocol",
   "crates/opactl",
@@ -53,6 +54,7 @@ genco = "0.16.1"
 glob = "0.3.0"
 hashbrown = "0.13"
 hex = "0.4.3"
+http = "0.2.9"
 insta = { version = "1.26.0", features = ["redactions", "toml"] }
 iref = "2.2"
 iref-enum = "2.1"
@@ -137,6 +139,7 @@ tracing-subscriber = { version = "0.3.15", features = [
   "env-filter",
   "json",
 ] }
+tungstenite = "0.19"
 url = "2.3.1"
 user-error = "1.2.8"
 uuid = "1.2.2"

--- a/crates/gq-subscribe/Cargo.toml
+++ b/crates/gq-subscribe/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+edition = "2021"
+name = "gq-ws"
+version = "0.7.0"
+
+[dependencies]
+anyhow = { workspace = true }
+clap = { workspace = true }
+http = { workspace = true }
+rand = { workspace = true }
+serde_json = { workspace = true }
+tungstenite = { workspace = true }

--- a/crates/gq-subscribe/src/main.rs
+++ b/crates/gq-subscribe/src/main.rs
@@ -1,0 +1,127 @@
+use clap::{Arg, Command};
+use http::{HeaderValue, StatusCode};
+use rand::distributions::Alphanumeric;
+use rand::{thread_rng, Rng};
+use serde_json::{json, Value};
+use std::net::SocketAddr;
+use tungstenite::{client::IntoClientRequest, connect, Message};
+
+fn main() -> Result<(), anyhow::Error> {
+    let args = Command::new("gq-ws")
+        .author("Blockchain Technology Partners")
+        .about("Perform GraphQL subscription to a websocket")
+        .arg(
+            Arg::new("request")
+                .long("subscription")
+                .short('s')
+                .takes_value(true)
+                .required(true)
+                .help("the GraphQL subscription request"),
+        )
+        .arg(
+            Arg::new("count")
+                .long("notification-count")
+                .short('c')
+                .takes_value(true)
+                .required(true)
+                .help("how many responses to report"),
+        )
+        .arg(
+            Arg::new("address")
+                .long("chronicle-address")
+                .short('a')
+                .takes_value(true)
+                .default_value("127.0.0.1:9982")
+                .help("the network address of the Chronicle API"),
+        )
+        .arg(
+            Arg::new("token")
+                .long("bearer-token")
+                .short('t')
+                .takes_value(true)
+                .help("the bearer token to pass for authorization"),
+        )
+        .get_matches();
+
+    let subscription_query = args.value_of("request").unwrap();
+    let notification_count: u32 = args.value_of("count").unwrap().parse()?;
+    let chronicle_address: SocketAddr = args.value_of("address").unwrap().parse()?;
+    let bearer_token = args.value_of("token");
+
+    // generate random ID for subscription
+    let subscription_id: String = thread_rng()
+        .sample_iter(&Alphanumeric)
+        .take(12)
+        .map(char::from)
+        .collect();
+
+    // prepare websocket request
+    let mut client_request = format!("ws://{chronicle_address}/ws").into_client_request()?;
+    let headers = client_request.headers_mut();
+    if let Some(token) = bearer_token {
+        headers.insert(
+            "Authorization",
+            HeaderValue::from_str(&format!("Bearer {token}"))?,
+        );
+    }
+    headers.insert(
+        "Sec-WebSocket-Protocol",
+        HeaderValue::from_str("graphql-ws")?,
+    );
+
+    // connect and upgrade websocket
+    let (mut socket, response) = connect(client_request)?;
+    if response.status() != StatusCode::SWITCHING_PROTOCOLS {
+        panic!("failed connect and upgrade: {response:#?}");
+    }
+
+    // initialize gql connection
+    let conn_init_json = json!({
+        "type": "connection_init"
+    });
+    let conn_init_msg = Message::Text(serde_json::to_string(&conn_init_json)?);
+    socket.write_message(conn_init_msg)?;
+    let conn_response = socket.read_message()?;
+    if let Value::Object(map) = serde_json::from_str::<Value>(&conn_response.clone().into_text()?)?
+    {
+        if map.get("type") == Some(&Value::String("connection_ack".to_string())) {
+            // connection initialized, so subscribe
+            let subscription_json = json!({
+                "type": "start",
+                "id": subscription_id,
+                "payload": {
+                    "query": subscription_query
+                }
+            });
+            let subscription_msg = Message::Text(serde_json::to_string(&subscription_json)?);
+            socket.write_message(subscription_msg)?;
+
+            // receive and print notifications
+            let data_json = Value::String("data".to_string());
+            let subscription_id_json = Value::String(subscription_id);
+            let mut remaining = notification_count;
+            while remaining > 0 {
+                remaining -= 1;
+                let notification_msg = socket.read_message()?;
+                let notification_json =
+                    serde_json::from_str::<Value>(&notification_msg.into_text()?)?;
+
+                if let Value::Object(map) = notification_json.clone() {
+                    if map.get("type") == Some(&data_json)
+                        && map.get("id") == Some(&subscription_id_json)
+                    {
+                        let notification_pretty =
+                            serde_json::to_string_pretty(map.get("payload").unwrap())?;
+                        println!("{notification_pretty}");
+                    } else {
+                        panic!("expected a response to subscription, got: {notification_json}");
+                    }
+                } else {
+                    panic!("expected a JSON object notification, got: {notification_json}");
+                }
+            }
+            return Ok(());
+        }
+    }
+    panic!("expected acknowledgement of connection initialization, got: {conn_response}");
+}

--- a/docker/unified-builder
+++ b/docker/unified-builder
@@ -121,12 +121,9 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
   exit 1; \
   fi \
   && cargo build --locked --release --target ${CARGO_BUILD_TARGET} ${BUILD_ARGS} \
-  && mv -f target/${CARGO_BUILD_TARGET}/release/chronicle /artifacts/${TARGETARCH} \
-  && mv -f target/${CARGO_BUILD_TARGET}/release/chronicle_sawtooth_tp /artifacts/${TARGETARCH} \
-  && mv -f target/${CARGO_BUILD_TARGET}/release/chronicle-domain-lint /artifacts/${TARGETARCH} \
-  && mv -f target/${CARGO_BUILD_TARGET}/release/opactl /artifacts/${TARGETARCH} \
-  && mv -f target/${CARGO_BUILD_TARGET}/release/opa-tp /artifacts/${TARGETARCH} \
-  && mv -f target/${CARGO_BUILD_TARGET}/release/oauth-token /artifacts/${TARGETARCH}
+  && for i in chronicle chronicle_sawtooth_tp chronicle-domain-lint opactl opa-tp oauth-token gq-ws; \
+  do mv -f target/${CARGO_BUILD_TARGET}/release/$i /artifacts/${TARGETARCH}; \
+  done
 
 
 FROM crossbuild AS testbase
@@ -303,6 +300,7 @@ EXPOSE 8090
 
 # Build the chronicle-helm-api-test image
 FROM --platform=${TARGETPLATFORM} debian-upgraded AS chronicle-helm-api-test
+ARG TARGETARCH
 
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
@@ -317,6 +315,7 @@ RUN bash ./setup_lts.x
 RUN apt-get install -y nodejs
 RUN npm install -g -f graphqurl --yes
 
+COPY --from=artifacts /artifacts/${TARGETARCH}/gq-ws /usr/local/bin/
 COPY docker/helm-api-subscribe-submit-test /usr/local/bin/subscribe-submit-test
 
 CMD /usr/local/bin/subscribe-submit-test


### PR DESCRIPTION
Assists CHRON-330 by providing a new Rust binary. Example usage:

```
gq-ws -c 2 -s "subscription { commitNotifications { stage delta txId error } }" -t mybearertokenfromoauthtoken
```

It works *only* for subscriptions. The "2" is how many notifications we want reported (I guessed, a submit then a commit). The `-t` argument is optional, it can also do anonymous. `--help` offers a bit more information.

# PR Checklist

## Please complete this checklist after opening your PR

* [x] I have updated documentation as necessary
* [x] I have updated helm chart(s) if needed
* [x] I have added tests if needed
* [x] All new and existing tests are passing
* [x] Any breaking changes are clearly flagged and documented
* [x] I’ve included a link to any relevant ticket(s)
