### PR TITLE
rename verify_jwt to verify_token

### DIFF
--- a/crates/api/src/chronicle_graphql/authorization.rs
+++ b/crates/api/src/chronicle_graphql/authorization.rs
@@ -102,7 +102,7 @@ impl TokenChecker {
     }
 
     #[instrument(level = "debug", skip_all, err)]
-    pub async fn verify_jwt(&self, token: &str) -> Result<Map<String, Value>, Error> {
+    pub async fn verify_token(&self, token: &str) -> Result<Map<String, Value>, Error> {
         let mut claims = Map::new();
         let mut error = None;
         match self.attempt_jwt(token).await {

--- a/crates/api/src/chronicle_graphql/mod.rs
+++ b/crates/api/src/chronicle_graphql/mod.rs
@@ -616,7 +616,7 @@ async fn check_claims(
         if let Ok(authorization) = HeaderValue::from_str(authorization) {
             let bearer_token_maybe: Option<Bearer> = Credentials::decode(&authorization);
             if let Some(bearer_token) = bearer_token_maybe {
-                if let Ok(claims) = secconf.checker.verify_jwt(bearer_token.token()).await {
+                if let Ok(claims) = secconf.checker.verify_token(bearer_token.token()).await {
                     if check_required_claims(&secconf.must_claim, &claims) {
                         return Ok(Some(JwtClaims(claims)));
                     }


### PR DESCRIPTION
The function can verify opaque access tokens as well as JWTs so its name was misleading.

# PR Checklist

## Please complete this checklist after opening your PR

* [x] I have updated documentation as necessary
* [x] I have updated helm chart(s) if needed
* [x] I have added tests if needed
* [ ] All new and existing tests are passing
* [x] Any breaking changes are clearly flagged and documented
* [x] I’ve included a link to any relevant ticket(s)
