### PR TITLE
fix(charts): fix auth endpoints cli templating

### DIFF
--- a/charts/chronicle/Chart.yaml
+++ b/charts/chronicle/Chart.yaml
@@ -17,7 +17,7 @@ keywords:
 # This is the chart version. This version number should be incremented each
 # time you make changes to the chart and its templates, including the app
 # version.
-version: 0.1.17
+version: 0.1.18
 
 # This is the version number of Chronicle being deployed. This version
 # number should be incremented each time you make changes to Chronicle.

--- a/charts/chronicle/templates/_chronicle.tpl
+++ b/charts/chronicle/templates/_chronicle.tpl
@@ -82,17 +82,20 @@ http://{{ include "chronicle.id-provider.service" . }}:8090/userinfo
 {{- else -}}
 {{- if .Values.devIdProvider.enabled -}}
 {{ include "chronicle.id-provider.service.jwks.url" . }}
-{{- else -}}
-{{/* Do nothing */}}
 {{- end -}}
 {{- end -}}
 {{- end -}}
 
 {{- define "chronicle.jwks-url.cli" -}}
-{{- if or (.Values.auth.jwks.url) (.Values.devIdProvider.enabled) -}}
+{{- if or (.Values.auth.jwks.url) (.Values.auth.userinfo.url) -}}
+{{- if .Values.auth.jwks.url -}}
 --jwks-address {{ include "chronicle.jwks-url.url" . }} \
 {{- end -}}
-{{/* Do nothing */}}
+{{- else -}}
+{{- if .Values.devIdProvider.enabled -}}
+--jwks-address {{ include "chronicle.jwks-url.url" . }} \
+{{- end -}}
+{{- end -}}
 {{- end -}}
 
 {{/* The JWKS and userinfo URLs are connected. */}}
@@ -106,17 +109,20 @@ http://{{ include "chronicle.id-provider.service" . }}:8090/userinfo
 {{- else -}}
 {{- if .Values.devIdProvider.enabled -}}
 {{ include "chronicle.id-provider.service.userinfo.url" . }}
-{{- else -}}
-{{/* Do nothing */}}
 {{- end -}}
 {{- end -}}
 {{- end -}}
 
 {{- define "chronicle.userinfo-url.cli" -}}
-{{- if or (.Values.auth.userinfo.url) (.Values.devIdProvider.enabled) -}}
+{{- if or (.Values.auth.jwks.url) (.Values.auth.userinfo.url) -}}
+{{- if .Values.auth.userinfo.url -}}
 --userinfo-address {{ include "chronicle.userinfo-url" . }} \
 {{- end -}}
-{{/* Do nothing */}}
+{{- else -}}
+{{- if .Values.devIdProvider.enabled -}}
+--userinfo-address {{ include "chronicle.userinfo-url" . }} \
+{{- end -}}
+{{- end -}}
 {{- end -}}
 
 {{- define "chronicle.root-key.secret" -}}


### PR DESCRIPTION
This PR corrects the templates to ensure the following behavior.

- If a user provides a jwks or userinfo endpoint (or both), Chronicle uses them
- If a user provides no endpoints but enables the `devIdProvider`, then Chronicle uses the endpoints for the `devIdProvider`
- If a user provides no endpoints and the `devIdProvider` is not enabled, we do not want any cli args for jwks and userinfo endpoints passed to Chronicle.

# PR Checklist

## Please complete this checklist after opening your PR

* [x] I have updated documentation as necessary
* [x] I have updated helm chart(s) if needed
* [x] I have added tests if needed
* [x] All new and existing tests are passing
* [x] Any breaking changes are clearly flagged and documented
* [x] I’ve included a link to any relevant ticket(s)
