### PR TITLE
test: backport sleep coverage and determinism support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3387,9 +3387,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.53"
+version = "0.10.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12df40a956736488b7b44fe79fe12d4f245bb5b3f5a1f6095e499760015be392"
+checksum = "345df152bc43501c5eb9e4654ff05f794effb78d4efe3d53abc158baddc0703d"
 dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
@@ -3428,9 +3428,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.88"
+version = "0.9.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2ce0f250f34a308dcfdbb351f511359857d4ed2134ba715a4eadd46e1ffd617"
+checksum = "374533b0e45f3a7ced10fcaeccca020e66656bc03dac384f852e4e5a7a8104a6"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,7 @@ mime = "0.3"
 mockito = "1.0.2"
 oauth2 = "4.4"
 opa = "0.9.0"
-openssl = "0.10.48"
+openssl = "0.10.55"
 opentelemetry = { version = "0.18.0", features = ["rt-tokio"] }
 opentelemetry-jaeger = { version = "0.17.0", features = [
   "rt-tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ insta = { version = "1.26.0", features = ["redactions", "toml"] }
 iref = "2.2"
 iref-enum = "2.1"
 json-ld = { version = "0.14" }
-json-syntax = { version = "*", features = ["serde", "serde_json"] }
+json-syntax = { version = "0.9", features = ["serde", "serde_json"] }
 jsonschema = "0.17.0"
 jwtk = { version = "0.2.4", features = ["remote-jwks"] }
 k256 = { version = "0.11.3", features = [
@@ -120,7 +120,7 @@ structopt = "0.3.26"
 temp-dir = "0.1.11"
 tempfile = "3.4.0"
 testcontainers = "0.14"
-thiserror = "1.0.38"
+thiserror = "1.0"
 tokio = { version = "1.27", features = [
   "time",
   "macros",

--- a/crates/api/src/chronicle_graphql/mod.rs
+++ b/crates/api/src/chronicle_graphql/mod.rs
@@ -15,8 +15,8 @@ use common::{
     ledger::{SubmissionError, SubmissionStage},
     opa::{ExecutorContext, OpaExecutorError},
     prov::{
-        to_json_ld::ToJson, ChronicleIri, ChronicleTransactionId, CompactedJson, ExternalId,
-        ExternalIdPart, ProvModel,
+        to_json_ld::ToJson, ChronicleIri, ChronicleTransactionId, ExternalId, ExternalIdPart,
+        ProvModel,
     },
 };
 use derivative::*;
@@ -839,7 +839,7 @@ impl IriEndpoint {
             Ok(()) => match self.store.connection() {
                 Ok(connection) => match retrieve(connection, id, ns) {
                     Ok(data) => match data.to_json().compact().await {
-                        Ok(CompactedJson(mut json)) => {
+                        Ok(mut json) => {
                             use serde_json::Value;
                             if let Value::Object(mut map) = json {
                                 map.insert(

--- a/crates/api/src/persistence/mod.rs
+++ b/crates/api/src/persistence/mod.rs
@@ -1,8 +1,4 @@
-use std::{
-    collections::{BTreeMap, HashMap},
-    str::FromStr,
-    time::Duration,
-};
+use std::{collections::BTreeMap, str::FromStr, time::Duration};
 
 use async_sawtooth_sdk::ledger::{BlockId, BlockIdError};
 use chrono::DateTime;
@@ -184,7 +180,7 @@ impl Store {
             attributes,
             ..
         }: &Activity,
-        ns: &HashMap<NamespaceId, Namespace>,
+        ns: &BTreeMap<NamespaceId, Namespace>,
     ) -> Result<(), StoreError> {
         use schema::activity as dsl;
         let _namespace = ns.get(namespaceid).ok_or(StoreError::InvalidNamespace {})?;
@@ -267,7 +263,7 @@ impl Store {
             attributes,
             ..
         }: &Agent,
-        ns: &HashMap<NamespaceId, Namespace>,
+        ns: &BTreeMap<NamespaceId, Namespace>,
     ) -> Result<(), StoreError> {
         use schema::agent::dsl;
         let _namespace = ns.get(namespaceid).ok_or(StoreError::InvalidNamespace {})?;
@@ -331,7 +327,7 @@ impl Store {
             signature_time,
             ..
         }: &Attachment,
-        ns: &HashMap<NamespaceId, Namespace>,
+        ns: &BTreeMap<NamespaceId, Namespace>,
     ) -> Result<(), StoreError> {
         let _namespace = ns.get(namespaceid).ok_or(StoreError::InvalidNamespace {})?;
         let (_, nsid) =
@@ -377,7 +373,7 @@ impl Store {
             domaintypeid,
             attributes,
         }: &Entity,
-        ns: &HashMap<NamespaceId, Namespace>,
+        ns: &BTreeMap<NamespaceId, Namespace>,
     ) -> Result<(), StoreError> {
         use schema::entity::dsl;
         let _namespace = ns.get(namespaceid).ok_or(StoreError::InvalidNamespace {})?;
@@ -543,7 +539,7 @@ impl Store {
             public_key,
             ..
         }: &Identity,
-        ns: &HashMap<NamespaceId, Namespace>,
+        ns: &BTreeMap<NamespaceId, Namespace>,
     ) -> Result<(), StoreError> {
         use schema::identity::dsl;
         let _namespace = ns.get(namespaceid).ok_or(StoreError::InvalidNamespace {})?;

--- a/crates/async-sawtooth-sdk/src/ledger.rs
+++ b/crates/async-sawtooth-sdk/src/ledger.rs
@@ -364,8 +364,8 @@ impl<
             builder,
             channel,
             last_seen_block: Default::default(),
-            _e: std::marker::PhantomData::default(),
-            _t: std::marker::PhantomData::default(),
+            _e: std::marker::PhantomData,
+            _t: std::marker::PhantomData,
         }
     }
 

--- a/crates/chronicle-domain-test/src/test.rs
+++ b/crates/chronicle-domain-test/src/test.rs
@@ -750,6 +750,8 @@ mod test {
         }
         "###);
 
+        tokio::time::sleep(Duration::from_millis(1000)).await;
+
         insta::assert_json_snapshot!(schema
           .execute(Request::new(
             &format!(
@@ -921,6 +923,8 @@ mod test {
           }
         }
         "###);
+
+        tokio::time::sleep(Duration::from_millis(1000)).await;
 
         insta::assert_json_snapshot!(schema
           .execute(Request::new(
@@ -1678,6 +1682,8 @@ mod test {
           }
         "###);
 
+        tokio::time::sleep(Duration::from_millis(1500)).await;
+
         insta::assert_json_snapshot!(schema
           .execute(Request::new(
               r#"
@@ -1724,6 +1730,8 @@ mod test {
             }
           }
         "###);
+
+        tokio::time::sleep(Duration::from_millis(1500)).await;
 
         // use the same delegated contractor for two different roles
 
@@ -1837,7 +1845,7 @@ mod test {
         context = 'chronicle:entity:testentity1'
         "###);
 
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        tokio::time::sleep(Duration::from_millis(1000)).await;
 
         insta::assert_toml_snapshot!(schema
           .execute(Request::new(
@@ -1887,7 +1895,7 @@ mod test {
         context = 'chronicle:entity:testentity1'
         "###);
 
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        tokio::time::sleep(Duration::from_millis(1000)).await;
 
         insta::assert_toml_snapshot!(schema
           .execute(Request::new(
@@ -1946,7 +1954,7 @@ mod test {
         context = 'chronicle:entity:testentity1'
         "###);
 
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        tokio::time::sleep(Duration::from_millis(1000)).await;
 
         insta::assert_toml_snapshot!(schema
           .execute(Request::new(
@@ -2004,7 +2012,7 @@ mod test {
         context = 'chronicle:entity:testentity1'
         "###);
 
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        tokio::time::sleep(Duration::from_millis(1000)).await;
 
         insta::assert_toml_snapshot!(schema
           .execute(Request::new(
@@ -2081,7 +2089,7 @@ mod test {
         context = 'chronicle:agent:testagent1'
         "###);
 
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        tokio::time::sleep(Duration::from_millis(1000)).await;
 
         insta::assert_toml_snapshot!(schema
           .execute(Request::new(
@@ -2121,7 +2129,7 @@ mod test {
         context = 'chronicle:activity:testactivity1'
         "###);
 
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        tokio::time::sleep(Duration::from_millis(1000)).await;
 
         insta::assert_toml_snapshot!(schema
           .execute(Request::new(
@@ -2161,7 +2169,7 @@ mod test {
         context = 'chronicle:entity:testentity1'
         "###);
 
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        tokio::time::sleep(Duration::from_millis(1000)).await;
 
         let agent = schema
             .execute(Request::new(
@@ -2204,6 +2212,8 @@ mod test {
         context = 'chronicle:activity:testactivityid1'
         "###);
 
+        tokio::time::sleep(Duration::from_millis(1000)).await;
+
         // create another activity
         insta::assert_toml_snapshot!(schema
           .execute(Request::new(
@@ -2220,6 +2230,8 @@ mod test {
         [data.defineItemManufacturedActivity]
         context = 'chronicle:activity:testactivityid2'
         "###);
+
+        tokio::time::sleep(Duration::from_millis(1000)).await;
 
         // establish WasInformedBy relationship
         insta::assert_toml_snapshot!(schema
@@ -2239,7 +2251,7 @@ mod test {
         context = 'chronicle:activity:testactivityid1'
         "###);
 
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        tokio::time::sleep(Duration::from_millis(1000)).await;
 
         // query WasInformedBy relationship
         insta::assert_toml_snapshot!(schema
@@ -2273,7 +2285,7 @@ mod test {
         externalId = 'testactivityid2'
         "###);
 
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        tokio::time::sleep(Duration::from_millis(1000)).await;
 
         // create a third activity
         insta::assert_toml_snapshot!(schema
@@ -2291,7 +2303,7 @@ mod test {
         context = 'chronicle:activity:testactivityid3'
         "###);
 
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        tokio::time::sleep(Duration::from_millis(1000)).await;
 
         // establish another WasInformedBy relationship
         insta::assert_toml_snapshot!(schema
@@ -2311,7 +2323,7 @@ mod test {
         context = 'chronicle:activity:testactivityid1'
         "###);
 
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        tokio::time::sleep(Duration::from_millis(1000)).await;
 
         // query WasInformedBy relationship
         insta::assert_toml_snapshot!(schema
@@ -2448,7 +2460,7 @@ mod test {
         }
         "###);
 
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        tokio::time::sleep(Duration::from_millis(1000)).await;
 
         // attribute the entity to the agent
         insta::assert_json_snapshot!(schema
@@ -2472,7 +2484,7 @@ mod test {
               }
               "###);
 
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        tokio::time::sleep(Duration::from_millis(1000)).await;
 
         // query WasAttributedTo relationship
         insta::assert_toml_snapshot!(schema
@@ -2516,7 +2528,7 @@ mod test {
         locationAttribute = 'SomeLocation'
         "###);
 
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        tokio::time::sleep(Duration::from_millis(1000)).await;
 
         insta::assert_toml_snapshot!(schema
                   .execute(Request::new(
@@ -2560,7 +2572,7 @@ mod test {
         locationAttribute = 'SomeLocation'
         "###);
 
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        tokio::time::sleep(Duration::from_millis(1000)).await;
 
         insta::assert_toml_snapshot!(schema
                 .execute(Request::new(
@@ -2603,7 +2615,7 @@ mod test {
         certIdAttribute = 'SomeCertId'
         "###);
 
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        tokio::time::sleep(Duration::from_millis(1000)).await;
 
         insta::assert_toml_snapshot!(schema
                 .execute(Request::new(
@@ -2647,7 +2659,7 @@ mod test {
         certIdAttribute = 'SomeCertId'
         "###);
 
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        tokio::time::sleep(Duration::from_millis(1000)).await;
 
         // create another agent and attribute the entity to that other agent as well
         insta::assert_json_snapshot!(schema
@@ -2677,7 +2689,7 @@ mod test {
         }
         "###);
 
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        tokio::time::sleep(Duration::from_millis(1000)).await;
 
         // query WasAttributedTo relationship
         insta::assert_toml_snapshot!(schema
@@ -2730,7 +2742,7 @@ mod test {
         locationAttribute = 'AnotherLocation'
         "###);
 
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        tokio::time::sleep(Duration::from_millis(1000)).await;
 
         insta::assert_toml_snapshot!(schema
             .execute(Request::new(
@@ -2783,7 +2795,7 @@ mod test {
         locationAttribute = 'AnotherLocation'
         "###);
 
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        tokio::time::sleep(Duration::from_millis(1000)).await;
 
         insta::assert_toml_snapshot!(schema
                 .execute(Request::new(
@@ -2825,7 +2837,7 @@ mod test {
         certIdAttribute = 'SomeCertId'
         "###);
 
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        tokio::time::sleep(Duration::from_millis(1000)).await;
 
         insta::assert_toml_snapshot!(schema
                 .execute(Request::new(
@@ -2903,6 +2915,8 @@ mod test {
         context = 'chronicle:activity:testactivity1'
         "###);
 
+        tokio::time::sleep(Duration::from_millis(1000)).await;
+
         // create an entity
         insta::assert_toml_snapshot!(schema
           .execute(Request::new(
@@ -2918,6 +2932,8 @@ mod test {
         [data.defineNCBRecordEntity]
         context = 'chronicle:entity:testentity1'
         "###);
+
+        tokio::time::sleep(Duration::from_millis(1000)).await;
 
         // establish Generated relationship
         insta::assert_toml_snapshot!(schema
@@ -2937,7 +2953,7 @@ mod test {
         context = 'chronicle:entity:testentity1'
         "###);
 
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        tokio::time::sleep(Duration::from_millis(1000)).await;
 
         // query Generated relationship
         insta::assert_toml_snapshot!(schema
@@ -2971,6 +2987,8 @@ mod test {
         externalId = 'testentity1'
         "###);
 
+        tokio::time::sleep(Duration::from_millis(1000)).await;
+
         // The following demonstrates that a second wasGeneratedBy
         // relationship cannot be made once the first has been established.
 
@@ -2991,6 +3009,8 @@ mod test {
         context = 'chronicle:entity:testitem'
         "###);
 
+        tokio::time::sleep(Duration::from_millis(1000)).await;
+
         // establish another Generated relationship
         insta::assert_toml_snapshot!(schema
             .execute(Request::new(
@@ -3009,7 +3029,7 @@ mod test {
         context = 'chronicle:entity:testitem'
         "###);
 
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        tokio::time::sleep(Duration::from_millis(1000)).await;
 
         // query Generated relationship
         insta::assert_toml_snapshot!(schema
@@ -3066,7 +3086,7 @@ mod test {
 
         assert_eq!(res.errors, vec![]);
 
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        tokio::time::sleep(Duration::from_millis(1000)).await;
 
         let res = schema
             .execute(Request::new(
@@ -3088,7 +3108,7 @@ mod test {
 
         assert_eq!(res.errors, vec![]);
 
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        tokio::time::sleep(Duration::from_millis(1000)).await;
 
         let res = schema
                 .execute(Request::new(
@@ -3104,7 +3124,7 @@ mod test {
 
         assert_eq!(res.errors, vec![]);
 
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        tokio::time::sleep(Duration::from_millis(1000)).await;
 
         let res = schema
             .execute(Request::new(
@@ -3120,7 +3140,7 @@ mod test {
 
         assert_eq!(res.errors, vec![]);
 
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        tokio::time::sleep(Duration::from_millis(1000)).await;
 
         let from = DateTime::<Utc>::from_utc(
             NaiveDate::from_ymd_opt(1968, 9, 1)
@@ -3169,7 +3189,7 @@ mod test {
                 assert_eq!(res.errors, vec![]);
             }
 
-            tokio::time::sleep(Duration::from_millis(100)).await;
+            tokio::time::sleep(Duration::from_millis(1000)).await;
             let res = schema
                 .execute(Request::new(format!(
                     r#"
@@ -3183,7 +3203,7 @@ mod test {
                 .await;
             assert_eq!(res.errors, vec![]);
 
-            tokio::time::sleep(Duration::from_millis(100)).await;
+            tokio::time::sleep(Duration::from_millis(1000)).await;
 
             let res = schema
                 .execute(Request::new(format!(
@@ -3203,6 +3223,8 @@ mod test {
 
             assert_eq!(res.errors, vec![]);
 
+            tokio::time::sleep(Duration::from_millis(1000)).await;
+
             let res = schema
                 .execute(Request::new(format!(
                     r#"
@@ -3221,7 +3243,7 @@ mod test {
 
             assert_eq!(res.errors, vec![]);
 
-            tokio::time::sleep(Duration::from_millis(100)).await;
+            tokio::time::sleep(Duration::from_millis(1000)).await;
 
             let agent = if i % 2 == 0 {
                 "testagent1"
@@ -3241,7 +3263,7 @@ mod test {
                 )))
                 .await;
 
-            tokio::time::sleep(Duration::from_millis(100)).await;
+            tokio::time::sleep(Duration::from_millis(1000)).await;
 
             assert_eq!(res.errors, vec![]);
         }
@@ -3619,6 +3641,8 @@ mod test {
         }
         "###);
 
+        tokio::time::sleep(Duration::from_millis(1000)).await;
+
         // Entire timeline reverse order
         insta::assert_json_snapshot!(schema
           .execute(Request::new(
@@ -3990,6 +4014,8 @@ mod test {
         }
         "###);
 
+        tokio::time::sleep(Duration::from_millis(1000)).await;
+
         // By activity type
 
         // Note the case of `ItemCertified` and `ItemCodified` in the `activityTypes`
@@ -4092,6 +4118,8 @@ mod test {
         }
         "###);
 
+        tokio::time::sleep(Duration::from_millis(1000)).await;
+
         // As previous but omitting forEntity and forAgent
         insta::assert_json_snapshot!(schema
           .execute(Request::new(
@@ -4188,6 +4216,8 @@ mod test {
         }
         "###);
 
+        tokio::time::sleep(Duration::from_millis(1000)).await;
+
         // By agent
         insta::assert_json_snapshot!(schema
           .execute(Request::new(
@@ -4261,6 +4291,8 @@ mod test {
           }
         }
         "###);
+
+        tokio::time::sleep(Duration::from_millis(1000)).await;
 
         // As previous but omitting forEntity and activityTypes
         insta::assert_json_snapshot!(schema
@@ -4355,7 +4387,7 @@ mod test {
             assert_eq!(res.errors, vec![]);
         }
 
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        tokio::time::sleep(Duration::from_millis(1000)).await;
 
         // Default cursor
 
@@ -4494,6 +4526,8 @@ mod test {
           }
         }
         "###);
+
+        tokio::time::sleep(Duration::from_millis(1000)).await;
 
         // Middle cursor
 
@@ -4723,6 +4757,8 @@ mod test {
         }
         "###);
 
+        tokio::time::sleep(Duration::from_millis(1000)).await;
+
         // Out of bound cursor
 
         // Note the case of `Contractor` in the `agentsByType(agentType:` field of
@@ -4870,6 +4906,8 @@ mod test {
             .to_string(),
         ));
 
+        tokio::time::sleep(Duration::from_millis(1000)).await;
+
         insta::assert_json_snapshot!(schema
           .execute(Request::new(
               r#"
@@ -4894,6 +4932,8 @@ mod test {
           "#);
 
         let res = stream.next().await.unwrap();
+
+        tokio::time::sleep(Duration::from_millis(1000)).await;
 
         insta::assert_json_snapshot!(res, @r###"
         {

--- a/crates/chronicle-protocol/src/messages.rs
+++ b/crates/chronicle-protocol/src/messages.rs
@@ -39,7 +39,7 @@ impl TransactionPayload for ChronicleSubmitTransaction {
         let mut ops = Vec::with_capacity(self.tx.tx.len());
         for op in &self.tx.tx {
             let op_json = op.to_json();
-            let compact_json_string = op_json.compact().await?.0.to_string();
+            let compact_json_string = op_json.compact().await?.to_string();
             // using `unwrap` to work around `MessageBuilder::make_sawtooth_transaction`,
             // which calls here from `sawtooth-protocol::messages` being non-fallible
             ops.push(compact_json_string);

--- a/crates/common/src/prov/model/mod.rs
+++ b/crates/common/src/prov/model/mod.rs
@@ -10,7 +10,7 @@ use rdf_types::{vocabulary::no_vocabulary_mut, BlankIdBuf};
 use serde::Serialize;
 use serde_json::Value;
 use std::{
-    collections::{BTreeMap, HashMap, HashSet},
+    collections::{BTreeMap, BTreeSet},
     convert::Infallible,
     fmt::{Debug, Display},
 };
@@ -317,7 +317,7 @@ impl Entity {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Ord, PartialOrd, Serialize, Deserialize)]
 pub struct Derivation {
     pub generated_id: EntityId,
     pub used_id: EntityId,
@@ -325,7 +325,7 @@ pub struct Derivation {
     pub typ: DerivationType,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Ord, PartialOrd, Serialize, Deserialize)]
 pub struct Delegation {
     pub namespace_id: NamespaceId,
     pub id: DelegationId,
@@ -359,7 +359,7 @@ impl Delegation {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Ord, PartialOrd, Serialize, Deserialize)]
 pub struct Association {
     pub namespace_id: NamespaceId,
     pub id: AssociationId,
@@ -385,25 +385,25 @@ impl Association {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Ord, PartialOrd, Serialize, Deserialize)]
 pub struct Usage {
     pub activity_id: ActivityId,
     pub entity_id: EntityId,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Ord, PartialOrd, Serialize, Deserialize)]
 pub struct Generation {
     pub activity_id: ActivityId,
     pub generated_id: EntityId,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Ord, PartialOrd, Serialize, Deserialize)]
 pub struct GeneratedEntity {
     pub entity_id: EntityId,
     pub generated_id: ActivityId,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Ord, PartialOrd, Serialize, Deserialize)]
 pub struct Attribution {
     pub namespace_id: NamespaceId,
     pub id: AttributionId,
@@ -438,25 +438,25 @@ type NamespacedAttachment = NamespacedId<EvidenceId>;
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ProvModel {
-    pub namespaces: HashMap<NamespaceId, Namespace>,
-    pub agents: HashMap<NamespacedAgent, Agent>,
-    pub activities: HashMap<NamespacedActivity, Activity>,
-    pub entities: HashMap<NamespacedEntity, Entity>,
-    pub identities: HashMap<NamespacedIdentity, Identity>,
-    pub attachments: HashMap<NamespacedAttachment, Attachment>,
-    pub has_identity: HashMap<NamespacedAgent, NamespacedIdentity>,
-    pub had_identity: HashMap<NamespacedAgent, HashSet<NamespacedIdentity>>,
-    pub has_evidence: HashMap<NamespacedEntity, NamespacedAttachment>,
-    pub had_attachment: HashMap<NamespacedEntity, HashSet<NamespacedAttachment>>,
-    pub association: HashMap<NamespacedActivity, HashSet<Association>>,
-    pub derivation: HashMap<NamespacedEntity, HashSet<Derivation>>,
-    pub delegation: HashMap<NamespacedAgent, HashSet<Delegation>>,
-    pub acted_on_behalf_of: HashMap<NamespacedAgent, HashSet<Delegation>>,
-    pub generation: HashMap<NamespacedEntity, HashSet<Generation>>,
-    pub usage: HashMap<NamespacedActivity, HashSet<Usage>>,
-    pub was_informed_by: HashMap<NamespacedActivity, HashSet<NamespacedActivity>>,
-    pub generated: HashMap<NamespacedActivity, HashSet<GeneratedEntity>>,
-    pub attribution: HashMap<NamespacedEntity, HashSet<Attribution>>,
+    pub namespaces: BTreeMap<NamespaceId, Namespace>,
+    pub agents: BTreeMap<NamespacedAgent, Agent>,
+    pub activities: BTreeMap<NamespacedActivity, Activity>,
+    pub entities: BTreeMap<NamespacedEntity, Entity>,
+    pub identities: BTreeMap<NamespacedIdentity, Identity>,
+    pub attachments: BTreeMap<NamespacedAttachment, Attachment>,
+    pub has_identity: BTreeMap<NamespacedAgent, NamespacedIdentity>,
+    pub had_identity: BTreeMap<NamespacedAgent, BTreeSet<NamespacedIdentity>>,
+    pub has_evidence: BTreeMap<NamespacedEntity, NamespacedAttachment>,
+    pub had_attachment: BTreeMap<NamespacedEntity, BTreeSet<NamespacedAttachment>>,
+    pub association: BTreeMap<NamespacedActivity, BTreeSet<Association>>,
+    pub derivation: BTreeMap<NamespacedEntity, BTreeSet<Derivation>>,
+    pub delegation: BTreeMap<NamespacedAgent, BTreeSet<Delegation>>,
+    pub acted_on_behalf_of: BTreeMap<NamespacedAgent, BTreeSet<Delegation>>,
+    pub generation: BTreeMap<NamespacedEntity, BTreeSet<Generation>>,
+    pub usage: BTreeMap<NamespacedActivity, BTreeSet<Usage>>,
+    pub was_informed_by: BTreeMap<NamespacedActivity, BTreeSet<NamespacedActivity>>,
+    pub generated: BTreeMap<NamespacedActivity, BTreeSet<GeneratedEntity>>,
+    pub attribution: BTreeMap<NamespacedEntity, BTreeSet<Attribution>>,
 }
 
 impl ProvModel {
@@ -484,7 +484,7 @@ impl ProvModel {
     ) {
         self.derivation
             .entry((namespace_id, id.clone()))
-            .or_insert_with(HashSet::new)
+            .or_insert_with(BTreeSet::new)
             .insert(Derivation {
                 typ,
                 generated_id: id,
@@ -517,11 +517,11 @@ impl ProvModel {
         };
         self.delegation
             .entry((namespace_id.clone(), responsible_id.clone()))
-            .or_insert_with(HashSet::new)
+            .or_insert_with(BTreeSet::new)
             .insert(delegation.clone());
         self.acted_on_behalf_of
             .entry((namespace_id.clone(), delegate_id.clone()))
-            .or_insert_with(HashSet::new)
+            .or_insert_with(BTreeSet::new)
             .insert(delegation);
     }
 
@@ -534,7 +534,7 @@ impl ProvModel {
     ) {
         self.association
             .entry((namespace_id.clone(), activity_id.clone()))
-            .or_insert_with(HashSet::new)
+            .or_insert_with(BTreeSet::new)
             .insert(Association {
                 namespace_id: namespace_id.clone(),
                 id: AssociationId::from_component_ids(agent_id, activity_id, role.as_ref()),
@@ -552,7 +552,7 @@ impl ProvModel {
     ) {
         self.generation
             .entry((namespace, generated_id.clone()))
-            .or_insert_with(HashSet::new)
+            .or_insert_with(BTreeSet::new)
             .insert(Generation {
                 activity_id: activity_id.clone(),
                 generated_id: generated_id.clone(),
@@ -567,7 +567,7 @@ impl ProvModel {
     ) {
         self.generated
             .entry((namespace, generated_id.clone()))
-            .or_insert_with(HashSet::new)
+            .or_insert_with(BTreeSet::new)
             .insert(GeneratedEntity {
                 entity_id: entity_id.clone(),
                 generated_id: generated_id.clone(),
@@ -577,7 +577,7 @@ impl ProvModel {
     pub fn used(&mut self, namespace: NamespaceId, activity_id: &ActivityId, entity_id: &EntityId) {
         self.usage
             .entry((namespace, activity_id.clone()))
-            .or_insert_with(HashSet::new)
+            .or_insert_with(BTreeSet::new)
             .insert(Usage {
                 activity_id: activity_id.clone(),
                 entity_id: entity_id.clone(),
@@ -592,7 +592,7 @@ impl ProvModel {
     ) {
         self.was_informed_by
             .entry((namespace.clone(), activity.clone()))
-            .or_insert_with(HashSet::new)
+            .or_insert_with(BTreeSet::new)
             .insert((namespace, informing_activity.clone()));
     }
 
@@ -605,7 +605,7 @@ impl ProvModel {
     ) {
         self.attribution
             .entry((namespace_id.clone(), entity_id.clone()))
-            .or_insert_with(HashSet::new)
+            .or_insert_with(BTreeSet::new)
             .insert(Attribution {
                 namespace_id: namespace_id.clone(),
                 id: AttributionId::from_component_ids(agent_id, entity_id, role.as_ref()),
@@ -618,7 +618,7 @@ impl ProvModel {
     pub fn had_identity(&mut self, namespace: NamespaceId, agent: &AgentId, identity: &IdentityId) {
         self.had_identity
             .entry((namespace.clone(), agent.clone()))
-            .or_insert_with(HashSet::new)
+            .or_insert_with(BTreeSet::new)
             .insert((namespace, identity.clone()));
     }
 
@@ -637,7 +637,7 @@ impl ProvModel {
     ) {
         self.had_attachment
             .entry((namespace.clone(), entity))
-            .or_insert_with(HashSet::new)
+            .or_insert_with(BTreeSet::new)
             .insert((namespace, attachment.clone()));
     }
 
@@ -924,7 +924,7 @@ impl ProvModel {
                     _ => {}
                 };
 
-                self.modify_activity(&namespace, &id, move |mut activity| {
+                self.modify_activity(&namespace, &id, move |activity| {
                     activity.ended = Some(time);
                 });
 
@@ -1298,7 +1298,7 @@ lazy_static! {
 }
 
 impl ExpandedJson {
-    pub async fn compact(self) -> Result<CompactedJson, CompactionError> {
+    async fn compact_unordered(self) -> Result<CompactedJson, CompactionError> {
         use json_ld::{
             syntax::context, Compact, ExpandedDocument, Process, ProcessingMode, TryFromJson,
         };
@@ -1347,9 +1347,12 @@ impl ExpandedJson {
                 inner: e.to_string(),
             })?;
 
+        // Sort @graph
+
         // reference context
 
-        let json = output.into_value().into();
+        let json: Value = output.into_value().into();
+
         if let Value::Object(mut map) = json {
             map.insert(
                 "@context".to_string(),
@@ -1361,20 +1364,20 @@ impl ExpandedJson {
         }
     }
 
-    pub async fn compact_stable_order(self) -> Result<Value, CompactionError> {
-        let mut v: serde_json::Value = serde_json::from_str(&self.compact().await?.0.to_string())?;
+    // Sort @graph by json value, as they are unstable and we need deterministic output
+    pub async fn compact(self) -> Result<Value, CompactionError> {
+        let mut v: serde_json::Value =
+            serde_json::from_str(&self.compact_unordered().await?.0.to_string())?;
 
-        // Sort @graph by //@id, as objects are unordered
         if let Some(v) = v.pointer_mut("/@graph").and_then(|p| p.as_array_mut()) {
-            v.sort_by(|l, r| {
-                let lid = l.get("@id").and_then(|o| o.as_str());
-
-                let rid = r.get("@id").and_then(|o| o.as_str());
-                lid.cmp(&rid)
-            });
+            v.sort_by_cached_key(|v| v.to_string());
         }
 
         Ok(v)
+    }
+
+    pub async fn compact_stable_order(self) -> Result<Value, CompactionError> {
+        self.compact().await
     }
 }
 pub mod from_json_ld;

--- a/crates/common/src/prov/model/proptest.rs
+++ b/crates/common/src/prov/model/proptest.rs
@@ -13,12 +13,10 @@ use crate::{
     },
 };
 
-use super::{
-    ActivityUses, ActsOnBehalfOf, CompactedJson, EntityDerive, EntityHasEvidence, StartActivity,
-};
+use super::{ActivityUses, ActsOnBehalfOf, EntityDerive, EntityHasEvidence, StartActivity};
 
 prop_compose! {
-    fn an_external_id()(external_id in ".*") -> ExternalId {
+    fn an_external_id()(external_id in "[A-Za-z]") -> ExternalId {
         ExternalId::from(external_id)
     }
 }
@@ -61,7 +59,7 @@ prop_compose! {
 
 // Choose from a limited selection of namespaces so that we get multiple references
 prop_compose! {
-    fn namespace()(namespaces in prop::collection::vec(a_namespace(), 2), index in (0..2usize)) -> NamespaceId {
+    fn namespace()(namespaces in prop::collection::vec(a_namespace(), 1), index in (0..1usize)) -> NamespaceId {
         namespaces.get(index).unwrap().to_owned()
     }
 }
@@ -356,7 +354,7 @@ fn operation_seq() -> impl Strategy<Value = Vec<ChronicleOperation>> {
     proptest::collection::vec(transaction(), 1..50)
 }
 
-fn compact_json(prov: &ProvModel) -> CompactedJson {
+fn compact_json(prov: &ProvModel) -> serde_json::Value {
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
@@ -685,11 +683,17 @@ proptest! {
         // Test that serialisation to and from JSON-LD is symmetric
         let lhs_json_expanded = prov.to_json().0;
 
-        let lhs_json = compact_json(&prov).0;
+        let lhs_json = compact_json(&prov);
 
         let serialized_prov = prov_from_json_ld(lhs_json.clone());
 
         prop_assert_eq!(&prov, &serialized_prov, "Prov reserialisation compact: \n{} expanded \n {}",
             serde_json::to_string_pretty(&lhs_json).unwrap(), serde_json::to_string_pretty(&lhs_json_expanded).unwrap());
+
+                    // Test that serialisation to JSON-LD is deterministic
+        for _ in 0..10 {
+            let lhs_json_2 = compact_json(&prov).clone();
+            prop_assert_eq!( lhs_json.clone().to_string(), lhs_json_2.to_string());
+        }
     }
 }

--- a/crates/common/src/prov/operations.rs
+++ b/crates/common/src/prov/operations.rs
@@ -17,7 +17,19 @@ use super::{
 };
 
 #[derive(
-    QueryId, SqlType, AsExpression, Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize,
+    QueryId,
+    SqlType,
+    AsExpression,
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    Hash,
+    Ord,
+    PartialOrd,
+    Serialize,
+    Deserialize,
 )]
 #[diesel(sql_type = Integer)]
 #[repr(i32)]

--- a/crates/sawtooth-tp/src/tp.rs
+++ b/crates/sawtooth-tp/src/tp.rs
@@ -251,12 +251,10 @@ impl TP for ChronicleTransactionHandler {
             .map_err(|e| ApplyError::InternalError(ProcessorError::SerdeJson(e).to_string()))?;
 
         // Set up Context for OPA rule check
-        let operation = tx
-            .to_json()
-            .compact()
-            .await
-            .map_err(|e| ApplyError::InternalError(ProcessorError::Compaction(e).to_string()))?
-            .0;
+        let operation =
+            tx.to_json().compact().await.map_err(|e| {
+                ApplyError::InternalError(ProcessorError::Compaction(e).to_string())
+            })?;
 
         // Get the dependencies
         let deps = tx


### PR DESCRIPTION
Picks out additional sleep coverage, as well as adding some itself, and determinism support from [PR 367](https://github.com/btpworks/chronicle/pull/367).  

# PR Checklist

## Please complete this checklist after opening your PR

* [ ] I have updated documentation as necessary
* [ ] I have updated helm chart(s) if needed
* [ ] I have added tests if needed
* [ ] All new and existing tests are passing
* [ ] Any breaking changes are clearly flagged and documented
* [ ] I’ve included a link to any relevant ticket(s)
