### PR TITLE
have maven build share artifact cache

### DIFF
--- a/docker/unified-builder
+++ b/docker/unified-builder
@@ -281,6 +281,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 
 
 FROM hostbase AS auth-server-artifacts
+ARG UID=1001
 
 USER root
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
@@ -291,9 +292,9 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   maven \
   openjdk-17-jdk-headless
 
-RUN useradd -m builder
+RUN useradd -u ${UID} -m builder
 USER builder
-RUN mkdir /home/builder/fake-oidc-server/
+RUN mkdir /home/builder/.m2/ /home/builder/fake-oidc-server/
 WORKDIR /home/builder/fake-oidc-server/
 
 RUN git init
@@ -301,7 +302,8 @@ RUN git remote add origin https://github.com/CESNET/fake-oidc-server.git
 RUN git fetch origin 586a884d217e1eee7be2cc5951907745d4112165
 RUN git reset --hard FETCH_HEAD
 COPY docker/id-provider-settings.yml src/main/resources/application.yml
-RUN mvn -B package
+RUN --mount=type=cache,target=/home/builder/.m2,sharing=locked,uid=${UID} \
+  mvn -B package
 
 
 FROM auth-server-requirements AS id-provider


### PR DESCRIPTION
The stage with the Maven build may be executed more than once so this avoids downloading all the JARs again.

# PR Checklist

## Please complete this checklist after opening your PR

* [x] I have updated documentation as necessary
* [x] I have updated helm chart(s) if needed
* [x] I have added tests if needed
* [x] All new and existing tests are passing
* [x] Any breaking changes are clearly flagged and documented
* [x] I’ve included a link to any relevant ticket(s)