### PR TITLE
fix: Exit 0 on no policy found with get-policy

### DIFF
--- a/crates/async-sawtooth-sdk/src/error.rs
+++ b/crates/async-sawtooth-sdk/src/error.rs
@@ -66,4 +66,7 @@ pub enum SawtoothCommunicationError {
 
     #[error("Infallible {0}")]
     Infallible(#[from] std::convert::Infallible),
+
+    #[error("Resource not found")]
+    ResourceNotFound,
 }

--- a/crates/async-sawtooth-sdk/src/ledger.rs
+++ b/crates/async-sawtooth-sdk/src/ledger.rs
@@ -638,6 +638,8 @@ impl<
 
         if response.status == ClientStateGetResponse_Status::OK {
             Ok(response.value)
+        } else if response.status == ClientStateGetResponse_Status::NO_RESOURCE {
+            Err(SawtoothCommunicationError::ResourceNotFound)
         } else {
             Err(SawtoothCommunicationError::UnexpectedStatus {
                 status: response.status as i32,

--- a/crates/opactl/src/main.rs
+++ b/crates/opactl/src/main.rs
@@ -385,9 +385,16 @@ async fn dispatch_args<
             Ok((Waited::NoWait, reader))
         }
         Some(("get-policy", matches)) => {
-            let policy: Vec<u8> = reader
+            let policy: Result<Vec<u8>, _> = reader
                 .get_state_entry(&policy_address(matches.get_one::<String>("id").unwrap()))
-                .await?;
+                .await;
+
+            if let Err(SawtoothCommunicationError::ResourceNotFound) = policy {
+                print!("No policy found");
+                return Ok((Waited::NoWait, reader));
+            }
+
+            let policy = policy?;
 
             if let Some(path) = matches.get_one::<String>("output") {
                 let mut file = File::create(path).unwrap();


### PR DESCRIPTION
* Introduce a resource not found error into SawtoothCommunicationError
* Handle this specifically for get-policy

Ref: CHRON-379

# PR Checklist

## Please complete this checklist after opening your PR

* [x] I have updated documentation as necessary
* [x] I have updated helm chart(s) if needed
* [x] I have added tests if needed
* [x] All new and existing tests are passing
* [x] Any breaking changes are clearly flagged and documented
* [x] I’ve included a link to any relevant ticket(s)
