### PR TITLE
fix(api): include derivation data when fetching provmodel for entity

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -448,6 +448,8 @@ where
             if state_with_effects != *state {
                 transactions.push(tx.clone());
                 state.apply(tx)?;
+            } else {
+                info!(?tx, "Transaction has no effect, data already recorded");
             }
         }
 

--- a/crates/common/src/prov/operations.rs
+++ b/crates/common/src/prov/operations.rs
@@ -59,6 +59,20 @@ where
     }
 }
 
+impl TryFrom<i32> for DerivationType {
+    type Error = &'static str;
+
+    fn try_from(value: i32) -> Result<Self, Self::Error> {
+        match value {
+            -1 => Ok(DerivationType::None),
+            1 => Ok(DerivationType::Revision),
+            2 => Ok(DerivationType::Quotation),
+            3 => Ok(DerivationType::PrimarySource),
+            _ => Err("Unrecognized enum variant when converting from 'i32'"),
+        }
+    }
+}
+
 impl DerivationType {
     pub fn revision() -> Self {
         Self::Revision


### PR DESCRIPTION
# [CHRON-428](https://blockchaintp.atlassian.net/browse/CHRON-428)

I'm going to include a lengthy JSON-LD array of data that can be used to test what this PR does, which is: 
solve a bug discovered through use of Chronicle's `import` feature where Chronicle would attempt to record `EntityDerive` transactions even after they had already been recorded. This is because the `prov_model_for_entity` method for `Store` was not including `Derivation` table data in its reports.

Related PRs include: [#271](https://github.com/btpworks/chronicle/pull/271) and [#213](https://github.com/btpworks/chronicle/pull/213)

## Testing

- Save the data (it's data for an untyped Chronicle domain) below in a file called `import.json` and put in your Chronicle root directory. 
- Use a database that has not previously recorded the transactions listed below.
- Run:

```bash
RUST_LOG=info \
cargo run --bin chronicle \   
--features inmem \
-- import \ 
testns \  
60976119-adc6-3826-a57b-3ccb0580e7bd \ 
import.json
``` 

- Run the same command again.

Success should be indicated by the following log message:

`INFO api: Import will not result in any data changes`

Checking this before this PR and after should demonstrate the intention, hopefully.

```json
[
    {
        "@id": "_:n1",
        "@type": [
            "http://btp.works/chronicleoperations/ns#ActivityExists"
        ],
        "http://btp.works/chronicleoperations/ns#activityName": [
            {
                "@value": "transition"
            }
        ],
        "http://btp.works/chronicleoperations/ns#namespaceName": [
            {
                "@value": "testns"
            }
        ],
        "http://btp.works/chronicleoperations/ns#namespaceUuid": [
            {
                "@value": "60976119-adc6-3826-a57b-3ccb0580e7bd"
            }
        ]
    },
    {
        "@id": "_:n1",
        "@type": [
            "http://btp.works/chronicleoperations/ns#ActivityUses"
        ],
        "http://btp.works/chronicleoperations/ns#activityName": [
            {
                "@value": "incubate"
            }
        ],
        "http://btp.works/chronicleoperations/ns#entityName": [
            {
                "@value": "bandwidth"
            }
        ],
        "http://btp.works/chronicleoperations/ns#namespaceName": [
            {
                "@value": "testns"
            }
        ],
        "http://btp.works/chronicleoperations/ns#namespaceUuid": [
            {
                "@value": "60976119-adc6-3826-a57b-3ccb0580e7bd"
            }
        ]
    },
    {
        "@id": "_:n1",
        "@type": [
            "http://btp.works/chronicleoperations/ns#AgentActsOnBehalfOf"
        ],
        "http://btp.works/chronicleoperations/ns#activityName": [
            {
                "@value": "incubate"
            }
        ],
        "http://btp.works/chronicleoperations/ns#delegateId": [
            {
                "@value": "Ivah Cole"
            }
        ],
        "http://btp.works/chronicleoperations/ns#namespaceName": [
            {
                "@value": "testns"
            }
        ],
        "http://btp.works/chronicleoperations/ns#namespaceUuid": [
            {
                "@value": "60976119-adc6-3826-a57b-3ccb0580e7bd"
            }
        ],
        "http://btp.works/chronicleoperations/ns#responsibleId": [
            {
                "@value": "Fritz Walsh"
            }
        ]
    },
    {
        "@id": "_:n1",
        "@type": [
            "http://btp.works/chronicleoperations/ns#AgentExists"
        ],
        "http://btp.works/chronicleoperations/ns#agentName": [
            {
                "@value": "Leslie Kris"
            }
        ],
        "http://btp.works/chronicleoperations/ns#namespaceName": [
            {
                "@value": "testns"
            }
        ],
        "http://btp.works/chronicleoperations/ns#namespaceUuid": [
            {
                "@value": "60976119-adc6-3826-a57b-3ccb0580e7bd"
            }
        ]
    },
    {
        "@id": "_:n1",
        "@type": [
            "http://btp.works/chronicleoperations/ns#CreateNamespace"
        ],
        "http://btp.works/chronicleoperations/ns#namespaceName": [
            {
                "@value": "testns"
            }
        ],
        "http://btp.works/chronicleoperations/ns#namespaceUuid": [
            {
                "@value": "60976119-adc6-3826-a57b-3ccb0580e7bd"
            }
        ]
    },
    {
        "@id": "_:n1",
        "@type": [
            "http://btp.works/chronicleoperations/ns#EndActivity"
        ],
        "http://btp.works/chronicleoperations/ns#activityName": [
            {
                "@value": "orchestrate"
            }
        ],
        "http://btp.works/chronicleoperations/ns#endActivityTime": [
            {
                "@value": "2001-07-08T00:35:00.026490+09:30"
            }
        ],
        "http://btp.works/chronicleoperations/ns#namespaceName": [
            {
                "@value": "testns"
            }
        ],
        "http://btp.works/chronicleoperations/ns#namespaceUuid": [
            {
                "@value": "60976119-adc6-3826-a57b-3ccb0580e7bd"
            }
        ]
    },
    {
        "@id": "_:n1",
        "@type": [
            "http://btp.works/chronicleoperations/ns#EntityDerive"
        ],
        "http://btp.works/chronicleoperations/ns#entityName": [
            {
                "@value": "vortals"
            }
        ],
        "http://btp.works/chronicleoperations/ns#namespaceName": [
            {
                "@value": "testns"
            }
        ],
        "http://btp.works/chronicleoperations/ns#namespaceUuid": [
            {
                "@value": "60976119-adc6-3826-a57b-3ccb0580e7bd"
            }
        ],
        "http://btp.works/chronicleoperations/ns#usedEntityName": [
            {
                "@value": "deliverables"
            }
        ]
    },
    {
        "@id": "_:n1",
        "@type": [
            "http://btp.works/chronicleoperations/ns#EntityExists"
        ],
        "http://btp.works/chronicleoperations/ns#entityName": [
            {
                "@value": "deliverables"
            }
        ],
        "http://btp.works/chronicleoperations/ns#namespaceName": [
            {
                "@value": "testns"
            }
        ],
        "http://btp.works/chronicleoperations/ns#namespaceUuid": [
            {
                "@value": "60976119-adc6-3826-a57b-3ccb0580e7bd"
            }
        ]
    },
    {
        "@id": "_:n1",
        "@type": [
            "http://btp.works/chronicleoperations/ns#SetAttributes"
        ],
        "http://btp.works/chronicleoperations/ns#activityName": [
            {
                "@value": "iterate"
            }
        ],
        "http://btp.works/chronicleoperations/ns#attributes": [
            {
                "@type": "@json",
                "@value": {}
            }
        ],
        "http://btp.works/chronicleoperations/ns#namespaceName": [
            {
                "@value": "testns"
            }
        ],
        "http://btp.works/chronicleoperations/ns#namespaceUuid": [
            {
                "@value": "60976119-adc6-3826-a57b-3ccb0580e7bd"
            }
        ]
    },
    {
        "@id": "_:n1",
        "@type": [
            "http://btp.works/chronicleoperations/ns#SetAttributes"
        ],
        "http://btp.works/chronicleoperations/ns#agentName": [
            {
                "@value": "Godfrey Satterfield"
            }
        ],
        "http://btp.works/chronicleoperations/ns#attributes": [
            {
                "@type": "@json",
                "@value": {}
            }
        ],
        "http://btp.works/chronicleoperations/ns#namespaceName": [
            {
                "@value": "testns"
            }
        ],
        "http://btp.works/chronicleoperations/ns#namespaceUuid": [
            {
                "@value": "60976119-adc6-3826-a57b-3ccb0580e7bd"
            }
        ]
    },
    {
        "@id": "_:n1",
        "@type": [
            "http://btp.works/chronicleoperations/ns#SetAttributes"
        ],
        "http://btp.works/chronicleoperations/ns#activityName": [
            {
                "@value": "envisioneer"
            }
        ],
        "http://btp.works/chronicleoperations/ns#attributes": [
            {
                "@type": "@json",
                "@value": {
                    "CommunicationChannel": "bandwidth",
                    "CustomerID": "platforms",
                    "ParticipantID": "paradigms"
                }
            }
        ],
        "http://btp.works/chronicleoperations/ns#domaintypeId": [
            {
                "@value": "Consent"
            }
        ],
        "http://btp.works/chronicleoperations/ns#namespaceName": [
            {
                "@value": "testns"
            }
        ],
        "http://btp.works/chronicleoperations/ns#namespaceUuid": [
            {
                "@value": "60976119-adc6-3826-a57b-3ccb0580e7bd"
            }
        ]
    },
    {
        "@id": "_:n1",
        "@type": [
            "http://btp.works/chronicleoperations/ns#SetAttributes"
        ],
        "http://btp.works/chronicleoperations/ns#activityName": [
            {
                "@value": "target"
            }
        ],
        "http://btp.works/chronicleoperations/ns#attributes": [
            {
                "@type": "@json",
                "@value": {
                    "SharedKYCPart": "partnerships",
                    "StatusIndicator": "schemas"
                }
            }
        ],
        "http://btp.works/chronicleoperations/ns#domaintypeId": [
            {
                "@value": "ConsentCreated"
            }
        ],
        "http://btp.works/chronicleoperations/ns#namespaceName": [
            {
                "@value": "testns"
            }
        ],
        "http://btp.works/chronicleoperations/ns#namespaceUuid": [
            {
                "@value": "60976119-adc6-3826-a57b-3ccb0580e7bd"
            }
        ]
    },
    {
        "@id": "_:n1",
        "@type": [
            "http://btp.works/chronicleoperations/ns#SetAttributes"
        ],
        "http://btp.works/chronicleoperations/ns#activityName": [
            {
                "@value": "incubate"
            }
        ],
        "http://btp.works/chronicleoperations/ns#attributes": [
            {
                "@type": "@json",
                "@value": {
                    "SharedKYCPart": "niches",
                    "StatusIndicator": "portals"
                }
            }
        ],
        "http://btp.works/chronicleoperations/ns#domaintypeId": [
            {
                "@value": "ConsentUpdated"
            }
        ],
        "http://btp.works/chronicleoperations/ns#namespaceName": [
            {
                "@value": "testns"
            }
        ],
        "http://btp.works/chronicleoperations/ns#namespaceUuid": [
            {
                "@value": "60976119-adc6-3826-a57b-3ccb0580e7bd"
            }
        ]
    },
    {
        "@id": "_:n1",
        "@type": [
            "http://btp.works/chronicleoperations/ns#SetAttributes"
        ],
        "http://btp.works/chronicleoperations/ns#activityName": [
            {
                "@value": "orchestrate"
            }
        ],
        "http://btp.works/chronicleoperations/ns#attributes": [
            {
                "@type": "@json",
                "@value": {
                    "CustomerID": "ROI"
                }
            }
        ],
        "http://btp.works/chronicleoperations/ns#domaintypeId": [
            {
                "@value": "Customer"
            }
        ],
        "http://btp.works/chronicleoperations/ns#namespaceName": [
            {
                "@value": "testns"
            }
        ],
        "http://btp.works/chronicleoperations/ns#namespaceUuid": [
            {
                "@value": "60976119-adc6-3826-a57b-3ccb0580e7bd"
            }
        ]
    },
    {
        "@id": "_:n1",
        "@type": [
            "http://btp.works/chronicleoperations/ns#SetAttributes"
        ],
        "http://btp.works/chronicleoperations/ns#attributes": [
            {
                "@type": "@json",
                "@value": {}
            }
        ],
        "http://btp.works/chronicleoperations/ns#entityName": [
            {
                "@value": "methodologies"
            }
        ],
        "http://btp.works/chronicleoperations/ns#namespaceName": [
            {
                "@value": "testns"
            }
        ],
        "http://btp.works/chronicleoperations/ns#namespaceUuid": [
            {
                "@value": "60976119-adc6-3826-a57b-3ccb0580e7bd"
            }
        ]
    },
    {
        "@id": "_:n1",
        "@type": [
            "http://btp.works/chronicleoperations/ns#StartActivity"
        ],
        "http://btp.works/chronicleoperations/ns#activityName": [
            {
                "@value": "integrate"
            }
        ],
        "http://btp.works/chronicleoperations/ns#namespaceName": [
            {
                "@value": "testns"
            }
        ],
        "http://btp.works/chronicleoperations/ns#namespaceUuid": [
            {
                "@value": "60976119-adc6-3826-a57b-3ccb0580e7bd"
            }
        ],
        "http://btp.works/chronicleoperations/ns#startActivityTime": [
            {
                "@value": "2000-07-08T00:35:00.026490+09:30"
            }
        ]
    },
    {
        "@id": "_:n1",
        "@type": [
            "http://btp.works/chronicleoperations/ns#WasAssociatedWith"
        ],
        "http://btp.works/chronicleoperations/ns#activityName": [
            {
                "@value": "drive"
            }
        ],
        "http://btp.works/chronicleoperations/ns#agentName": [
            {
                "@value": "Kendra Cummings"
            }
        ],
        "http://btp.works/chronicleoperations/ns#namespaceName": [
            {
                "@value": "testns"
            }
        ],
        "http://btp.works/chronicleoperations/ns#namespaceUuid": [
            {
                "@value": "60976119-adc6-3826-a57b-3ccb0580e7bd"
            }
        ],
        "http://btp.works/chronicleoperations/ns#role": [
            "UNSPECIFIED"
        ]
    },
    {
        "@id": "_:n1",
        "@type": [
            "http://btp.works/chronicleoperations/ns#WasAssociatedWith"
        ],
        "http://btp.works/chronicleoperations/ns#activityName": [
            {
                "@value": "incentivize"
            }
        ],
        "http://btp.works/chronicleoperations/ns#agentName": [
            {
                "@value": "Ashly Weimann"
            }
        ],
        "http://btp.works/chronicleoperations/ns#namespaceName": [
            {
                "@value": "testns"
            }
        ],
        "http://btp.works/chronicleoperations/ns#namespaceUuid": [
            {
                "@value": "60976119-adc6-3826-a57b-3ccb0580e7bd"
            }
        ]
    },
    {
        "@id": "_:n1",
        "@type": [
            "http://btp.works/chronicleoperations/ns#WasAttributedTo"
        ],
        "http://btp.works/chronicleoperations/ns#agentName": [
            {
                "@value": "Faustino Sporer"
            }
        ],
        "http://btp.works/chronicleoperations/ns#entityName": [
            {
                "@value": "supply-chains"
            }
        ],
        "http://btp.works/chronicleoperations/ns#namespaceName": [
            {
                "@value": "testns"
            }
        ],
        "http://btp.works/chronicleoperations/ns#namespaceUuid": [
            {
                "@value": "60976119-adc6-3826-a57b-3ccb0580e7bd"
            }
        ]
    },
    {
        "@id": "_:n1",
        "@type": [
            "http://btp.works/chronicleoperations/ns#WasGeneratedBy"
        ],
        "http://btp.works/chronicleoperations/ns#activityName": [
            {
                "@value": "seize"
            }
        ],
        "http://btp.works/chronicleoperations/ns#entityName": [
            {
                "@value": "paradigms"
            }
        ],
        "http://btp.works/chronicleoperations/ns#namespaceName": [
            {
                "@value": "testns"
            }
        ],
        "http://btp.works/chronicleoperations/ns#namespaceUuid": [
            {
                "@value": "60976119-adc6-3826-a57b-3ccb0580e7bd"
            }
        ]
    },
    {
        "@id": "_:n1",
        "@type": [
            "http://btp.works/chronicleoperations/ns#WasInformedBy"
        ],
        "http://btp.works/chronicleoperations/ns#activityName": [
            {
                "@value": "streamline"
            }
        ],
        "http://btp.works/chronicleoperations/ns#informingActivityName": [
            {
                "@value": "visualize"
            }
        ],
        "http://btp.works/chronicleoperations/ns#namespaceName": [
            {
                "@value": "testns"
            }
        ],
        "http://btp.works/chronicleoperations/ns#namespaceUuid": [
            {
                "@value": "60976119-adc6-3826-a57b-3ccb0580e7bd"
            }
        ]
    }
]
```

---
# PR Checklist

## Please complete this checklist after opening your PR

* [x] I have updated documentation as necessary
* [x] I have updated helm chart(s) if needed
* [x] I have added tests if needed
* [x] All new and existing tests are passing
* [x] Any breaking changes are clearly flagged and documented
* [x] I’ve included a link to any relevant ticket(s)


[CHRON-428]: https://blockchaintp.atlassian.net/browse/CHRON-428?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ