### PR TITLE
cleanly check for policy and update to Chronicle v0.7.4

### DIFF
--- a/charts/chronicle/Chart.yaml
+++ b/charts/chronicle/Chart.yaml
@@ -17,7 +17,7 @@ keywords:
 # This is the chart version. This version number should be incremented each
 # time you make changes to the chart and its templates, including the app
 # version.
-version: 0.1.21
+version: 0.1.22
 
 # This is the version number of Chronicle being deployed. This version
 # number should be incremented each time you make changes to Chronicle.

--- a/charts/chronicle/Chart.yaml
+++ b/charts/chronicle/Chart.yaml
@@ -21,7 +21,7 @@ version: 0.1.22
 
 # This is the version number of Chronicle being deployed. This version
 # number should be incremented each time you make changes to Chronicle.
-appVersion: 0.7.3
+appVersion: 0.7.4
 
 dependencies:
   - name: standard-defs

--- a/charts/chronicle/templates/chronicle-init.yaml
+++ b/charts/chronicle/templates/chronicle-init.yaml
@@ -159,13 +159,17 @@ spec:
           command: [ "bash", "-ec"]
           args:
             - |
-              if opactl \
-                  --sawtooth-address tcp://$HOST:$PORT \
-                    get-policy \
-                      --id {{ .Values.opa.policy.id }} \
-                      --output policy.bin >/dev/null 2>&1; then
+              echo "Attempting to get policy."
+              opactl \
+                --sawtooth-address tcp://$HOST:$PORT \
+                  get-policy \
+                    --id {{ .Values.opa.policy.id }} \
+                    --output /shared-data/policy.bin
+
+              if [ -f "/shared-data/policy.bin" ]; then
                 echo "Policy already set."
                 touch /shared-data/policy-already-set
+                exit 0
               else
                 echo "Policy not found."
                 exit 0

--- a/charts/chronicle/values.yaml
+++ b/charts/chronicle/values.yaml
@@ -34,7 +34,7 @@ devIdProvider:
     ## @md | `devIdProvider.image.repository` | the image repository | blockchaintp/id-provider |
     repository: blockchaintp/id-provider-amd64
     ## @md | `devIdProvider.image.tag` | the image tag | latest |
-    tag: BTP2.1.0-0.7.3
+    tag: BTP2.1.0-0.7.4
 
 ## @md | `extraVolumes` | a list of additional volumes to add to chronicle | [] |
 extraVolumes: []
@@ -45,7 +45,7 @@ image:
   ## @md | `image.repository` | the repository of the image | blockchaintp/chronicle |
   repository: blockchaintp/chronicle-amd64
   ## @md | `image.tag`| the tag of the image to use | latest |
-  tag: BTP2.1.0-0.7.3
+  tag: BTP2.1.0-0.7.4
   ## @md | `image.pullPolicy` | the image pull policy to use | IfNotPresent |
   pullPolicy: IfNotPresent
 
@@ -98,7 +98,7 @@ opa:
       ## @md | `image.repository` | the repository of the image | blockchaintp/chronicle |
       repository: blockchaintp/opactl-amd64
       ## @md | `image.tag`| the tag of the image to use | latest |
-      tag: BTP2.1.0-0.7.3
+      tag: BTP2.1.0-0.7.4
   policy:
     entrypoint: allow_transactions.allowed_users
     id: allow_transactions
@@ -108,7 +108,7 @@ opa:
       ## @md | `image.repository` | the repository of the image | blockchaintp/chronicle |
       repository: blockchaintp/opa-tp-amd64
       ## @md | `image.tag`| the tag of the image to use | latest |
-      tag: BTP2.1.0-0.7.3
+      tag: BTP2.1.0-0.7.4
       ## @md | `image.pullPolicy` | the image pull policy to use | IfNotPresent |
       pullPolicy: IfNotPresent
     ## @md | `opa.tp.resources` | resources | map | nil |
@@ -142,7 +142,7 @@ test:
       ## @md | `test.api.image.repository` | the image repository | blockchaintp/chronicle-helm-api-test |
       repository: blockchaintp/chronicle-helm-api-test-amd64
       ## @md | `test.api.image.tag` | the image tag | latest |
-      tag: BTP2.1.0-0.7.3
+      tag: BTP2.1.0-0.7.4
   ## @md | `test.auth` | test the chronicle auth server API |
   auth:
     ## @md | `test.auth.enabled` | true to enable auth-related testing | true |
@@ -218,7 +218,7 @@ tp:
     ## @md | `tp.image.repository` | the image repository | blockchaintp/chronicle-tp |
     repository: blockchaintp/chronicle-tp-amd64
     ## @md | `tp.image.tag` | the image tag | latest |
-    tag: BTP2.1.0-0.7.3
+    tag: BTP2.1.0-0.7.4
   ## @md | `tp.extraVolumes` | extra volumes declarations for the chronicle-tp deployment | list | nil
   extraVolumes:
   ## @md | `tp.extraVolumeMounts` | extra volume mounts for chronicle-tp deployment | list | nil


### PR DESCRIPTION
# [CHRON-402](https://blockchaintp.atlassian.net/browse/CHRON-402)

Follows [CHRON-379](https://blockchaintp.atlassian.net/browse/CHRON-379), updating the Helm Chart. Now, when we check if the policy has been set we can simply check if `opactl` output a policy bundle to a file or not.

# BREAKING CHANGES - DEPENDS ON A 0.7.4 RELEASE

Requires [#348](https://github.com/btpworks/chronicle/pull/348)

## To-do
- [x] fix incrementing chart version
- [x] tag 0.7.4
- [x] update image versions

# PR Checklist

## Please complete this checklist after opening your PR

* [x] I have updated documentation as necessary
* [x] I have updated helm chart(s) if needed
* [x] I have added tests if needed
* [x] All new and existing tests are passing
* [x] Any breaking changes are clearly flagged and documented
* [x] I’ve included a link to any relevant ticket(s)


[CHRON-402]: https://blockchaintp.atlassian.net/browse/CHRON-402?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CHRON-379]: https://blockchaintp.atlassian.net/browse/CHRON-379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ