### PR TITLE
do not COPY artifacts with --link

### DIFF
--- a/docker/unified-builder
+++ b/docker/unified-builder
@@ -155,7 +155,7 @@ USER tester
 
 
 FROM --platform=${TARGETPLATFORM} rust:${RUST_VERSION} as artifacts
-COPY --from=crossbuild --link /artifacts /artifacts
+COPY --from=crossbuild /artifacts /artifacts
 
 
 FROM --platform=${TARGETPLATFORM} rust:${RUST_VERSION} as chronicle-builder


### PR DESCRIPTION
# PR Checklist

Docker Engine 23.0.1, which currently runs on our CI, has caching that [may misbehave](https://github.com/docker/buildx/issues/1099#issuecomment-1524265654) if `COPY --link` is used because of https://github.com/moby/moby/issues/45111. This PR drops the `--link` as we are using it at the start of the stage anyway and it is not worth tempting fate.

## Please complete this checklist after opening your PR

* [x] I have updated documentation as necessary
* [x] I have updated helm chart(s) if needed
* [x] I have added tests if needed
* [x] All new and existing tests are passing
* [x] Any breaking changes are clearly flagged and documented
* [x] I’ve included a link to any relevant ticket(s)
