### PR TITLE
deprecate agent: parameter in API

### DIFF
--- a/crates/api/src/chronicle_graphql/mutation.rs
+++ b/crates/api/src/chronicle_graphql/mutation.rs
@@ -230,7 +230,7 @@ pub async fn start_activity<'a>(
     ctx: &Context<'a>,
     id: ActivityId,
     namespace: Option<String>,
-    agent: Option<AgentId>,
+    agent: Option<AgentId>, // deprecated, slated for removal in CHRON-185
     time: Option<DateTime<Utc>>,
 ) -> async_graphql::Result<Submission> {
     let api = ctx.data_unchecked::<ApiDispatch>();
@@ -258,7 +258,7 @@ pub async fn end_activity<'a>(
     ctx: &Context<'a>,
     id: ActivityId,
     namespace: Option<String>,
-    agent: Option<AgentId>,
+    agent: Option<AgentId>, // deprecated, slated for removal in CHRON-185
     time: Option<DateTime<Utc>>,
 ) -> async_graphql::Result<Submission> {
     let api = ctx.data_unchecked::<ApiDispatch>();
@@ -286,7 +286,7 @@ pub async fn instant_activity<'a>(
     ctx: &Context<'a>,
     id: ActivityId,
     namespace: Option<String>,
-    agent: Option<AgentId>,
+    agent: Option<AgentId>, // deprecated, slated for removal in CHRON-185
     time: Option<DateTime<Utc>>,
 ) -> async_graphql::Result<Submission> {
     let api = ctx.data_unchecked::<ApiDispatch>();

--- a/docs/recording_provenance.md
+++ b/docs/recording_provenance.md
@@ -660,10 +660,11 @@ time](#ended-at-time). Eliding the time parameter will use the current system
 time. Time stamps should be in
 [RFC3339](https://www.rfc-editor.org/rfc/rfc3339.html) format.
 
-Started at time operations also take an optional `AgentIdOrExternal`, to
-associate the activity with the agent - there is no current way to record a role
-with this however, so prefer [wasAssociatedWith](#association) if you need
-role-based modeling.
+Started at Time operations also take an optional `AgentIdOrExternal`,
+to associate the activity with the agent. This `agent` parameter causes
+confusion, by always recording that the agent's role is unspecified,
+so it is **deprecated** and should *not* be used. Instead, use
+[wasAssociatedWith](#association) to associate activities with agents.
 
 ```graphql
 mutation {
@@ -688,10 +689,11 @@ model a time range. Eliding the time parameter will use the current system time.
 Time stamps should be in [RFC3339](https://www.rfc-editor.org/rfc/rfc3339.html)
 format.
 
-Ended at time operations also take an optional `AgentIdOrExternal`, to associate
-the activity with the agent - there is no current way to record a role with this
-however, so prefer [wasAssociatedWith](#association) if you need role-based
-modeling.
+Ended at Time operations also take an optional `AgentIdOrExternal`,
+to associate the activity with the agent. This `agent` parameter causes
+confusion, by always recording that the agent's role is unspecified,
+so it is **deprecated** and should *not* be used. Instead, use
+[wasAssociatedWith](#association) to associate activities with agents.
 
 ```graphql
 mutation {


### PR DESCRIPTION
Applies to,

- `startActivity`
- `endActivity`
- `instantActivity`

Addresses CHRON-458 in anticipation of CHRON-185.

Unfortunately, with `async-graphql` generating the schema, I do not see a convenient way of machine-readably marking the parameter as being deprecated.

# PR Checklist

## Please complete this checklist after opening your PR

* [x] I have updated documentation as necessary
* [x] I have updated helm chart(s) if needed
* [x] I have added tests if needed
* [x] All new and existing tests are passing
* [x] Any breaking changes are clearly flagged and documented
* [x] I’ve included a link to any relevant ticket(s)
