### PR TITLE
cover for that attribution table may not exist yet

### DIFF
--- a/crates/api/migrations/2022-01-18-144301_ledger_sync/down.sql
+++ b/crates/api/migrations/2022-01-18-144301_ledger_sync/down.sql
@@ -1,4 +1,5 @@
 -- This file should undo anything in `up.sql`
+
 drop table activity_attribute;
 drop table agent_attribute;
 drop table entity_attribute;
@@ -7,7 +8,7 @@ drop table hadidentity;
 drop table wasinformedby;
 drop table usage;
 drop table association;
-drop table attribution;
+drop table if exists attribution;
 drop table generation;
 drop table derivation;
 drop table delegation;

--- a/crates/api/migrations/2023-06-16-145625_attribution_fix/down.sql
+++ b/crates/api/migrations/2023-06-16-145625_attribution_fix/down.sql
@@ -1,0 +1,4 @@
+-- This file should undo anything in `up.sql`
+
+-- drop table attribution;
+-- is already included in the 2022-01-18-144301 migration

--- a/crates/api/migrations/2023-06-16-145625_attribution_fix/up.sql
+++ b/crates/api/migrations/2023-06-16-145625_attribution_fix/up.sql
@@ -1,0 +1,8 @@
+create table if not exists attribution (
+    agent_id integer not null,
+    entity_id integer not null,
+    role text not null default '',
+    foreign key(agent_id) references agent(id),
+    foreign key(entity_id) references entity(id),
+    primary key(agent_id, entity_id, role)
+);


### PR DESCRIPTION
A previous `up.sql` was edited in #237 to add `attribution`, a mistake that I should have caught. So, some deployments may have the table, some may not. The proper way to do these is shown in #251. Resolves the error in CHRON-408.

# PR Checklist

## Please complete this checklist after opening your PR

* [x] I have updated documentation as necessary
* [x] I have updated helm chart(s) if needed
* [x] I have added tests if needed
* [x] All new and existing tests are passing
* [x] Any breaking changes are clearly flagged and documented
* [x] I’ve included a link to any relevant ticket(s)
