### PR TITLE
helm test blocks install if third party endpoints enabled without a token

### DIFF
--- a/docs/helm-jwks-opa.md
+++ b/docs/helm-jwks-opa.md
@@ -109,6 +109,10 @@ The applicability of the above depends on the configuration of your OIDC
 server, and the rules in your OPA access policy. At least one of the above
 URLs must be set for Chronicle to accept a user's authorization.
 
+**Note**: By default, if `auth.userinfo.url` is provided, `test.auth.token` is
+required. To learn more about testing with Helm and default settings, see
+this [Note on Default Settings](./helm_testing.md#note-on-default-settings).
+
 ##### Claims fields
 
 To your `auth:` section add a further Helm value:
@@ -240,3 +244,6 @@ Alternatively, to obtain JWTs with your own OIDC client, it must connect to
 that mock OIDC server. Login credentials for a dummy user can be obtained from
 the `id-provider` container's logs where the `OidcController` notes its
 config on startup.
+
+For more on Chronicle Helm testing scenarios, see our documentation on
+[Helm Testing Scenarios](./helm_testing.md#testing-scenarios).

--- a/docs/helm-scenarios.md
+++ b/docs/helm-scenarios.md
@@ -42,6 +42,10 @@ omitted. Similarly, if the claims determining Chronicle identity are `iss sub`
 then `id:` can also be omitted as those are the default. To also allow
 anonymous requests, without an `Authorization:` header, also omit `required:`.
 
+**Note**: By default, if `auth.userinfo.url` is provided, `test.auth.token` is
+required. To learn more about testing with Helm and default settings, see
+this [Note on Default Settings](./helm_testing.md#note-on-default-settings).
+
 ### OIDC but not OPA: allow everything, recording identity
 
 Chronicle can record who performed transactions while permitting them all:
@@ -134,3 +138,6 @@ You may instead choose to disable OPA with,
 opa:
   enabled: false
 ```
+
+For more on Chronicle Helm testing scenarios, see our documentation on
+[Helm Testing Scenarios](./helm_testing.md#testing-scenarios).

--- a/docs/helm_testing.md
+++ b/docs/helm_testing.md
@@ -190,3 +190,23 @@ test:
 The user provides a token and auth endpoints. Note that in this scenario, it does
 not matter whether the devIdProvider is enabled or not, but testing requires that
 the user provides a token that will work with their third-party auth service.
+
+#### Note on Default Settings
+
+If you provide your own `auth.userinfo.url` Chronicle's Helm Chart
+`auth-endpoints-test` requires `test.auth.token`. This is because failing to
+provide this will require reinstallation of the Chart in order to enable testing
+of a third-party userinfo URL.
+
+Add the following settings to your `values.yaml` to disable the tests:
+
+```yaml
+test:
+  api:
+    enabled: false
+  auth:
+    enabled: false
+```
+
+Alternatively, provide `test.auth.token` in your `values.yaml`, as described in
+[Auth Required, Third Party Auth Service](#auth-required-third-party-auth-service).


### PR DESCRIPTION
This resolves [CHRON-426](https://blockchaintp.atlassian.net/browse/CHRON-426) by, as originally suggested by @mtbc , adding documentation that explains default testing settings and requirements when a user provides their own auth endpoints.

# PR Checklist

## Please complete this checklist after opening your PR

* [x] I have updated documentation as necessary
* [x] I have updated helm chart(s) if needed
* [x] I have added tests if needed
* [x] All new and existing tests are passing
* [x] Any breaking changes are clearly flagged and documented
* [x] I’ve included a link to any relevant ticket(s)


[CHRON-426]: https://blockchaintp.atlassian.net/browse/CHRON-426?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ