### PR TITLE
helm api test writes to "chronicle-system" namespace

### DIFF
--- a/docker/helm-api-subscribe-submit-test
+++ b/docker/helm-api-subscribe-submit-test
@@ -70,7 +70,7 @@ issueGraphQLSubscription "$HOST:$PORT" "$subscriptionQuery" >"$subscriptionOutpu
 mutationQuery="mutation {
   defineAgent(
     externalId: \"$random_externalId\",
-    namespace: \"helm-api-subscribe-submit-test\",
+    namespace: \"chronicle-system\",
     attributes: {}
   ) {
     txId

--- a/docs/helm_testing.md
+++ b/docs/helm_testing.md
@@ -36,6 +36,9 @@ The API Test Job includes the following test steps:
 - Wait for the API to be ready.
 - Execute the tests using the `subscribe-submit-test` script.
 
+Note, the Chronicle Helm Chart API test uses the reserved
+[`chronicle-system` namespace](./namespaces.md#chronicle-system).
+
 ### Auth Endpoints Test Job
 
 The Auth Endpoints Test Job verifies the availability and correctness of the


### PR DESCRIPTION
Now we have the `"chronicle-system"` namespace let's use it.

[CHRON-449](https://blockchaintp.atlassian.net/browse/CHRON-449)

# PR Checklist

## Please complete this checklist after opening your PR

* [x] I have updated documentation as necessary
* [x] I have updated helm chart(s) if needed
* [x] I have added tests if needed
* [x] All new and existing tests are passing
* [x] Any breaking changes are clearly flagged and documented
* [x] I’ve included a link to any relevant ticket(s)


[CHRON-449]: https://blockchaintp.atlassian.net/browse/CHRON-449?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ