### PR TITLE
set dev-id-provider endpoint for userinfo correctly

### DIFF
--- a/charts/chronicle/Chart.yaml
+++ b/charts/chronicle/Chart.yaml
@@ -17,7 +17,7 @@ keywords:
 # This is the chart version. This version number should be incremented each
 # time you make changes to the chart and its templates, including the app
 # version.
-version: 0.1.16
+version: 0.1.17
 
 # This is the version number of Chronicle being deployed. This version
 # number should be incremented each time you make changes to Chronicle.

--- a/charts/chronicle/templates/_chronicle.tpl
+++ b/charts/chronicle/templates/_chronicle.tpl
@@ -55,8 +55,12 @@ chronicle: {{ include "common.names.fullname" . }}
 {{ include "common.names.fullname" . }}-test-id-provider
 {{- end -}}
 
-{{- define "chronicle.id-provider.service.url" -}}
+{{- define "chronicle.id-provider.service.jwks.url" -}}
 http://{{ include "chronicle.id-provider.service" . }}:8090/jwks
+{{- end -}}
+
+{{- define "chronicle.id-provider.service.userinfo.url" -}}
+http://{{ include "chronicle.id-provider.service" . }}:8090/userinfo
 {{- end -}}
 
 {{- define "chronicle.id-claims" -}}
@@ -77,7 +81,7 @@ http://{{ include "chronicle.id-provider.service" . }}:8090/jwks
 {{- end -}}
 {{- else -}}
 {{- if .Values.devIdProvider.enabled -}}
-{{ include "chronicle.id-provider.service.url" . }}
+{{ include "chronicle.id-provider.service.jwks.url" . }}
 {{- else -}}
 {{/* Do nothing */}}
 {{- end -}}
@@ -101,7 +105,7 @@ http://{{ include "chronicle.id-provider.service" . }}:8090/jwks
 {{- end -}}
 {{- else -}}
 {{- if .Values.devIdProvider.enabled -}}
-{{ include "chronicle.id-provider.service.url" . }}
+{{ include "chronicle.id-provider.service.userinfo.url" . }}
 {{- else -}}
 {{/* Do nothing */}}
 {{- end -}}

--- a/charts/chronicle/templates/tests/api-test.yaml
+++ b/charts/chronicle/templates/tests/api-test.yaml
@@ -25,7 +25,7 @@ spec:
           command: [ "sh", "-c" ]
           args:
             - |
-              URL="{{ include "chronicle.id-provider.service.url" . }}"
+              URL="{{ include "chronicle.id-provider.service.jwks.url" . }}"
 
               wait_for_url() {
                 local url=$1


### PR DESCRIPTION
dev-id-provider was configuring the JWKS endpoint for `--userinfo-address`. Chart test passed because Chronicle was happy to get a JSON object back.

Having `auth.id.claims: email` would detect this but that's not the best default for normal deployments.

# PR Checklist

## Please complete this checklist after opening your PR

* [x] I have updated documentation as necessary
* [x] I have updated helm chart(s) if needed
* [x] I have added tests if needed
* [x] All new and existing tests are passing
* [x] Any breaking changes are clearly flagged and documented
* [x] I’ve included a link to any relevant ticket(s)
