### PR TITLE
avoid Debian OpenJDK installation issue

### DIFF
--- a/docker/opa-builder
+++ b/docker/opa-builder
@@ -99,13 +99,13 @@ FROM  alpine:3.16.3 as tested-artifacts
 COPY --from=tested --link /artifacts /artifacts
 
 # Copy opa-tp to image
-FROM debian:bullseye-slim AS opa-tp
+FROM debian:bookworm-slim AS opa-tp
 ARG TARGETARCH
 WORKDIR /
 COPY .artifacts/artifacts/${TARGETARCH}/opa-tp /usr/local/bin/opa-tp
 
 # Copy opactl to image
-FROM debian:bullseye-slim AS opactl
+FROM debian:bookworm-slim AS opactl
 ARG TARGETARCH
 WORKDIR /
 COPY .artifacts/artifacts/${TARGETARCH}/opactl /usr/local/bin/opactl

--- a/docker/unified-builder
+++ b/docker/unified-builder
@@ -276,9 +276,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   --mount=type=cache,target=/var/lib/apt,sharing=locked \
   apt-get update \
   && apt-get install --no-install-recommends -y \
-  ca-certificates-java \
   curl \
-  && apt-get install --no-install-recommends -y \
   openjdk-17-jre-headless
 
 

--- a/docker/unified-builder
+++ b/docker/unified-builder
@@ -190,7 +190,7 @@ WORKDIR /app
 RUN cargo fetch --locked
 
 
-FROM --platform=${TARGETPLATFORM} debian:bullseye-slim AS debian-upgraded
+FROM --platform=${TARGETPLATFORM} debian:bookworm-slim AS debian-upgraded
 
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   --mount=type=cache,target=/var/lib/apt,sharing=locked \


### PR DESCRIPTION
Debian bullseye's ca-certificates-java's post-installation script started failing when installed as a dependency of openjdk-17-jre-headless. Debian bookworm has now been released as the next stable version of Debian, and it does not suffer from that post-installation script bug. Reverts the workaround from #361.

# PR Checklist

## Please complete this checklist after opening your PR

* [x] I have updated documentation as necessary
* [x] I have updated helm chart(s) if needed
* [x] I have added tests if needed
* [x] All new and existing tests are passing
* [x] Any breaking changes are clearly flagged and documented
* [x] I’ve included a link to any relevant ticket(s)
