### PR TITLE
no longer ignore some advisories

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -2,15 +2,5 @@
 ignore = [
   # `time` localtime_r segfault
   # No current known workarounds as it is a libc issue
-  "RUSTSEC-2020-0071",
-
-  # `chrono` localtime_r segfault
-  # No current known workarounds as it is a libc issue
-  "RUSTSEC-2020-0159",
-
-  # Await patch in 2.x
-  "RUSTSEC-2021-0037",
-
-  #CBOR will be replaced with proto for TP events before long
-  "RUSTSEC-2021-0127"
+  "RUSTSEC-2020-0071"
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3590,9 +3590,9 @@ checksum = "b687ff7b5da449d39e418ad391e5e08da53ec334903ddbb921db208908fc372c"
 
 [[package]]
 name = "pest"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e68e84bfb01f0507134eac1e9b410a12ba379d064eab48c50ba4ce329a527b70"
+checksum = "f73935e4d55e2abf7f130186537b19e7a4abc886a0252380b59248af473a3fc9"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -3600,9 +3600,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b79d4c71c865a25a4322296122e3924d30bc8ee0834c8bfc8b95f7f054afbfb"
+checksum = "aef623c9bbfa0eedf5a0efba11a5ee83209c326653ca31ff019bec3a95bfff2b"
 dependencies = [
  "pest",
  "pest_generator",
@@ -3610,9 +3610,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c435bf1076437b851ebc8edc3a18442796b30f1728ffea6262d59bbe28b077e"
+checksum = "b3e8cba4ec22bada7fc55ffe51e2deb6a0e0db2d0b7ab0b103acc80d2510c190"
 dependencies = [
  "pest",
  "pest_meta",
@@ -3623,9 +3623,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "745a452f8eb71e39ffd8ee32b3c5f51d03845f99786fa9b68db6ff509c505411"
+checksum = "a01f71cb40bd8bb94232df14b946909e14660e33fc05db3e50ae2a82d7ea0ca0"
 dependencies = [
  "once_cell",
  "pest",
@@ -4583,7 +4583,6 @@ dependencies = [
  "rand_core 0.6.4",
  "sawtooth-sdk",
  "serde",
- "serde_cbor",
  "serde_derive",
  "serde_json",
  "tempfile",
@@ -4697,16 +4696,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2"
 dependencies = [
  "serde_derive",
-]
-
-[[package]]
-name = "serde_cbor"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
-dependencies = [
- "half",
- "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,7 +110,6 @@ rust-embed = { version = "6.6.0", features = [
 ] }
 sawtooth-sdk = { git = "https://github.com/hyperledger/sawtooth-sdk-rust", rev = "5a300de" }
 serde = "1.0.152"
-serde_cbor = "0.11.2"
 serde_derive = "1.0.152"
 serde_json = "1.0.93"
 serde_yaml = "0.9.14"

--- a/crates/sawtooth-tp/Cargo.toml
+++ b/crates/sawtooth-tp/Cargo.toml
@@ -41,7 +41,6 @@ rand                 = { workspace = true }
 rand_core            = { workspace = true }
 sawtooth-sdk         = { workspace = true }
 serde                = { workspace = true }
-serde_cbor           = { workspace = true }
 serde_derive         = { workspace = true }
 serde_json           = { workspace = true }
 tokio                = { workspace = true }


### PR DESCRIPTION
At least since the work on #368 for CHRON-419, these make no difference to `cargo audit`. Also removes `serde_cbor` since #67 and bumps `pest` to v2.7.0.

# PR Checklist

## Please complete this checklist after opening your PR

* [x] I have updated documentation as necessary
* [x] I have updated helm chart(s) if needed
* [x] I have added tests if needed
* [ ] All new and existing tests are passing
* [x] Any breaking changes are clearly flagged and documented
* [x] I’ve included a link to any relevant ticket(s)
