### PR TITLE
fix(charts): allow helm api test to support 3rd party auth service

### DIFF
--- a/charts/chronicle/Chart.yaml
+++ b/charts/chronicle/Chart.yaml
@@ -17,7 +17,7 @@ keywords:
 # This is the chart version. This version number should be incremented each
 # time you make changes to the chart and its templates, including the app
 # version.
-version: 0.1.18
+version: 0.1.19
 
 # This is the version number of Chronicle being deployed. This version
 # number should be incremented each time you make changes to Chronicle.

--- a/charts/chronicle/templates/test-token-getter-roles.yaml
+++ b/charts/chronicle/templates/test-token-getter-roles.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.test.enabled }}
+{{- if .Values.test.api.enabled }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/charts/chronicle/templates/tests/api-test.yaml
+++ b/charts/chronicle/templates/tests/api-test.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.test.enabled }}
+{{- if .Values.test.api.enabled }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -16,8 +16,9 @@ spec:
       serviceAccountName:  {{ include "lib.serviceAccountName" . }}
       automountServiceAccountToken: true
       {{- if .Values.auth.required }}
+      {{ if not .Values.test.auth.token }}
       {{ if not .Values.devIdProvider.enabled }}
-      {{ required "If 'auth.required' when using the test suite 'devIdProvider.enabled' must be set to 'true'!" .Values.devIdProvider.enabled }}
+      {{ required "If 'auth.required' when using the api-test 'test.auth.token' must be provided or 'devIdProvider.enabled' must be set to 'true'!" .Values.devIdProvider.enabled }}
       {{ end }}
       initContainers:
         - name: wait-for-id-provider
@@ -73,6 +74,7 @@ spec:
           volumeMounts:
             - name: shared-data
               mountPath: /shared-data
+      {{ end }}
       {{- end }}
       containers:
         - name: test
@@ -80,12 +82,24 @@ spec:
           command: [ "sh", "-ec" ]
           args:
             - |
+              {{ if not .Values.test.auth.token }}
+              {{ if or .Values.auth.jwks.url .Values.auth.userinfo.url }}
+              echo "Auth endpoints provided but no token provided."
+              echo "Please provide 'test.auth.token' in the values.yaml file."
+              exit 1
+              {{ end }}
+              {{ end }}
+
               API={{ include "chronicle.api.service" . }}
               export PORT={{ .Values.port }}
               echo "Waiting for API to be ready ..."
               wait-for-it $API:$PORT --timeout=0
               echo "Getting IP address for API ..."
               getent hosts $API | cut -f 1 -d \ | head -n 1 > /shared-data/api-ip || exit 1
+
+              {{- if .Values.test.auth.token }}
+              echo "{{ .Values.test.auth.token }}" > /shared-data/jwks-token
+              {{- end }}
 
               if [ -f "/shared-data/jwks-token" ]; then
                 echo "Found token."

--- a/charts/chronicle/values.yaml
+++ b/charts/chronicle/values.yaml
@@ -133,7 +133,9 @@ serviceAccount:
 test:
   ## @md | `test.api` | test the chronicle GraphQL server API |
   api:
-    ## @md | `api-test-container.image` | the image to use for the api-test container | blockchaintp/chronicle-api-test |
+    ## @md | `test.api.enabled` | true to enable api-test Jobs and Services | true |
+    enabled: true
+    ## @md | `test.api.image` | the image to use for the api-test container | blockchaintp/chronicle-helm-api-test |
     image:
       ## @md | `test.api.image.pullPolicy` | the image pull policy | IfNotPresent |
       pullPolicy: IfNotPresent
@@ -141,8 +143,9 @@ test:
       repository: blockchaintp/chronicle-helm-api-test-amd64
       ## @md | `test.api.image.tag` | the image tag | latest |
       tag: BTP2.1.0-0.7.3
-  ## @md | `test.enabled` | true to enable test Jobs and Services | true |
-  enabled: true
+  auth:
+    ## @md | `test.auth.token` | provide a token for auth-related testing | nil |
+    token:
 
 postgres:
   # if enabled we allocate a postgres database here

--- a/docs/helm_testing.md
+++ b/docs/helm_testing.md
@@ -1,0 +1,154 @@
+# Helm Testing
+
+This section provides an overview and instructions for testing the Chronicle application
+using Helm. The Chronicle Helm Chart includes relevant components and configurations
+related to testing the application.
+
+## Introduction
+
+Helm is a package manager for Kubernetes that enables streamlined deployment, management,
+and testing of applications. The testing functionality in Helm allows you to verify
+the correctness and stability of your application after deployment.
+
+To learn `helm test`, see the [Chart Tests](https://helm.sh/docs/topics/chart_tests/)
+and [Helm Test](https://helm.sh/docs/helm/helm_test/) sections of the Helm documentation.
+
+The testing components and configurations specific to testing with the Chronicle
+Helm Chart are described below.
+
+## Testing Components
+
+### API Test Job
+
+The API Test Job is responsible for executing a test against the Chronicle API. It
+ensures the availability GraphQL API endpoint. The Job is defined in the Helm Chart
+under the condition:
+
+```yaml
+test:
+  api:
+    enabled: true
+```
+
+The API Test Job includes the following test steps:
+
+- Authenticate and obtain a token (if required).
+- Wait for the API to be ready.
+- Execute the tests using the `subscribe-submit-test` script.
+
+### `devIdProvider` (optional)
+
+The `devIdProvider` is an optional component used for authentication during
+testing and development. It simulates an identity provider to provide tokens for
+API and auth endpoint tests. The `devIdProvider` is defined in the Helm Chart
+under the condition:
+
+```yaml
+devIdProvider:
+  enabled: true
+```
+
+The following resources are created for the `devIdProvider`:
+
+- `Service`: Provides network access to the `devIdProvider`.
+- `StatefulSet`: Manages the stateful container that makes up the `devIdProvider`.
+
+### RBAC Configuration
+
+The RBAC (Role-Based Access Control) configuration allows the necessary permissions
+for testing. It grants the required access rights to the Service Account used during
+testing.
+
+## Configuration
+
+The relevant values for testing are located under the `test` section in the `values.yaml`
+file. Specifically:
+
+- `auth.required`: Specifies whether Chronicle's API will require authentication.
+  If set to `true`, either `devIdProvider` must be enabled, or the user must provide
+  `test.auth.token`.
+- `test.api.enabled`: Specifies whether the API test functionality is enabled (`true`)
+  or not (`false`).
+- `test.auth.token`: Provides a token that can be used for authentication-related
+  testing. This value can be set to a specific token for testing authentication scenarios.
+- `devIdProvider.enabled`: Specifies whether the `devIdProvider` is
+  enabled (`true`) or not (`false`).
+
+```yaml
+auth:
+  required: true
+
+devIdProvider:
+  enabled: true
+
+test:
+  api:
+    enabled: true
+  auth:
+    token:
+```
+
+## Testing Scenarios
+
+### Without Auth
+
+```yaml
+auth:
+  required: false
+
+test:
+  api:
+    enabled: true
+```
+
+These are Chronicle's default `values.yaml` settings. Running `helm test <installation>`
+will run the api-test without using an authorization token.
+
+### Auth Required, Using `devIdProvider`
+
+```yaml
+auth:
+  jwks:
+    url:
+  required: true
+  userinfo:
+    url:
+
+devIdProvider:
+  enabled: true
+
+test:
+  api:
+    enabled: true
+  auth:
+    token:
+```
+
+The test uses the `devIdProvider` to acquire a token, which it passes in the
+authorization header to the api-test. Chronicle has been initialized with the default
+`devIdProvider` auth endpoints. If `test.auth.token` is not provided and
+`auth.required: true`, then `devIdProvider` must be enabled.
+
+### Auth Required, Third Party Auth Service
+
+```yaml
+auth:
+  jwks:
+    url: https://dev-xyz-9abc.us.auth0.com/.well-known/jwks.json
+  required: true
+  userinfo:
+    url: https://dev-xyz-9abc.us.auth0.com/userinfo
+
+devIdProvider:
+  enabled: false
+
+test:
+  api:
+    enabled: true
+  auth:
+    token: eyJhbGciOiJkaXIiLCJlbmMiOiJBMjU2R0NNIiwiaXNzIjoiaHR0cHM6Ly9kZXYtY2hhLTlhZXQudXMuYXV0aDAuY29tLyJ9..wSM9N-paE7lA_YaL.T8Mla-PJ5VcFWdBX6SaxCkzq5LVFnEGg2eiMNc-rCXgCd6CUTFQ9Ra_JbuFZrfVZA0JxaaeY5XHJYVBJ6Gwjq25qU5XxXrXk64ZdHNIBgUYhkHoKOvEIjqYpvv8pl1A4MndAbE8NqFpyYgkaWVhSk0X9zSMWTZ6D_Y4lwMr4ihCNqJ4nd8KuyswwDYrHCnQbmBDE6u0yGmLQEIoLm1ZaCnhgDTzdnX2RgcluOrZR5a-yW8Vw6VogsGHwh6-2gsDHxgdmjpZlfR0jGHkceeCw9xl-ccVaLmTH2DS49nrhiYBfrx8oZ5dTKdj9d0ZWJ91c4CI.beiznku1urlYppbo8WHoCg
+```
+
+The user provides a token and auth endpoints. Note, in this scenario it does not
+matter whether the `devIdProvider` is enabled or not, but that testing requires
+that the user provides a token that will work with their third-party auth service.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,6 +38,7 @@ nav:
       - Untyped Chronicle: untyped_chronicle.md
   - Testing:
       - Building your domain: building.md
+      - Helm Testing: helm_testing.md
   - Installing:
       - Installing with Sextant: sextant.md
       - Security settings via Helm: helm-jwks-opa.md


### PR DESCRIPTION
- If using api-test and `auth.required: true`, if `test.auth.token` provided, the api-test will use the token for the test. 
- If `test.auth.token` is not provided and `auth.required:true` then `devIdProvider` must be enabled.

[CHRON-404](https://blockchaintp.atlassian.net/browse/CHRON-404)

# PR Checklist

## Please complete this checklist after opening your PR

* [x] I have updated documentation as necessary
* [x] I have updated helm chart(s) if needed
* [x] I have added tests if needed
* [x] All new and existing tests are passing
* [x] Any breaking changes are clearly flagged and documented
* [x] I’ve included a link to any relevant ticket(s)


[CHRON-404]: https://blockchaintp.atlassian.net/browse/CHRON-404?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ