### PR TITLE
do not tolerate failure response from userinfo endpoint

### DIFF
--- a/crates/api/src/chronicle_graphql/authorization.rs
+++ b/crates/api/src/chronicle_graphql/authorization.rs
@@ -144,14 +144,14 @@ impl TokenChecker {
                             ),
                         })
                     }
-                } else if error.is_some() {
-                    tracing::trace!("first error before UserInfo was {error:?}");
+                } else {
+                    if error.is_some() {
+                        tracing::trace!("first error before UserInfo was {error:?}");
+                    }
                     error = Some(Error::UserInfoResponse {
                         server: userinfo_uri.clone(),
                         status: response.status(),
                     });
-                } else {
-                    cache.cache_set(token.to_string(), Map::new());
                 }
             }
         }


### PR DESCRIPTION
Fixes CHRON-460 to match https://docs.btp.works/chronicle/oidc-opa-flow/.

Raises the worrying question of why it was as it was.

# PR Checklist

## Please complete this checklist after opening your PR

* [x] I have updated documentation as necessary
* [x] I have updated helm chart(s) if needed
* [x] I have added tests if needed
* [x] All new and existing tests are passing
* [x] Any breaking changes are clearly flagged and documented
* [x] I’ve included a link to any relevant ticket(s)
