### PR TITLE
WIP: health/ endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -736,6 +736,7 @@ dependencies = [
  "insta",
  "iref",
  "jsonschema",
+ "metrics-exporter-prometheus",
  "opa",
  "opa-tp-protocol",
  "opentelemetry",

--- a/charts/chronicle/templates/statefulset.yaml
+++ b/charts/chronicle/templates/statefulset.yaml
@@ -123,8 +123,9 @@ spec:
                 {{- end }}
                 serve-api \
                   --interface 0.0.0.0:{{ .Values.port }} \
-                  {{- if .Values.healthCheck.enabled }}
-                  --liveness-check {{ .Values.healthCheck.interval }} \
+                  {{- if .Values.healthMetrics.enabled }}
+                  --enable-health-metrics \
+                  --health-metrics-interval {{ .Values.healthMetrics.interval }} \
                   {{- end }}
                   {{- if .Values.auth.required }}
                   --require-auth \

--- a/charts/chronicle/values.yaml
+++ b/charts/chronicle/values.yaml
@@ -41,11 +41,11 @@ extraVolumes: []
 ## @md | `extraVolumeMounts` | a list of additional volume mounts to add to chronicle | [] |
 extraVolumeMounts: []
 
-healthCheck:
-  ## @md | `healthCheck.enabled` | if true enable the liveness depth charge check | false |
-  enabled: false
-  ## @md | `healthCheck.interval` | the interval between health checks | "1800" |
-  interval:
+healthMetrics:
+  ## @md | `healthMetrics.enabled` | if true enable the liveness depth charge check | true |
+  enabled: true
+  ## @md | `healthMetrics.interval` | the interval between depth charge transactions | 1800 |
+  interval: 1800
 
 image:
   ## @md | `image.repository` | the repository of the image | blockchaintp/chronicle |

--- a/crates/api/src/chronicle_graphql/health.rs
+++ b/crates/api/src/chronicle_graphql/health.rs
@@ -1,0 +1,19 @@
+use metrics_exporter_prometheus::PrometheusHandle;
+
+#[derive(Clone)]
+pub struct Metrics(PrometheusHandle);
+
+impl Metrics {
+    pub fn new(handle: PrometheusHandle) -> Self {
+        Self(handle)
+    }
+}
+
+#[poem::async_trait]
+impl poem::Endpoint for Metrics {
+    type Output = poem::Response;
+
+    async fn call(&self, _req: poem::Request) -> poem::Result<Self::Output> {
+        Ok(self.0.render().into())
+    }
+}

--- a/crates/api/src/chronicle_graphql/health.rs
+++ b/crates/api/src/chronicle_graphql/health.rs
@@ -1,19 +1,85 @@
 use metrics_exporter_prometheus::PrometheusHandle;
 
-#[derive(Clone)]
-pub struct Metrics(PrometheusHandle);
+use crate::ApiError;
 
-impl Metrics {
-    pub fn new(handle: PrometheusHandle) -> Self {
-        Self(handle)
-    }
+#[derive(Clone)]
+pub enum Health {
+    HealthEndpoint(PrometheusHandle),
+    MetricsEndpoint(PrometheusHandle),
 }
 
 #[poem::async_trait]
-impl poem::Endpoint for Metrics {
+impl poem::Endpoint for Health {
     type Output = poem::Response;
 
     async fn call(&self, _req: poem::Request) -> poem::Result<Self::Output> {
-        Ok(self.0.render().into())
+        match self {
+            Health::HealthEndpoint(handle) => {
+                let metrics = handle.render().to_string();
+
+                let latest_round_trip_key = "latest_depth_charge_round_trip";
+                let latest = match extract_latest_roundtrip(&metrics, latest_round_trip_key) {
+                    Ok(value) => match value.parse::<f64>() {
+                        Ok(value) => value,
+                        Err(err) => return Ok(err.to_string().into()),
+                    },
+                    Err(err) => return Ok(err.to_string().into()),
+                };
+
+                let quantile = "0.999";
+                let metric = match extract_value_for_quantile(&metrics, quantile) {
+                    Ok(value) => match value.parse::<f64>() {
+                        Ok(value) => value,
+                        Err(err) => return Ok(err.to_string().into()),
+                    },
+                    Err(err) => return Ok(err.to_string().into()),
+                };
+
+                if latest < metric * 2.0 {
+                    Ok(poem::Response::builder()
+                        .status(poem::http::StatusCode::OK)
+                        .body(format!(
+                            "API is healthy! Latest round trip: {}ms, {}th percentile: {}ms",
+                            latest, quantile, metric
+                        )))
+                } else {
+                    Ok(poem::Response::builder()
+                        .status(poem::http::StatusCode::INTERNAL_SERVER_ERROR)
+                        .body(format!(
+                            "Health check failed! Latest round trip: {}ms, {}th percentile: {}ms",
+                            latest, quantile, metric
+                        )))
+                }
+            }
+            Health::MetricsEndpoint(handle) => Ok(handle.render().into()),
+        }
     }
+}
+
+fn extract_latest_roundtrip(metrics: &str, key: &str) -> Result<String, ApiError> {
+    for line in metrics.lines() {
+        if line.starts_with(key) {
+            let value = line.trim_start_matches(key).trim().to_string();
+
+            return Ok(value);
+        }
+    }
+
+    Err(ApiError::MetricsLatestRoundTripNotFound)
+}
+
+fn extract_value_for_quantile(metrics: &str, quantile: &str) -> Result<String, ApiError> {
+    let target_key = format!("depth_charge_round_trip{{quantile=\"{}\"}}", quantile);
+
+    for line in metrics.lines() {
+        if line.starts_with(&target_key) {
+            let value = line.trim_start_matches(&target_key).trim().to_string();
+
+            return Ok(value);
+        }
+    }
+
+    Err(ApiError::MetricsQuantileNotFound {
+        quantile: quantile.to_string(),
+    })
 }

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -40,7 +40,6 @@ use common::{
 };
 
 use metrics::histogram;
-use metrics_exporter_prometheus::PrometheusBuilder;
 pub use persistence::StoreError;
 use persistence::{Store, MIGRATIONS};
 use r2d2::Pool;
@@ -67,26 +66,8 @@ use uuid::Uuid;
 
 #[derive(Error, Debug)]
 pub enum ApiError {
-    #[error("Storage: {0:?}")]
-    Store(#[from] persistence::StoreError),
-
-    #[error("Transaction failed: {0}")]
-    Transaction(#[from] diesel::result::Error),
-
-    #[error("Invalid IRI: {0}")]
-    Iri(#[from] iref::Error),
-
-    #[error("JSON-LD processing: {0}")]
-    JsonLD(String),
-
-    #[error("Ledger error: {0}")]
-    Ledger(#[from] SubmissionError),
-
-    #[error("Signing: {0}")]
-    Signing(#[from] SignerError),
-
-    #[error("No agent is currently in use, please call agent use or supply an agent in your call")]
-    NoCurrentAgent,
+    #[error("Invalid socket address: {0}")]
+    AddressParse(#[from] AddrParseError),
 
     #[error("Api shut down before reply")]
     ApiShutdownRx,
@@ -94,38 +75,56 @@ pub enum ApiError {
     #[error("Api shut down before send: {0}")]
     ApiShutdownTx(#[from] SendError<ApiSendWithReply>),
 
-    #[error("Ledger shut down before send: {0}")]
-    LedgerShutdownTx(#[from] SendError<LedgerSendWithReply>),
-
-    #[error("Invalid socket address: {0}")]
-    AddressParse(#[from] AddrParseError),
-
     #[error("Connection pool: {0}")]
     ConnectionPool(#[from] r2d2::Error),
-
-    #[error("IO error: {0}")]
-    InputOutput(#[from] std::io::Error),
-
-    #[error("Blocking thread pool: {0}")]
-    Join(#[from] JoinError),
-
-    #[error("State update subscription: {0}")]
-    Subscription(#[from] SubscriptionError),
-
-    #[error("No appropriate activity to end")]
-    NotCurrentActivity,
 
     #[error("Contradiction: {0}")]
     Contradiction(#[from] Contradiction),
 
-    #[error("Processor: {0}")]
-    ProcessorError(#[from] ProcessorError),
-
     #[error("Identity: {0}")]
     IdentityError(#[from] IdentityError),
 
+    #[error("IO error: {0}")]
+    InputOutput(#[from] std::io::Error),
+
+    #[error("Invalid IRI: {0}")]
+    Iri(#[from] iref::Error),
+
+    #[error("JSON-LD processing: {0}")]
+    JsonLD(String),
+
+    #[error("Blocking thread pool: {0}")]
+    Join(#[from] JoinError),
+
+    #[error("Ledger error: {0}")]
+    Ledger(#[from] SubmissionError),
+
+    #[error("Ledger shut down before send: {0}")]
+    LedgerShutdownTx(#[from] SendError<LedgerSendWithReply>),
+
+    #[error("No agent is currently in use, please call agent use or supply an agent in your call")]
+    NoCurrentAgent,
+
+    #[error("No appropriate activity to end")]
+    NotCurrentActivity,
+
+    #[error("Processor: {0}")]
+    ProcessorError(#[from] ProcessorError),
+
     #[error("Sawtooth communication error: {0}")]
     SawtoothCommunicationError(#[from] SawtoothCommunicationError),
+
+    #[error("Signing: {0}")]
+    Signing(#[from] SignerError),
+
+    #[error("Storage: {0:?}")]
+    Store(#[from] persistence::StoreError),
+
+    #[error("State update subscription: {0}")]
+    Subscription(#[from] SubscriptionError),
+
+    #[error("Transaction failed: {0}")]
+    Transaction(#[from] diesel::result::Error),
 }
 
 /// Ugly but we need this until ! is stable, see <https://github.com/rust-lang/rust/issues/64715>
@@ -254,26 +253,6 @@ impl ApiDispatch {
     }
 }
 
-fn install_prometheus_metrics_exporter() {
-    let metrics_endpoint = "127.0.0.1:9000";
-    let metrics_listen_socket = match metrics_endpoint.parse::<std::net::SocketAddrV4>() {
-        Ok(addr) => addr,
-        Err(e) => {
-            error!("Unable to parse metrics listen socket address: {e:?}");
-            return;
-        }
-    };
-
-    if let Err(e) = PrometheusBuilder::new()
-        .with_http_listener(metrics_listen_socket)
-        .install()
-    {
-        error!("Prometheus exporter installation for liveness check metrics failed: {e:?}");
-    } else {
-        debug!("Liveness check metrics Prometheus exporter installed with endpoint on {metrics_endpoint}/metrics");
-    }
-}
-
 impl<U, LEDGER> Api<U, LEDGER>
 where
     U: UuidGen + Send + Sync + Clone + std::fmt::Debug + 'static,
@@ -292,7 +271,7 @@ where
         uuidgen: U,
         namespace_bindings: HashMap<String, Uuid>,
         policy_name: Option<String>,
-        liveness_check_interval: Option<u64>,
+        depth_charge_interval: Option<u64>,
     ) -> Result<ApiDispatch, ApiError> {
         let (commit_tx, mut commit_rx) = mpsc::channel::<ApiSendWithReply>(10);
 
@@ -420,15 +399,12 @@ where
             }
         });
 
-        if let Some(interval) = liveness_check_interval {
-            debug!("Starting liveness depth charge task");
+        if let Some(interval) = depth_charge_interval {
+            debug!("Starting health metrics depth charge task");
 
             let depth_charge_api = dispatch.clone();
 
             tokio::task::spawn(async move {
-                // Configure and install Prometheus exporter
-                install_prometheus_metrics_exporter();
-
                 loop {
                     tokio::time::sleep(std::time::Duration::from_secs(interval)).await;
                     let api = depth_charge_api.clone();
@@ -1739,8 +1715,6 @@ mod test {
         let database = TemporaryDatabase::default();
         let pool = database.connection_pool().unwrap();
 
-        let liveness_check_interval = None;
-
         let dispatch = Api::new(
             pool,
             embed_tp.ledger.clone(),
@@ -1748,7 +1722,7 @@ mod test {
             SameUuid,
             HashMap::default(),
             Some("allow_transactions".into()),
-            liveness_check_interval,
+            None,
         )
         .await
         .unwrap();

--- a/crates/chronicle-domain-test/src/test.rs
+++ b/crates/chronicle-domain-test/src/test.rs
@@ -183,7 +183,6 @@ mod test {
 
         let database = TemporaryDatabase::default();
         let pool = database.connection_pool().unwrap();
-        let liveness_check_interval = None;
 
         let dispatch = Api::new(
             pool.clone(),
@@ -192,7 +191,7 @@ mod test {
             SameUuid,
             HashMap::default(),
             None,
-            liveness_check_interval,
+            None,
         )
         .await
         .unwrap();

--- a/crates/chronicle/Cargo.toml
+++ b/crates/chronicle/Cargo.toml
@@ -27,6 +27,7 @@ genco                = { workspace = true }
 hex                  = { workspace = true }
 iref                 = { workspace = true }
 jsonschema           = { workspace = true }
+metrics-exporter-prometheus = { workspace = true }
 opa                  = { workspace = true }
 opentelemetry        = { workspace = true }
 percent-encoding     = { workspace = true }

--- a/crates/chronicle/src/bootstrap/cli.rs
+++ b/crates/chronicle/src/bootstrap/cli.rs
@@ -44,6 +44,9 @@ pub enum CliError {
     #[error("Invalid configuration file: {0}")]
     ConfigInvalid(#[from] toml::de::Error),
 
+    #[error("Health endpoint is enabled but the metrics on which it depends are not. Please enable health metrics or disable the health endpoint.")]
+    HealthEndpointConfigError,
+
     #[error("Metrics endpoint is enabled but the metrics on which it depends are not. Please enable health metrics or disable the metrics endpoint.")]
     MetricsEndpointConfigError,
 
@@ -984,8 +987,8 @@ impl SubCommand for CliModel {
                         .long("offer-endpoints")
                         .takes_value(true)
                         .min_values(1)
-                        .value_parser(["data", "graphql", "metrics"])
-                        .default_values(&["data", "graphql", "metrics"])
+                        .value_parser(["data", "graphql", "health", "metrics"])
+                        .default_values(&["data", "graphql", "health", "metrics"])
                         .help("which API endpoints to offer")
                     ).arg(
                         Arg::new("enable-health-metrics")

--- a/crates/chronicle/src/bootstrap/mod.rs
+++ b/crates/chronicle/src/bootstrap/mod.rs
@@ -444,6 +444,9 @@ where
             .map(String::clone)
             .collect();
 
+        if endpoints.contains(&"health".to_string()) && health_metrics_handle.is_none() {
+            return Err(CliError::HealthEndpointConfigError);
+        }
         if endpoints.contains(&"metrics".to_string()) && health_metrics_handle.is_none() {
             return Err(CliError::MetricsEndpointConfigError);
         }
@@ -464,6 +467,7 @@ where
             Endpoints::new(
                 endpoints.contains(&"graphql".to_string()),
                 endpoints.contains(&"data".to_string()),
+                endpoints.contains(&"health".to_string()),
                 endpoints.contains(&"metrics".to_string()),
             ),
             health_metrics_handle,

--- a/crates/chronicle/src/bootstrap/mod.rs
+++ b/crates/chronicle/src/bootstrap/mod.rs
@@ -5,7 +5,9 @@ mod opa;
 #[cfg(feature = "inmem")]
 use api::inmem::EmbeddedChronicleTp;
 use api::{
-    chronicle_graphql::{ChronicleApiServer, ChronicleGraphQl, JwksUri, SecurityConf, UserInfoUri},
+    chronicle_graphql::{
+        ChronicleApiServer, ChronicleGraphQl, Endpoints, JwksUri, SecurityConf, UserInfoUri,
+    },
     Api, ApiDispatch, ApiError, StoreError, UuidGen,
 };
 use async_graphql::{async_trait, ObjectType};
@@ -27,8 +29,9 @@ use common::{
     prov::{operations::ChronicleOperation, to_json_ld::ToJson, ExpandedJson, NamespaceId},
     signing::DirectoryStoredKeys,
 };
+use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
 use std::io::IsTerminal;
-use tracing::{debug, error, info, instrument, warn};
+use tracing::{debug, error, info, instrument};
 use user_error::UFE;
 
 use config::*;
@@ -143,8 +146,8 @@ pub async fn api_server<Query, Mutation>(
     gql: ChronicleGraphQl<Query, Mutation>,
     interface: Option<Vec<SocketAddr>>,
     security_conf: SecurityConf,
-    serve_graphql: bool,
-    serve_data: bool,
+    endpoints: Endpoints,
+    metrics_handle: Option<PrometheusHandle>,
 ) -> Result<(), ApiError>
 where
     Query: ObjectType + Copy,
@@ -156,8 +159,8 @@ where
             api.clone(),
             addresses,
             security_conf,
-            serve_graphql,
-            serve_data,
+            endpoints,
+            metrics_handle,
         )
         .await?
     }
@@ -171,7 +174,7 @@ pub async fn api(
     options: &ArgMatches,
     config: &Config,
     policy_name: Option<String>,
-    liveness_check_interval: Option<u64>,
+    depth_charge_interval: Option<u64>,
 ) -> Result<ApiDispatch, CliError> {
     let ledger = ledger(config, options)?;
 
@@ -182,7 +185,7 @@ pub async fn api(
         UniqueUuid,
         config.namespace_bindings.clone(),
         policy_name,
-        liveness_check_interval,
+        depth_charge_interval,
     )
     .await?)
 }
@@ -193,7 +196,7 @@ pub async fn api(
     _options: &ArgMatches,
     config: &Config,
     remote_opa: Option<String>,
-    liveness_check_interval: Option<u64>,
+    depth_charge_interval: Option<u64>,
 ) -> Result<api::ApiDispatch, ApiError> {
     let embedded_tp = in_mem_ledger(config, _options)?;
 
@@ -204,7 +207,7 @@ pub async fn api(
         UniqueUuid,
         config.namespace_bindings.clone(),
         remote_opa,
-        liveness_check_interval,
+        depth_charge_interval,
     )
     .await
 }
@@ -319,26 +322,44 @@ async fn configure_opa(config: &Config, options: &ArgMatches) -> Result<Configur
     }
 }
 
-/// If `--liveness-check` is set, we use either the interval in seconds provided or the default of 1800.
-/// Otherwise, we use `None` to disable the depth charge.
-fn configure_depth_charge(matches: &ArgMatches) -> Option<u64> {
+/// If health metrics are enabled, we use either the interval in seconds provided or the default of 1800.
+/// Otherwise, we return `None` for the handle **and** for the interval value in order to disable the health
+/// metrics depth charge transactions as well as the `/metrics` endpoint.
+fn configure_health_metrics(
+    matches: &ArgMatches,
+) -> Result<(Option<PrometheusHandle>, Option<u64>), CliError> {
     if let Some(serve_api_matches) = matches.subcommand_matches("serve-api") {
-        if let Some(interval) = serve_api_matches.value_of("liveness-check") {
-            let parsed_interval = interval.parse::<u64>().unwrap_or_else(|e| {
-                warn!("Failed to parse '--liveness-check' value: {e}");
-                1800
-            });
+        if serve_api_matches.is_present("enable-health-metrics") {
+            debug!("Health metrics enabled");
 
-            if parsed_interval == 1800 {
-                debug!("Using default liveness health check interval value: 1800");
-            } else {
-                debug!("Using custom liveness health check interval value: {parsed_interval}");
+            let interval = serve_api_matches
+                .value_of("health-metrics-interval")
+                .unwrap_or("1800")
+                .parse::<u64>()?;
+
+            debug!(
+                "Using {} health metrics interval value: {}",
+                if interval == 1800 {
+                    "default"
+                } else {
+                    "custom"
+                },
+                interval
+            );
+            let handle = PrometheusBuilder::new().install_recorder()?;
+
+            debug!("Health metrics Prometheus exporter installed successfully");
+            return Ok((Some(handle), Some(interval)));
+        } else {
+            debug!("Health metrics disabled");
+            if serve_api_matches.is_present("health-metrics-interval") {
+                debug!(
+                    "Health metrics interval value provided but health metrics disabled, ignoring"
+                );
             }
-            return Some(parsed_interval);
         }
     }
-    debug!("Liveness health check disabled");
-    None
+    Ok((None, None))
 }
 
 #[instrument(skip(gql, cli))]
@@ -359,14 +380,14 @@ where
 
     let opa = configure_opa(&config, &matches).await?;
 
-    let liveness_check_interval = configure_depth_charge(&matches);
+    let (health_metrics_handle, depth_charge_interval) = configure_health_metrics(&matches)?;
 
     let api = api(
         &pool,
         &matches,
         &config,
         opa.remote_settings(),
-        liveness_check_interval,
+        depth_charge_interval,
     )
     .await?;
     let ret_api = api.clone();
@@ -423,6 +444,10 @@ where
             .map(String::clone)
             .collect();
 
+        if endpoints.contains(&"metrics".to_string()) && health_metrics_handle.is_none() {
+            return Err(CliError::MetricsEndpointConfigError);
+        }
+
         api_server(
             &api,
             &pool,
@@ -436,8 +461,12 @@ where
                 allow_anonymous,
                 opa.context().clone(),
             ),
-            endpoints.contains(&"graphql".to_string()),
-            endpoints.contains(&"data".to_string()),
+            Endpoints::new(
+                endpoints.contains(&"graphql".to_string()),
+                endpoints.contains(&"data".to_string()),
+                endpoints.contains(&"metrics".to_string()),
+            ),
+            health_metrics_handle,
         )
         .await?;
 
@@ -847,8 +876,6 @@ pub mod test {
         let database = TemporaryDatabase::default();
         let pool = database.connection_pool().unwrap();
 
-        let liveness_check_interval = None;
-
         let dispatch = Api::new(
             pool,
             embedded_tp.ledger.clone(),
@@ -856,7 +883,7 @@ pub mod test {
             SameUuid,
             HashMap::default(),
             Some("allow_transactions".to_owned()),
-            liveness_check_interval,
+            None,
         )
         .await
         .unwrap();

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -22,6 +22,7 @@ Options are:
 
 - `data` for IRIs encoded in URIs (at `/context` and `/data`)
 - `graphql` for GraphQL requests (at `/` and `/ws`)
+- `metrics` for API health check metrics (at `/metrics`)
 
 ##### Authentication
 
@@ -64,22 +65,25 @@ typically suffixed `/userinfo`. If this option is supplied then the endpoint
 must supply any additional claims in response to the same `Authorization:`
 header that was provided by a user in making their API request.
 
-##### Liveness Health Check
+##### Health Metrics
 
-###### `--liveness-check <interval>`
+For more details, see our documentation on
+[Health Metrics](./health-checks-and-testing#health-metrics) in
+our section on [Health Checks and Testing](./health-checks-and-testing).
 
-Enables liveness depth charge checks and specifies the interval in seconds.
-
-For more details, see our documentation on the
-[Liveness Health Check](./health-checks-and-testing.md#liveness-health-check).
-
-The `interval` argument specifies the time duration in seconds between
-consecutive checks and is set to 1800 seconds (or 30 minutes) by default.
-
-By default, liveness checks are disabled.
+Health metrics are enabled by default.
 
 For configuration via Helm Chart, see our documentation on
-[Helm Options and the Liveness Health Check](./helm-options.md#liveness-health-check).
+[Helm Options and the Liveness Health Check](./helm-options.md#health-metrics).
+
+###### `--enable-health-metrics`
+
+Enables health metrics based on recurring depth charge transactions.
+
+###### `--health-metrics-interval <interval>`
+
+Specifies the time duration in seconds between health metrics depth charge
+transactions, set to 1800 seconds (or 30 minutes) by default.
 
 ##### Deprecated Options
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -22,6 +22,7 @@ Options are:
 
 - `data` for IRIs encoded in URIs (at `/context` and `/data`)
 - `graphql` for GraphQL requests (at `/` and `/ws`)
+- `health` for API health check (at `/health`)
 - `metrics` for API health check metrics (at `/metrics`)
 
 ##### Authentication

--- a/docs/health-checks-and-testing.md
+++ b/docs/health-checks-and-testing.md
@@ -2,31 +2,31 @@
 
 ## Helm Testing
 
-See [Helm Testing](./helm_testing.md).
+See [Helm Testing](./helm_testing).
 
-## Liveness Health Check
+## Health Metrics
 
-When the `--liveness-check` option is used, Chronicle enables liveness
+When the `--enable-health-metrics` option is used, Chronicle enables liveness
 depth charge checks to ensure system availability. It starts a background
 task that periodically executes a transaction to Chronicle's
-[System Namespace](./namespaces.md#chronicle-system). At each interval,
+[System Namespace](./namespaces#chronicle-system). At each interval,
 the depth charge operation is executed and timed. If the transaction is
 successfully committed, the elapsed time of the round trip is calculated
 and made available as a histogram metric.
 
-The liveness check task installs a [Prometheus](https://prometheus.io/)
+The health metrics task installs a [Prometheus](https://prometheus.io/)
 exporter to record metrics. If the transaction is successfully committed,
 the elapsed time of the round trip is calculated and recorded as a
 histogram metric in the Prometheus exporter. The collected data can be
-scraped from the exposed endpoint for analysis and monitoring purposes at
-`127.0.0.1:9000/metrics` or simply `127.0.0.1:9000`.
+scraped from the exposed endpoint for analysis and monitoring purposes, by
+default at `127.0.0.1:9982/metrics`.
 
 ### CLI
 
-See the section in our CLI docs on the
-[Liveness Health Check](./cli.md#liveness-health-check).
+See the section in our CLI docs on
+[Health Metrics](./cli#health-metrics).
 
 ### Helm
 
-See our Helm Options documentation on the
-[Liveness Health Check](./helm-options.md#liveness-health-check).
+See our Helm Options documentation on
+[Health Metrics](./helm-options#health-metrics).

--- a/docs/helm-options.md
+++ b/docs/helm-options.md
@@ -1,6 +1,6 @@
 # Other Chronicle Helm Options
 
-## Liveness Health Check
+## Health Metrics
 
 Chronicle can enable liveness depth charge checks to ensure system availability.
 
@@ -8,11 +8,13 @@ The following options in the Chronicle Helm Chart `values.yaml` file can be used
 to enable and configure the health check:
 
 ```yaml
-healthCheck:
+healthMetrics:
   enabled: true
   # Interval in seconds
   interval: 1800
 ```
 
-For more on how the [Liveness Health Check](#liveness-health-check) works, see
-[Health Checks and Testing](./health-checks-and-testing.md#liveness-health-check).
+If enabled, these metrics will be available by default at `0.0.0.0:9982/metrics`.
+
+For more on how the [Health Metrics](#health-metrics) work, see
+[Health Checks and Testing](./health-checks-and-testing#health-metrics).


### PR DESCRIPTION
# WIP: [CHRON-450](https://blockchaintp.atlassian.net/browse/CHRON-450)

- [x] Wraps our Prometheus metrics listener as another `poem` `Route::at` alongside other `--offer-endpoints` (currently `data` and `graphql`) so it listens alongside them on a `/metrics` path off `API_LISTEN_SOCKET` - takes care of [CHRON-450](https://blockchaintp.atlassian.net/browse/CHRON-450)
- [x] Adds `health/` endpoint that check current metrics from depth charge and returns `500`
- [ ] Improve response by including JSON with current round trip time
- [ ] Review the need to parse `String` from rendered metrics
- [ ] Figure out defaults - coupling of health endpoint with health metrics and the latter's configuration 
- [ ] Update Helm Chart

## PR Checklist

### Please complete this checklist after opening your PR

* [ ] I have updated documentation as necessary
* [ ] I have updated helm chart(s) if needed
* [ ] I have added tests if needed
* [ ] All new and existing tests are passing
* [ ] Any breaking changes are clearly flagged and documented
* [ ] I’ve included a link to any relevant ticket(s)


[CHRON-450]: https://blockchaintp.atlassian.net/browse/CHRON-450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ