### PR TITLE
Helm Chart init Job to delete itself after completing

### DIFF
--- a/charts/chronicle/Chart.yaml
+++ b/charts/chronicle/Chart.yaml
@@ -17,7 +17,7 @@ keywords:
 # This is the chart version. This version number should be incremented each
 # time you make changes to the chart and its templates, including the app
 # version.
-version: 0.1.22
+version: 0.1.23
 
 # This is the version number of Chronicle being deployed. This version
 # number should be incremented each time you make changes to Chronicle.

--- a/charts/chronicle/templates/chronicle-init.yaml
+++ b/charts/chronicle/templates/chronicle-init.yaml
@@ -3,12 +3,11 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   name: {{ include "common.names.fullname" . }}-init
   labels: {{ include "chronicle.labels" . | nindent 4 }}
     component: chronicle
 spec:
+  ttlSecondsAfterFinished: 100
   template:
     metadata:
       labels: {{ include "chronicle.labels" . | nindent 8 }}


### PR DESCRIPTION
Annotation being used is for hooks like tests but this `Job` isn't created by a hook.

This PR uses the [ttl mechanism for finished jobs](https://kubernetes.io/docs/concepts/workloads/controllers/job/#ttl-mechanism-for-finished-jobs).

[CHRON-385](https://blockchaintp.atlassian.net/browse/CHRON-385)

# PR Checklist

## Please complete this checklist after opening your PR

* [x] I have updated documentation as necessary
* [x] I have updated helm chart(s) if needed
* [x] I have added tests if needed
* [x] All new and existing tests are passing
* [x] Any breaking changes are clearly flagged and documented
* [x] I’ve included a link to any relevant ticket(s)


[CHRON-385]: https://blockchaintp.atlassian.net/browse/CHRON-385?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ