### PR TITLE
update version numbers to v0.7.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,7 +158,7 @@ checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 
 [[package]]
 name = "api"
-version = "0.7.0"
+version = "0.7.5"
 dependencies = [
  "assert_fs",
  "async-graphql",
@@ -359,7 +359,7 @@ dependencies = [
 
 [[package]]
 name = "async-sawtooth-sdk"
-version = "0.7.0"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -660,7 +660,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chronicle"
-version = "0.7.0"
+version = "0.7.5"
 dependencies = [
  "Inflector",
  "api",
@@ -713,7 +713,7 @@ dependencies = [
 
 [[package]]
 name = "chronicle-domain"
-version = "0.7.0"
+version = "0.7.5"
 dependencies = [
  "chronicle",
  "insta",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "chronicle-domain-lint"
-version = "0.7.0"
+version = "0.7.5"
 dependencies = [
  "chronicle",
  "clap 3.2.25",
@@ -730,7 +730,7 @@ dependencies = [
 
 [[package]]
 name = "chronicle-example"
-version = "0.7.0"
+version = "0.7.5"
 dependencies = [
  "chronicle",
  "chronicle-protocol",
@@ -748,7 +748,7 @@ dependencies = [
 
 [[package]]
 name = "chronicle-protocol"
-version = "0.7.0"
+version = "0.7.5"
 dependencies = [
  "async-sawtooth-sdk",
  "async-trait",
@@ -786,7 +786,7 @@ dependencies = [
 
 [[package]]
 name = "chronicle-synth"
-version = "0.7.0"
+version = "0.7.5"
 dependencies = [
  "assert_fs",
  "chronicle",
@@ -802,7 +802,7 @@ dependencies = [
 
 [[package]]
 name = "chronicle-telemetry"
-version = "0.7.0"
+version = "0.7.5"
 dependencies = [
  "opentelemetry",
  "opentelemetry-jaeger",
@@ -997,7 +997,7 @@ dependencies = [
 
 [[package]]
 name = "common"
-version = "0.7.0"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "api",
@@ -2062,7 +2062,7 @@ dependencies = [
 
 [[package]]
 name = "gq-ws"
-version = "0.7.0"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "clap 3.2.25",
@@ -3181,7 +3181,7 @@ dependencies = [
 
 [[package]]
 name = "oauth-token"
-version = "0.7.0"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "oauth2",
@@ -3252,7 +3252,7 @@ dependencies = [
 
 [[package]]
 name = "opa-tp"
-version = "0.7.0"
+version = "0.7.5"
 dependencies = [
  "async-sawtooth-sdk",
  "async-trait",
@@ -3280,7 +3280,7 @@ dependencies = [
 
 [[package]]
 name = "opa-tp-protocol"
-version = "0.7.0"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-sawtooth-sdk",
@@ -3312,7 +3312,7 @@ dependencies = [
 
 [[package]]
 name = "opactl"
-version = "0.7.0"
+version = "0.7.5"
 dependencies = [
  "async-sawtooth-sdk",
  "async-trait",
@@ -4552,7 +4552,7 @@ dependencies = [
 
 [[package]]
 name = "sawtooth_tp"
-version = "0.7.0"
+version = "0.7.5"
 dependencies = [
  "async-sawtooth-sdk",
  "async-trait",

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -2,7 +2,7 @@
 build   = "build.rs"
 edition = "2021"
 name    = "api"
-version = "0.7.0"
+version = "0.7.5"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/crates/async-sawtooth-sdk/Cargo.toml
+++ b/crates/async-sawtooth-sdk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name    = "async-sawtooth-sdk"
-version = "0.7.0"
+version = "0.7.5"
 
 [lib]
 name = "async_sawtooth_sdk"

--- a/crates/chronicle-domain-lint/Cargo.toml
+++ b/crates/chronicle-domain-lint/Cargo.toml
@@ -2,7 +2,7 @@
 build   = "build.rs"
 edition = "2021"
 name    = "chronicle-domain-lint"
-version = "0.7.0"
+version = "0.7.5"
 
 [dependencies]
 chronicle = { path = "../chronicle" }

--- a/crates/chronicle-domain-test/Cargo.toml
+++ b/crates/chronicle-domain-test/Cargo.toml
@@ -2,7 +2,7 @@
 build   = "build.rs"
 edition = "2021"
 name    = "chronicle-example"
-version = "0.7.0"
+version = "0.7.5"
 
 [[bin]]
 name = "chronicle-example"

--- a/crates/chronicle-domain/Cargo.toml
+++ b/crates/chronicle-domain/Cargo.toml
@@ -2,7 +2,7 @@
 build   = "build.rs"
 edition = "2021"
 name    = "chronicle-domain"
-version = "0.7.0"
+version = "0.7.5"
 
 [[bin]]
 name = "chronicle"

--- a/crates/chronicle-protocol/Cargo.toml
+++ b/crates/chronicle-protocol/Cargo.toml
@@ -2,7 +2,7 @@
 build   = "build.rs"
 edition = "2021"
 name    = "chronicle-protocol"
-version = "0.7.0"
+version = "0.7.5"
 
 [lib]
 name = "chronicle_protocol"

--- a/crates/chronicle-synth/Cargo.toml
+++ b/crates/chronicle-synth/Cargo.toml
@@ -2,7 +2,7 @@
 build   = "build.rs"
 edition = "2021"
 name    = "chronicle-synth"
-version = "0.7.0"
+version = "0.7.5"
 
 [lib]
 name = "chronicle_synth"

--- a/crates/chronicle-telemetry/Cargo.toml
+++ b/crates/chronicle-telemetry/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name    = "chronicle-telemetry"
-version = "0.7.0"
+version = "0.7.5"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/chronicle/Cargo.toml
+++ b/crates/chronicle/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name    = "chronicle"
-version = "0.7.0"
+version = "0.7.5"
 
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -2,7 +2,7 @@
 build   = "build.rs"
 edition = "2021"
 name    = "common"
-version = "0.7.0"
+version = "0.7.5"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/gq-subscribe/Cargo.toml
+++ b/crates/gq-subscribe/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "gq-ws"
-version = "0.7.0"
+version = "0.7.5"
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/id-provider/Cargo.toml
+++ b/crates/id-provider/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "oauth-token"
-version = "0.7.0"
+version = "0.7.5"
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/opa-tp-protocol/Cargo.toml
+++ b/crates/opa-tp-protocol/Cargo.toml
@@ -2,7 +2,7 @@
 build   = "build.rs"
 edition = "2021"
 name    = "opa-tp-protocol"
-version = "0.7.0"
+version = "0.7.5"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/opa-tp/Cargo.toml
+++ b/crates/opa-tp/Cargo.toml
@@ -2,7 +2,7 @@
 build   = "build.rs"
 edition = "2021"
 name    = "opa-tp"
-version = "0.7.0"
+version = "0.7.5"
 
 [lib]
 name = "opa_tp"

--- a/crates/opactl/Cargo.toml
+++ b/crates/opactl/Cargo.toml
@@ -2,7 +2,7 @@
 build   = "build.rs"
 edition = "2021"
 name    = "opactl"
-version = "0.7.0"
+version = "0.7.5"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/sawtooth-tp/Cargo.toml
+++ b/crates/sawtooth-tp/Cargo.toml
@@ -10,7 +10,7 @@ path = "src/lib.rs"
 build   = "build.rs"
 edition = "2021"
 name    = "sawtooth_tp"
-version = "0.7.0"
+version = "0.7.5"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Note that this also bumps `chronicle-telemetry` and `opa-tp` which are not listed as members of the workspace in the root `Cargo.toml`.

# PR Checklist

## Please complete this checklist after opening your PR

* [x] I have updated documentation as necessary
* [x] I have updated helm chart(s) if needed
* [x] I have added tests if needed
* [ ] All new and existing tests are passing
* [x] Any breaking changes are clearly flagged and documented
* [x] I’ve included a link to any relevant ticket(s)