### PR TITLE
WIP/Experiment: perftest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,7 +414,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -425,13 +425,13 @@ checksum = "ecc7ab41815b3c653ccd2978ec3255c81349336702dfdf62ee6f7069b12a3aae"
 
 [[package]]
 name = "async-trait"
-version = "0.1.71"
+version = "0.1.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a564d521dd56509c4c47480d00b80ee55f7e385ae48db5744c67ad50c92d2ebf"
+checksum = "cc6dde6e4ed435a4c1ee4e73592f5ba9da2151af10076cc04858746af9352d09"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -602,7 +602,7 @@ dependencies = [
  "async-lock",
  "async-task",
  "atomic-waker",
- "fastrand",
+ "fastrand 1.9.0",
  "futures-lite",
  "log",
 ]
@@ -701,9 +701,12 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.0.79"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+checksum = "6c6b2562119bf28c3439f7f02db99faf0aa1a8cdfe5772a2ee155d32227239f0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "cfg-if"
@@ -855,6 +858,7 @@ dependencies = [
  "console-subscriber",
  "tracing",
  "tracing-elastic-apm",
+ "tracing-flame",
  "tracing-log",
  "tracing-subscriber",
  "url",
@@ -922,9 +926,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.3.15"
+version = "4.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f644d0dac522c8b05ddc39aaaccc5b136d5dc4ff216610c5641e3be5becf56c"
+checksum = "5fd304a20bff958a57f04c4e96a2e7594cc4490a0e809cbd48bb6437edaa452d"
 dependencies = [
  "clap_builder",
  "clap_derive 4.3.12",
@@ -933,9 +937,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.3.15"
+version = "4.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af410122b9778e024f9e0fb35682cc09cc3f85cad5e8d3ba8f47a9702df6e73d"
+checksum = "01c6a3f08f1fe5662a35cfe393aec09c4df95f60ee93b7556505260f75eee9e1"
 dependencies = [
  "anstream",
  "anstyle",
@@ -974,7 +978,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -1332,7 +1336,7 @@ dependencies = [
  "anes",
  "cast",
  "ciborium",
- "clap 4.3.15",
+ "clap 4.3.19",
  "criterion-plot",
  "futures",
  "is-terminal",
@@ -1568,6 +1572,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7684a49fb1af197853ef7b2ee694bc1f5b4179556f1e5710e1760c5db6f5e929"
+
+[[package]]
 name = "derivative"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1603,7 +1613,7 @@ dependencies = [
  "diesel_table_macro_syntax",
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -1623,7 +1633,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc5557efc453706fed5e4fa85006fe9817c224c3f480a34c7e5959fd700921c5"
 dependencies = [
- "syn 2.0.26",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -1691,9 +1701,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "elliptic-curve"
@@ -1740,9 +1750,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+checksum = "6b30f669a7961ef1631673d2766cc92f52d64f7ef354d4fe0ddfd30ed52f0f4f"
 dependencies = [
  "errno-dragonfly",
  "libc",
@@ -1804,6 +1814,12 @@ checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
 dependencies = [
  "instant",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
 
 [[package]]
 name = "ff"
@@ -1937,7 +1953,7 @@ version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
 dependencies = [
- "fastrand",
+ "fastrand 1.9.0",
  "futures-core",
  "futures-io",
  "memchr",
@@ -1954,7 +1970,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -2084,9 +2100,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "globset"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1391ab1f92ffcc08911957149833e682aa3fe252b9f45f966d2ef972274c97df"
+checksum = "aca8bbd8e0707c1887a8bbb7e6b40e228f251ff5d62c8220a4a7a53c73aff006"
 dependencies = [
  "aho-corasick",
  "bstr",
@@ -2115,7 +2131,7 @@ dependencies = [
  "http",
  "rand 0.8.5",
  "serde_json",
- "tungstenite 0.19.0",
+ "tungstenite 0.19.0 (git+https://github.com/snapview/tungstenite-rs?rev=8901dcc)",
 ]
 
 [[package]]
@@ -2518,7 +2534,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi 0.3.2",
- "rustix 0.38.4",
+ "rustix 0.38.6",
  "windows-sys 0.48.0",
 ]
 
@@ -2736,7 +2752,7 @@ dependencies = [
  "anyhow",
  "base64 0.21.2",
  "bytecount",
- "clap 4.3.15",
+ "clap 4.3.19",
  "fancy-regex",
  "fraction",
  "getrandom 0.2.10",
@@ -2751,7 +2767,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "time 0.3.23",
+ "time 0.3.25",
  "url",
  "uuid 1.4.1",
 ]
@@ -2907,9 +2923,9 @@ checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.3"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09fc20d2ca12cb9f044c93e3bd6d32d523e6e2ec3db4f7b2939cd99026ecd3f0"
+checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
 
 [[package]]
 name = "lock_api"
@@ -2993,9 +3009,9 @@ dependencies = [
 
 [[package]]
 name = "matchit"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b87248edafb776e59e6ee64a79086f65890d3510f2c656c000bf2a7e8a0aea40"
+checksum = "67827e6ea8ee8a7c4a72227ef4fc08957040acffdb5f122733b24fa12daff41b"
 
 [[package]]
 name = "memchr"
@@ -3078,7 +3094,7 @@ checksum = "ddece26afd34c31585c74a4db0630c376df271c285d682d1e55012197830b6df"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -3333,9 +3349,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
 dependencies = [
  "autocfg",
  "libm",
@@ -3491,7 +3507,7 @@ dependencies = [
  "async-stl-client",
  "async-trait",
  "chronicle-telemetry",
- "clap 4.3.15",
+ "clap 4.3.19",
  "common",
  "const_format",
  "futures",
@@ -3544,7 +3560,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -3555,9 +3571,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "111.26.0+1.1.1u"
+version = "111.27.0+1.1.1v"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efc62c9f12b22b8f5208c23a7200a442b2e5999f8bdf80233852122b5a4f6f37"
+checksum = "06e8f197c82d7511c5b014030c9b1efeda40d7d5f99d23b4ceed3524a5e63f02"
 dependencies = [
  "cc",
 ]
@@ -3735,9 +3751,9 @@ checksum = "b687ff7b5da449d39e418ad391e5e08da53ec334903ddbb921db208908fc372c"
 
 [[package]]
 name = "pest"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d2d1d55045829d65aad9d389139882ad623b33b904e7c9f1b10c5b8927298e5"
+checksum = "1acb4a4365a13f749a93f1a094a7805e5cfa0955373a9de860d962eaa3a5fe5a"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -3745,9 +3761,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f94bca7e7a599d89dea5dfa309e217e7906c3c007fb9c3299c40b10d6a315d3"
+checksum = "666d00490d4ac815001da55838c500eafb0320019bbaa44444137c48b443a853"
 dependencies = [
  "pest",
  "pest_generator",
@@ -3755,22 +3771,22 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d490fe7e8556575ff6911e45567ab95e71617f43781e5c05490dc8d75c965c"
+checksum = "68ca01446f50dbda87c1786af8770d535423fa8a53aec03b8f4e3d7eb10e0929"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.28",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2674c66ebb4b4d9036012091b537aae5878970d6999f81a265034d85b136b341"
+checksum = "56af0a30af74d0445c0bf6d9d051c979b516a1a5af790d251daee76005420a48"
 dependencies = [
  "once_cell",
  "pest",
@@ -3842,7 +3858,7 @@ checksum = "ec2e072ecce94ec471b13398d5402c188e76ac03cf74dd1a975161b23a3f6d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -3922,9 +3938,9 @@ dependencies = [
 
 [[package]]
 name = "poem"
-version = "1.3.56"
+version = "1.3.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a56df40b79ebdccf7986b337f9b0e51ac55cd5e9d21fb20b6aa7c7d49741854"
+checksum = "f0d92c532a37a9e98c0e9a0411e6852b8acccf9ec07d5e6e450b01cbf947d90b"
 dependencies = [
  "async-trait",
  "base64 0.21.2",
@@ -3956,21 +3972,21 @@ dependencies = [
 
 [[package]]
 name = "poem-derive"
-version = "1.3.56"
+version = "1.3.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1701f977a2d650a03df42c053686ea0efdb83554f34c7b026b89383c0a1b7846"
+checksum = "f5dd58846a1f582215370384c3090c62c9ef188e9d798ffc67ea90d0a1a8a3b8"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.28",
 ]
 
 [[package]]
 name = "portable-atomic"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc55135a600d700580e406b4de0d59cb9ad25e344a3a091a97ded2622ec4ec6"
+checksum = "f32154ba0af3a075eefa1eda8bb414ee928f62303a54ea85b8d6638ff1a6ee9e"
 
 [[package]]
 name = "portpicker"
@@ -4280,9 +4296,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.31"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fe8a65d69dd0808184ebb5f836ab526bb259db23c657efa38711b1072ee47f0"
+checksum = "50f3b39ccfb720540debaa0164757101c08ecb8d326b15358ce76a62c7e85965"
 dependencies = [
  "proc-macro2",
 ]
@@ -4483,7 +4499,7 @@ checksum = "b2eae68fc220f7cf2532e4494aded17545fce192d59cd996e0fe7887f4ceb575"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.3.3",
+ "regex-automata 0.3.4",
  "regex-syntax 0.7.4",
 ]
 
@@ -4498,9 +4514,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39354c10dd07468c2e73926b23bb9c2caca74c5501e38a35da70406f1d923310"
+checksum = "b7b6d6190b7594385f61bd3911cd1be99dfddcfc365a4160cc2ab5bff4aed294"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4622,7 +4638,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rust-embed-utils",
- "syn 2.0.26",
+ "syn 2.0.28",
  "walkdir",
 ]
 
@@ -4665,22 +4681,22 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.4"
+version = "0.38.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a962918ea88d644592894bc6dc55acc6c0956488adcebbfb6e273506b7fd6e5"
+checksum = "1ee020b1716f0a80e2ace9b03441a749e402e86712f15f16fe8a8f75afac732f"
 dependencies = [
  "bitflags 2.3.3",
  "errno",
  "libc",
- "linux-raw-sys 0.4.3",
+ "linux-raw-sys 0.4.5",
  "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.21.5"
+version = "0.21.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79ea77c539259495ce8ca47f53e66ae0330a8819f67e23ac96ca02f50e7b7d36"
+checksum = "1d1feddffcfcc0b33f5c6ce9a29e341e4cd59c3f78e7ee45f4a40c038b1d6cbb"
 dependencies = [
  "log",
  "ring",
@@ -4699,9 +4715,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.1"
+version = "0.101.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f36a6828982f422756984e47912a7a51dcbc2a197aa791158f8ca61cd8204e"
+checksum = "513722fd73ad80a71f72b61009ea1b584bcfa1483ca93949c8f290298837fa59"
 dependencies = [
  "ring",
  "untrusted",
@@ -4880,9 +4896,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.9.1"
+version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc758eb7bffce5b308734e9b0c1468893cae9ff70ebf13e7090be8dcbcc83a8"
+checksum = "05b64fb303737d99b81884b2c63433e9ae28abebe5eb5045dcdd175dc2ecf4de"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
@@ -4893,9 +4909,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f51d0c0d83bec45f16480d0ce0058397a69e48fcdc52d1dc8855fb68acbd31a7"
+checksum = "e932934257d3b408ed8f30db49d85ea163bfe74961f017f405b025af298f0c7a"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -4909,29 +4925,29 @@ checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
 
 [[package]]
 name = "serde"
-version = "1.0.171"
+version = "1.0.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30e27d1e4fd7659406c492fd6cfaf2066ba8773de45ca75e855590f856dc34a9"
+checksum = "0ea67f183f058fe88a4e3ec6e2788e003840893b91bac4559cabedd00863b3ed"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.171"
+version = "1.0.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389894603bd18c46fa56231694f8d827779c0951a667087194cf9de94ed24682"
+checksum = "24e744d7782b686ab3b73267ef05697159cc0e5abbed3f47f9933165e5219036"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.28",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d03b412469450d4404fe8499a268edd7f8b79fecb074b0d812ad64ca21f4031b"
+checksum = "076066c5f1078eac5b722a31827a8832fe108bed65dfa75e233c89f8206e976c"
 dependencies = [
  "itoa",
  "ryu",
@@ -4993,9 +5009,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.24"
+version = "0.9.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd5f51e3fdb5b9cdd1577e1cb7a733474191b1aca6a72c2e50913241632c1180"
+checksum = "1a49e178e4452f45cb61d0cd8cebc1b0fafd3e41929e996cef79aa3aca91f574"
 dependencies = [
  "indexmap 2.0.0",
  "itoa",
@@ -5215,9 +5231,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.26"
+version = "2.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45c3457aacde3c65315de5031ec191ce46604304d2446e803d71ade03308d970"
+checksum = "04361975b3f5e348b2189d8dc55bc942f278b2d482a6a0365de5bdd62d351567"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5243,21 +5259,20 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.9"
+version = "0.12.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df8e77cb757a61f51b947ec4a7e3646efd825b73561db1c232a8ccb639e611a0"
+checksum = "9d0e916b1148c8e263850e1ebcbd046f333e0683c724876bb0da63ea4373dc8a"
 
 [[package]]
 name = "tempfile"
-version = "3.6.0"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31c0432476357e58790aaa47a8efb0c5138f137343f3b5f23bd36a27e3b0a6d6"
+checksum = "5486094ee78b2e5038a6382ed7645bc084dc2ec433426ca4c3cb61e2007b8998"
 dependencies = [
- "autocfg",
  "cfg-if",
- "fastrand",
+ "fastrand 2.0.0",
  "redox_syscall 0.3.5",
- "rustix 0.37.23",
+ "rustix 0.38.6",
  "windows-sys 0.48.0",
 ]
 
@@ -5301,22 +5316,22 @@ checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
-version = "1.0.43"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a35fc5b8971143ca348fa6df4f024d4d55264f3468c71ad1c2f365b0a4d58c42"
+checksum = "611040a08a0439f8248d1990b111c95baa9c704c805fa1f62104b39655fd7f90"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.43"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "463fe12d7993d3b327787537ce8dd4dfa058de32fc2b195ef3cde03dc4771e8f"
+checksum = "090198534930841fab3a5d1bb637cde49e339654e606195f8d9c76eeb081dc96"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -5342,10 +5357,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.23"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59e399c068f43a5d116fedaf73b203fa4f9c519f17e2b34f63221d3792f81446"
+checksum = "b0fdd63d58b18d663fbdf70e049f00a22c8e42be082203be7f26589213cd75ea"
 dependencies = [
+ "deranged",
  "serde",
  "time-core",
  "time-macros",
@@ -5359,9 +5375,9 @@ checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
 
 [[package]]
 name = "time-macros"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96ba15a897f3c86766b757e5ac7221554c6750054d74d5b28844fce5fb36a6c4"
+checksum = "eb71511c991639bb078fd5bf97757e03914361c48100d52878b8e52b46fb92cd"
 dependencies = [
  "time-core",
 ]
@@ -5443,7 +5459,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -5480,14 +5496,14 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54319c93411147bced34cb5609a80e0a8e44c5999c93903a81cd866630ec0bfd"
+checksum = "ec509ac96e9a0c43427c74f003127d953a265737636129424288d27cb5c4b12c"
 dependencies = [
  "futures-util",
  "log",
  "tokio",
- "tungstenite 0.18.0",
+ "tungstenite 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -5634,7 +5650,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -5664,6 +5680,17 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "version",
+]
+
+[[package]]
+name = "tracing-flame"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bae117ee14789185e129aaee5d93750abe67fdc5a9a62650452bfe4e122a3a9"
+dependencies = [
+ "lazy_static",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -5716,13 +5743,13 @@ checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "tungstenite"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30ee6ab729cd4cf0fd55218530c4522ed30b7b6081752839b68fcec8d0960788"
+checksum = "15fba1a6d6bb030745759a9a2a588bfe8490fc8b4751a277db3a0be1c9ebbf67"
 dependencies = [
- "base64 0.13.1",
  "byteorder",
  "bytes",
+ "data-encoding",
  "http",
  "httparse",
  "log",
@@ -5840,9 +5867,9 @@ dependencies = [
 
 [[package]]
 name = "urlencoding"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8db7427f936968176eaa7cdf81b7f98b980b18495ec28f1b5791ac3bfe3eea9"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "user-error"
@@ -6006,7 +6033,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.28",
  "wasm-bindgen-shared",
 ]
 
@@ -6040,7 +6067,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.28",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -6452,9 +6479,9 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winnow"
-version = "0.5.0"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fac9742fd1ad1bd9643b991319f72dd031016d44b77039a26977eb667141e7"
+checksum = "f46aab759304e4d7b2075a9aecba26228bb073ee8c50db796b2c72c676b5d807"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,4 @@
 [workspace]
-
 members = [
   "crates/common",
   "crates/api",
@@ -17,6 +16,7 @@ members = [
   "crates/opactl",
   "crates/sawtooth-tp",
 ]
+resolver = "2"
 
 [workspace.dependencies]
 Inflector = "0.11.4"
@@ -129,6 +129,7 @@ tokio-stream = { version = "0.1.11", features = ["sync"] }
 toml = "0.7.3"
 tracing = "0.1.37"
 tracing-elastic-apm = "3.2.3"
+tracing-flame = "*"
 tracing-log = "0.1.3"
 tracing-subscriber = { version = "0.3.15", features = [
   "default",

--- a/charts/chronicle/templates/statefulset.yaml
+++ b/charts/chronicle/templates/statefulset.yaml
@@ -102,41 +102,42 @@ spec:
           command: [ "bash", "-c"]
           args:
             - |
-              {{ if .Values.auth.required }}
-              {{ if and (not .Values.auth.jwks.url) (not .Values.auth.userinfo.url) (not .Values.devIdProvider.enabled) }}
-              {{ required "If 'auth.required' you need to provide at least 'auth.jwks.url' or 'auth.userinfo.url', or 'devIdProvider.enabled' must be 'true'!" .Values.auth.jwks.url }}
-              {{ end }}
-              {{ end }}
+              tail -f /dev/null
+              # {{ if .Values.auth.required }}
+              # {{ if and (not .Values.auth.jwks.url) (not .Values.auth.userinfo.url) (not .Values.devIdProvider.enabled) }}
+              # {{ required "If 'auth.required' you need to provide at least 'auth.jwks.url' or 'auth.userinfo.url', or 'devIdProvider.enabled' must be 'true'!" .Values.auth.jwks.url }}
+              # {{ end }}
+              # {{ end }}
 
-              echo "Waiting 20 seconds for postgres to start";
-              sleep 20;
-              chronicle \
-                -c /etc/chronicle/config/config.toml \
-                --console-logging json \
-                --sawtooth tcp://{{ include "chronicle.sawtooth.service" . }}:{{ include "chronicle.sawtooth.sawcomp" . }} \
-                --remote-database \
-                --database-name {{ .Values.postgres.database }} \
-                --database-username {{ .Values.postgres.user }} \
-                --database-host {{ .Values.postgres.host }} \
-                {{- if not .Values.opa.enabled }}
-                --embedded-opa-policy \
-                {{- end }}
-                {{- if .Values.perftest.enabled }}
-                perftest {{ .Values.perftest.ops }}
-                {{- else }}
-                serve-api \
-                  --interface 0.0.0.0:{{ .Values.port }} \
-                  {{- if .Values.healthCheck.enabled }}
-                  --liveness-check {{ .Values.healthCheck.interval }} \
-                  {{- end }}
-                  {{- if .Values.auth.required }}
-                  --require-auth \
-                  {{- end }}
-                  {{ include "chronicle.jwks-url.cli" . }}
-                  {{ include "chronicle.userinfo-url.cli" . }}
-                  {{ include "chronicle.id-claims" . }}
-                  ;
-                {{- end }}
+              # echo "Waiting 20 seconds for postgres to start";
+              # sleep 20;
+              # chronicle \
+              #   -c /etc/chronicle/config/config.toml \
+              #   --console-logging json \
+              #   --sawtooth tcp://{{ include "chronicle.sawtooth.service" . }}:{{ include "chronicle.sawtooth.sawcomp" . }} \
+              #   --remote-database \
+              #   --database-name {{ .Values.postgres.database }} \
+              #   --database-username {{ .Values.postgres.user }} \
+              #   --database-host {{ .Values.postgres.host }} \
+              #   {{- if not .Values.opa.enabled }}
+              #   --embedded-opa-policy \
+              #   {{- end }}
+              #   {{- if .Values.perftest.enabled }}
+              #   perftest {{ .Values.perftest.ops }}
+              #   {{- else }}
+              #   serve-api \
+              #     --interface 0.0.0.0:{{ .Values.port }} \
+              #     {{- if .Values.healthCheck.enabled }}
+              #     --liveness-check {{ .Values.healthCheck.interval }} \
+              #     {{- end }}
+              #     {{- if .Values.auth.required }}
+              #     --require-auth \
+              #     {{- end }}
+              #     {{ include "chronicle.jwks-url.cli" . }}
+              #     {{ include "chronicle.userinfo-url.cli" . }}
+              #     {{ include "chronicle.id-claims" . }}
+              #     ;
+              #   {{- end }}
           env: {{ include "lib.safeToYaml" .Values.env | nindent 12 }}
             - name: RUST_LOG
               value: {{ .Values.logLevel }}

--- a/charts/chronicle/templates/statefulset.yaml
+++ b/charts/chronicle/templates/statefulset.yaml
@@ -121,6 +121,9 @@ spec:
                 {{- if not .Values.opa.enabled }}
                 --embedded-opa-policy \
                 {{- end }}
+                {{- if .Values.perftest.enabled }}
+                perftest {{ .Values.perftest.ops }}
+                {{- else }}
                 serve-api \
                   --interface 0.0.0.0:{{ .Values.port }} \
                   {{- if .Values.healthCheck.enabled }}
@@ -133,6 +136,7 @@ spec:
                   {{ include "chronicle.userinfo-url.cli" . }}
                   {{ include "chronicle.id-claims" . }}
                   ;
+                {{- end }}
           env: {{ include "lib.safeToYaml" .Values.env | nindent 12 }}
             - name: RUST_LOG
               value: {{ .Values.logLevel }}

--- a/charts/chronicle/values.yaml
+++ b/charts/chronicle/values.yaml
@@ -124,6 +124,10 @@ opa:
     ## @md | `opa.tp.extraVolumeMounts` | extra volume mounts for opa-tp deployment | list | nil
     extraVolumeMounts:
 
+perftest:
+  enabled: false
+  ops: 1000
+
 ## @md | `port` | the port on which the chronicle service listens | 9982 |
 port: 9982
 

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -1943,7 +1943,7 @@ mod test {
     }
 
     fn embed_chronicle_tp() -> EmbeddedChronicleTp {
-        chronicle_telemetry::telemetry(None, chronicle_telemetry::ConsoleLogging::Pretty);
+        chronicle_telemetry::telemetry(None, None, chronicle_telemetry::ConsoleLogging::Pretty);
         let mut buf = vec![];
         Setting {
             entries: vec![Setting_Entry {
@@ -2004,7 +2004,7 @@ mod test {
     }
 
     async fn test_api<'a>() -> TestDispatch<'a> {
-        chronicle_telemetry::telemetry(None, chronicle_telemetry::ConsoleLogging::Pretty);
+        chronicle_telemetry::telemetry(None, None, chronicle_telemetry::ConsoleLogging::Pretty);
 
         let secretpath = TempDir::new().unwrap().into_path();
 

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -27,7 +27,7 @@ use common::{
     prov::{
         operations::{
             ActivityExists, ActivityUses, ActsOnBehalfOf, AgentExists, ChronicleOperation,
-            CreateNamespace, DerivationType, EndActivity, EntityDerive, EntityExists,
+            CreateNamespace, DerivationType, EndActivity, EntityDerive, EntityExists, RegisterKey,
             SetAttributes, StartActivity, WasAssociatedWith, WasAttributedTo, WasGeneratedBy,
             WasInformedBy,
         },
@@ -563,31 +563,291 @@ where
         Ok(ApiResponse::submission(id, model, tx_id))
     }
 
-    /// Ensure that Chronicle API calls that will not result in any changes in state should not be dispatched
+    /// Checks if ChronicleOperations resulting from Chronicle API calls will result in any changes in state
     ///
     /// # Arguments
-    /// * `state` - `ProvModel` for the operations' namespace
+    /// * `connection` - Connection to the Chronicle database
     /// * `to_apply` - Chronicle operations resulting from an API call
-    #[instrument(skip(self))]
-    fn ensure_effects(
+    #[instrument(skip(self, connection))]
+    fn check_for_effects(
         &mut self,
-        state: &mut ProvModel,
+        connection: &mut PgConnection,
         to_apply: &Vec<ChronicleOperation>,
     ) -> Result<Option<Vec<ChronicleOperation>>, ApiError> {
-        let mut transactions = Vec::new();
+        let mut model = ProvModel::default();
+        let mut transactions = Vec::<ChronicleOperation>::with_capacity(to_apply.len());
+        for op in to_apply {
+            let mut applied_model = match op {
+                ChronicleOperation::CreateNamespace(CreateNamespace { external_id, .. }) => {
+                    let (namespace, _) = self.ensure_namespace(connection, external_id)?;
+                    model.namespace_context(&namespace);
+                    model
+                }
+                ChronicleOperation::AgentExists(AgentExists {
+                    ref namespace,
+                    ref external_id,
+                }) => {
+                    model.namespace_context(namespace);
+                    self.store.apply_prov_model_for_agent_id(
+                        connection,
+                        model,
+                        &AgentId::from_external_id(external_id),
+                        namespace.external_id_part(),
+                    )?
+                }
+                ChronicleOperation::ActivityExists(ActivityExists {
+                    ref namespace,
+                    ref external_id,
+                }) => {
+                    model.namespace_context(namespace);
 
-        for tx in to_apply {
-            let mut state_with_effects = state.clone();
-            state_with_effects.apply(tx)?;
-            if state_with_effects != *state {
-                transactions.push(tx.clone());
-                state.apply(tx)?;
-            } else {
-                info!(?tx, "Transaction has no effect, data already recorded");
+                    self.store.apply_prov_model_for_activity_id(
+                        connection,
+                        model,
+                        &ActivityId::from_external_id(external_id),
+                        namespace.external_id_part(),
+                    )?
+                }
+                ChronicleOperation::EntityExists(EntityExists {
+                    ref namespace,
+                    ref external_id,
+                }) => {
+                    model.namespace_context(namespace);
+                    self.store.apply_prov_model_for_entity_id(
+                        connection,
+                        model,
+                        &EntityId::from_external_id(external_id),
+                        namespace.external_id_part(),
+                    )?
+                }
+                ChronicleOperation::ActivityUses(ActivityUses {
+                    ref namespace,
+                    ref id,
+                    ref activity,
+                }) => {
+                    model.namespace_context(namespace);
+                    self.store.prov_model_for_usage(
+                        connection,
+                        model,
+                        id,
+                        activity,
+                        namespace.external_id_part(),
+                    )?
+                }
+                ChronicleOperation::SetAttributes(ref o) => match o {
+                    SetAttributes::Activity { namespace, id, .. } => {
+                        model.namespace_context(namespace);
+                        self.store.apply_prov_model_for_activity_id(
+                            connection,
+                            model,
+                            id,
+                            namespace.external_id_part(),
+                        )?
+                    }
+                    SetAttributes::Agent { namespace, id, .. } => {
+                        model.namespace_context(namespace);
+                        self.store.apply_prov_model_for_agent_id(
+                            connection,
+                            model,
+                            id,
+                            namespace.external_id_part(),
+                        )?
+                    }
+                    SetAttributes::Entity { namespace, id, .. } => {
+                        model.namespace_context(namespace);
+                        self.store.apply_prov_model_for_entity_id(
+                            connection,
+                            model,
+                            id,
+                            namespace.external_id_part(),
+                        )?
+                    }
+                },
+                ChronicleOperation::StartActivity(StartActivity { namespace, id, .. }) => {
+                    model.namespace_context(namespace);
+                    self.store.apply_prov_model_for_activity_id(
+                        connection,
+                        model,
+                        id,
+                        namespace.external_id_part(),
+                    )?
+                }
+                ChronicleOperation::EndActivity(EndActivity { namespace, id, .. }) => {
+                    model.namespace_context(namespace);
+                    self.store.apply_prov_model_for_activity_id(
+                        connection,
+                        model,
+                        id,
+                        namespace.external_id_part(),
+                    )?
+                }
+                ChronicleOperation::WasInformedBy(WasInformedBy {
+                    namespace,
+                    activity,
+                    informing_activity,
+                }) => {
+                    model.namespace_context(namespace);
+                    let model = self.store.apply_prov_model_for_activity_id(
+                        connection,
+                        model,
+                        activity,
+                        namespace.external_id_part(),
+                    )?;
+                    self.store.apply_prov_model_for_activity_id(
+                        connection,
+                        model,
+                        informing_activity,
+                        namespace.external_id_part(),
+                    )?
+                }
+                ChronicleOperation::AgentActsOnBehalfOf(ActsOnBehalfOf {
+                    activity_id,
+                    responsible_id,
+                    delegate_id,
+                    namespace,
+                    ..
+                }) => {
+                    model.namespace_context(namespace);
+                    let model = self.store.apply_prov_model_for_agent_id(
+                        connection,
+                        model,
+                        responsible_id,
+                        namespace.external_id_part(),
+                    )?;
+                    let model = self.store.apply_prov_model_for_agent_id(
+                        connection,
+                        model,
+                        delegate_id,
+                        namespace.external_id_part(),
+                    )?;
+                    if let Some(id) = activity_id {
+                        self.store.apply_prov_model_for_activity_id(
+                            connection,
+                            model,
+                            id,
+                            namespace.external_id_part(),
+                        )?
+                    } else {
+                        model
+                    }
+                }
+                ChronicleOperation::RegisterKey(RegisterKey { namespace, id, .. }) => {
+                    model.namespace_context(namespace);
+                    self.store.apply_prov_model_for_agent_id(
+                        connection,
+                        model,
+                        id,
+                        namespace.external_id_part(),
+                    )?
+                }
+                ChronicleOperation::WasAssociatedWith(WasAssociatedWith {
+                    namespace,
+                    activity_id,
+                    agent_id,
+                    ..
+                }) => {
+                    model.namespace_context(namespace);
+                    let model = self.store.apply_prov_model_for_activity_id(
+                        connection,
+                        model,
+                        activity_id,
+                        namespace.external_id_part(),
+                    )?;
+
+                    self.store.apply_prov_model_for_agent_id(
+                        connection,
+                        model,
+                        agent_id,
+                        namespace.external_id_part(),
+                    )?
+                }
+                ChronicleOperation::WasGeneratedBy(WasGeneratedBy {
+                    namespace,
+                    id,
+                    activity,
+                }) => {
+                    model.namespace_context(namespace);
+                    let model = self.store.apply_prov_model_for_activity_id(
+                        connection,
+                        model,
+                        activity,
+                        namespace.external_id_part(),
+                    )?;
+
+                    self.store.apply_prov_model_for_entity_id(
+                        connection,
+                        model,
+                        id,
+                        namespace.external_id_part(),
+                    )?
+                }
+                ChronicleOperation::EntityDerive(EntityDerive {
+                    namespace,
+                    id,
+                    used_id,
+                    activity_id,
+                    ..
+                }) => {
+                    model.namespace_context(namespace);
+                    let model = self.store.apply_prov_model_for_entity_id(
+                        connection,
+                        model,
+                        id,
+                        namespace.external_id_part(),
+                    )?;
+
+                    let model = self.store.apply_prov_model_for_entity_id(
+                        connection,
+                        model,
+                        used_id,
+                        namespace.external_id_part(),
+                    )?;
+
+                    if let Some(id) = activity_id {
+                        self.store.apply_prov_model_for_activity_id(
+                            connection,
+                            model,
+                            id,
+                            namespace.external_id_part(),
+                        )?
+                    } else {
+                        model
+                    }
+                }
+                ChronicleOperation::WasAttributedTo(WasAttributedTo {
+                    namespace,
+                    entity_id,
+                    agent_id,
+                    ..
+                }) => {
+                    model.namespace_context(namespace);
+                    let model = self.store.apply_prov_model_for_entity_id(
+                        connection,
+                        model,
+                        entity_id,
+                        namespace.external_id_part(),
+                    )?;
+
+                    self.store.apply_prov_model_for_agent_id(
+                        connection,
+                        model,
+                        agent_id,
+                        namespace.external_id_part(),
+                    )?
+                }
+            };
+            let state = applied_model.clone();
+            applied_model.apply(op)?;
+            if state != applied_model {
+                info!("Compare: {:#?} != {:#?}", state, applied_model);
+                transactions.push(op.clone());
             }
+
+            model = applied_model;
         }
 
         if transactions.is_empty() {
+            info!("Transaction has no effect, data already recorded");
             Ok(None)
         } else {
             Ok(Some(transactions))
@@ -600,18 +860,11 @@ where
         id: impl Into<ChronicleIri>,
         identity: AuthId,
         to_apply: Vec<ChronicleOperation>,
-        namespace: NamespaceId,
         applying_new_namespace: bool,
     ) -> Result<ApiResponse, ApiError> {
         if applying_new_namespace {
             self.submit(id, identity, to_apply)
-        } else if let Some(to_apply) = {
-            let mut state = self
-                .store
-                .prov_model_for_namespace(connection, &namespace)?;
-            state.namespace_context(&namespace);
-            self.ensure_effects(&mut state, &to_apply)?
-        } {
+        } else if let Some(to_apply) = self.check_for_effects(connection, &to_apply)? {
             self.submit(id, identity, to_apply)
         } else {
             info!("API call will not result in any data changes");
@@ -674,7 +927,7 @@ where
                 let applying_new_namespace = !to_apply.is_empty();
 
                 let create = ChronicleOperation::WasGeneratedBy(WasGeneratedBy {
-                    namespace: namespace.clone(),
+                    namespace,
                     id: id.clone(),
                     activity: activity_id,
                 });
@@ -686,7 +939,6 @@ where
                     id,
                     identity,
                     to_apply,
-                    namespace,
                     applying_new_namespace,
                 )
             })
@@ -715,7 +967,7 @@ where
 
                 let (id, to_apply) = {
                     let create = ChronicleOperation::ActivityUses(ActivityUses {
-                        namespace: namespace.clone(),
+                        namespace,
                         id: id.clone(),
                         activity: activity_id,
                     });
@@ -730,7 +982,6 @@ where
                     id,
                     identity,
                     to_apply,
-                    namespace,
                     applying_new_namespace,
                 )
             })
@@ -760,7 +1011,7 @@ where
 
                 let (id, to_apply) = {
                     let create = ChronicleOperation::WasInformedBy(WasInformedBy {
-                        namespace: namespace.clone(),
+                        namespace,
                         activity: id.clone(),
                         informing_activity: informing_activity_id,
                     });
@@ -775,7 +1026,6 @@ where
                     id,
                     identity,
                     to_apply,
-                    namespace,
                     applying_new_namespace,
                 )
             })
@@ -814,7 +1064,7 @@ where
 
                 let set_type = ChronicleOperation::SetAttributes(SetAttributes::Entity {
                     id: EntityId::from_external_id(&external_id),
-                    namespace: namespace.clone(),
+                    namespace,
                     attributes,
                 });
 
@@ -825,7 +1075,6 @@ where
                     id,
                     identity,
                     to_apply,
-                    namespace,
                     applying_new_namespace,
                 )
             })
@@ -863,7 +1112,7 @@ where
                 let id = ActivityId::from_external_id(&external_id);
                 let set_type = ChronicleOperation::SetAttributes(SetAttributes::Activity {
                     id: id.clone(),
-                    namespace: namespace.clone(),
+                    namespace,
                     attributes,
                 });
 
@@ -874,7 +1123,6 @@ where
                     id,
                     identity,
                     to_apply,
-                    namespace,
                     applying_new_namespace,
                 )
             })
@@ -912,7 +1160,7 @@ where
                 let id = AgentId::from_external_id(&external_id);
                 let set_type = ChronicleOperation::SetAttributes(SetAttributes::Agent {
                     id: id.clone(),
-                    namespace: namespace.clone(),
+                    namespace,
                     attributes,
                 });
 
@@ -923,7 +1171,6 @@ where
                     id,
                     identity,
                     to_apply,
-                    namespace,
                     applying_new_namespace,
                 )
             })
@@ -1193,7 +1440,6 @@ where
                     responsible_id,
                     identity,
                     to_apply,
-                    namespace,
                     applying_new_namespace,
                 )
             })
@@ -1234,7 +1480,6 @@ where
                     responsible_id,
                     identity,
                     to_apply,
-                    namespace,
                     applying_new_namespace,
                 )
             })
@@ -1275,7 +1520,6 @@ where
                     responsible_id,
                     identity,
                     to_apply,
-                    namespace,
                     applying_new_namespace,
                 )
             })
@@ -1304,7 +1548,7 @@ where
                 let applying_new_namespace = !to_apply.is_empty();
 
                 let tx = ChronicleOperation::EntityDerive(EntityDerive {
-                    namespace: namespace.clone(),
+                    namespace,
                     id: id.clone(),
                     used_id: used_id.clone(),
                     activity_id: activity_id.clone(),
@@ -1318,7 +1562,6 @@ where
                     id,
                     identity,
                     to_apply,
-                    namespace,
                     applying_new_namespace,
                 )
             })
@@ -1354,24 +1597,12 @@ where
             // Check here to ensure that import operations result in data changes
             let mut connection = api.store.connection()?;
             connection.build_transaction().run(|connection| {
-                // If the namespace exists, get the model for the namespace and check each operation will have effects
-                let mut state = match api.store.prov_model_for_namespace(connection, &namespace) {
-                    Ok(mut state) => {
-                        info!("Importing data to existing namespace: {namespace}");
-                        // `prov_model_for_namespace` returns a model with the namespace context not applied
-                        state.namespace_context(&namespace);
-                        state
-                    }
-                    _ => {
-                        // If namespace does not exist, create a new model
-                        info!("Importing data to new namespace: {namespace}");
-                        ProvModel::default()
-                    }
-                };
-                if let Some(operations) = api.ensure_effects(&mut state, &operations)? {
+                if let Some(operations_to_apply) = api.check_for_effects(connection, &operations)? {
                     info!("Submitting import operations to ledger");
-                    let tx_id =
-                        api.submit_blocking(&ChronicleTransaction::new(operations, identity))?;
+                    let tx_id = api.submit_blocking(&ChronicleTransaction::new(
+                        operations_to_apply,
+                        identity,
+                    ))?;
                     Ok(ApiResponse::import_submitted(model, tx_id))
                 } else {
                     info!("Import will not result in any data changes");
@@ -1453,7 +1684,6 @@ where
                     id,
                     identity,
                     to_apply,
-                    namespace,
                     applying_new_namespace,
                 )
             })
@@ -1507,7 +1737,6 @@ where
                     id,
                     identity,
                     to_apply,
-                    namespace,
                     applying_new_namespace,
                 )
             })
@@ -1561,7 +1790,6 @@ where
                     id,
                     identity,
                     to_apply,
-                    namespace,
                     applying_new_namespace,
                 )
             })

--- a/crates/api/src/persistence/mod.rs
+++ b/crates/api/src/persistence/mod.rs
@@ -1298,8 +1298,29 @@ impl Store {
         let namespace = self.namespace_by_external_id(connection, ns)?.0;
 
         let mut model = ProvModel::default();
-        self.prov_model_for_agent(agent, &namespace, &mut model, connection)
-            .unwrap();
+        self.prov_model_for_agent(agent, &namespace, &mut model, connection)?;
+        Ok(model)
+    }
+
+    #[instrument(level = "debug", skip(connection))]
+    pub fn apply_prov_model_for_agent_id(
+        &self,
+        connection: &mut PgConnection,
+        mut model: ProvModel,
+        id: &AgentId,
+        ns: &ExternalId,
+    ) -> Result<ProvModel, StoreError> {
+        if let Some(agent) = schema::agent::table
+            .inner_join(schema::namespace::dsl::namespace)
+            .filter(schema::agent::external_id.eq(id.external_id_part()))
+            .filter(schema::namespace::external_id.eq(ns))
+            .select(query::Agent::as_select())
+            .first(connection)
+            .optional()?
+        {
+            let namespace = self.namespace_by_external_id(connection, ns)?.0;
+            self.prov_model_for_agent(agent, &namespace, &mut model, connection)?;
+        }
         Ok(model)
     }
 
@@ -1320,8 +1341,29 @@ impl Store {
         let namespace = self.namespace_by_external_id(connection, ns)?.0;
 
         let mut model = ProvModel::default();
-        self.prov_model_for_activity(activity, &namespace, &mut model, connection)
-            .unwrap();
+        self.prov_model_for_activity(activity, &namespace, &mut model, connection)?;
+        Ok(model)
+    }
+
+    #[instrument(level = "debug", skip(connection))]
+    pub fn apply_prov_model_for_activity_id(
+        &self,
+        connection: &mut PgConnection,
+        mut model: ProvModel,
+        id: &ActivityId,
+        ns: &ExternalId,
+    ) -> Result<ProvModel, StoreError> {
+        if let Some(activity) = schema::activity::table
+            .inner_join(schema::namespace::dsl::namespace)
+            .filter(schema::activity::external_id.eq(id.external_id_part()))
+            .filter(schema::namespace::external_id.eq(ns))
+            .select(query::Activity::as_select())
+            .first(connection)
+            .optional()?
+        {
+            let namespace = self.namespace_by_external_id(connection, ns)?.0;
+            self.prov_model_for_activity(activity, &namespace, &mut model, connection)?;
+        }
         Ok(model)
     }
 
@@ -1342,8 +1384,75 @@ impl Store {
         let namespace = self.namespace_by_external_id(connection, ns)?.0;
 
         let mut model = ProvModel::default();
-        self.prov_model_for_entity(entity, &namespace, &mut model, connection)
-            .unwrap();
+        self.prov_model_for_entity(entity, &namespace, &mut model, connection)?;
+        Ok(model)
+    }
+
+    #[instrument(level = "debug", skip(connection))]
+    pub fn apply_prov_model_for_entity_id(
+        &self,
+        connection: &mut PgConnection,
+        mut model: ProvModel,
+        id: &EntityId,
+        ns: &ExternalId,
+    ) -> Result<ProvModel, StoreError> {
+        if let Some(entity) = schema::entity::table
+            .inner_join(schema::namespace::dsl::namespace)
+            .filter(schema::entity::external_id.eq(id.external_id_part()))
+            .filter(schema::namespace::external_id.eq(ns))
+            .select(query::Entity::as_select())
+            .first(connection)
+            .optional()?
+        {
+            let namespace = self.namespace_by_external_id(connection, ns)?.0;
+            self.prov_model_for_entity(entity, &namespace, &mut model, connection)?;
+        }
+        Ok(model)
+    }
+
+    pub(crate) fn prov_model_for_usage(
+        &self,
+        connection: &mut PgConnection,
+        mut model: ProvModel,
+        id: &EntityId,
+        activity_id: &ActivityId,
+        ns: &ExternalId,
+    ) -> Result<ProvModel, StoreError> {
+        if let Some(entity) = schema::entity::table
+            .inner_join(schema::namespace::dsl::namespace)
+            .filter(schema::entity::external_id.eq(id.external_id_part()))
+            .filter(schema::namespace::external_id.eq(ns))
+            .select(query::Entity::as_select())
+            .first(connection)
+            .optional()?
+        {
+            if let Some(activity) = schema::activity::table
+                .inner_join(schema::namespace::dsl::namespace)
+                .filter(schema::activity::external_id.eq(id.external_id_part()))
+                .filter(schema::namespace::external_id.eq(ns))
+                .select(query::Activity::as_select())
+                .first(connection)
+                .optional()?
+            {
+                let namespace = self.namespace_by_external_id(connection, ns)?.0;
+                for used in schema::usage::table
+                    .filter(schema::usage::activity_id.eq(activity.id))
+                    .order(schema::usage::activity_id.asc())
+                    .inner_join(schema::entity::table)
+                    .select(schema::entity::external_id)
+                    .load::<String>(connection)?
+                {
+                    let used = used;
+                    model.used(
+                        namespace.clone(),
+                        activity_id,
+                        &EntityId::from_external_id(used),
+                    );
+                }
+                self.prov_model_for_entity(entity, &namespace, &mut model, connection)?;
+                self.prov_model_for_activity(activity, &namespace, &mut model, connection)?;
+            }
+        }
         Ok(model)
     }
 }

--- a/crates/chronicle-domain-test/src/test.rs
+++ b/crates/chronicle-domain-test/src/test.rs
@@ -122,7 +122,7 @@ mod test {
     async fn test_schema_with_opa<'a>(
         opa_executor: ExecutorContext,
     ) -> (Schema<Query, Mutation, Subscription>, TemporaryDatabase<'a>) {
-        chronicle_telemetry::telemetry(None, chronicle_telemetry::ConsoleLogging::Pretty);
+        chronicle_telemetry::telemetry(None, None, chronicle_telemetry::ConsoleLogging::Pretty);
 
         let secretpath = TempDir::new().unwrap().into_path();
 

--- a/crates/chronicle-telemetry/Cargo.toml
+++ b/crates/chronicle-telemetry/Cargo.toml
@@ -6,13 +6,14 @@ version = "0.7.5"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cfg-if                = { workspace = true }
-console-subscriber    = { workspace = true }
-tracing               = { workspace = true }
-tracing-elastic-apm   = { workspace = true }
-tracing-log           = { workspace = true }
-tracing-subscriber    = { workspace = true }
-url                   = { workspace = true, features = ["serde"] }
+cfg-if              = { workspace = true }
+console-subscriber  = { workspace = true }
+tracing             = { workspace = true }
+tracing-elastic-apm = { workspace = true }
+tracing-flame       = { workspace = true }
+tracing-log         = { workspace = true }
+tracing-subscriber  = { workspace = true }
+url                 = { workspace = true, features = ["serde"] }
 
 [features]
 tokio-tracing = []

--- a/crates/chronicle/src/bootstrap/cli.rs
+++ b/crates/chronicle/src/bootstrap/cli.rs
@@ -835,9 +835,17 @@ impl SubCommand for CliModel {
                     .value_hint(ValueHint::Url)
                     .help("Instrument using RUST_LOG environment"),
             )
+            .arg(
+                Arg::new("flamegraph")
+                    .long("flamegraph")
+                    .value_name("instrument")
+                    .takes_value(true)
+                    .value_hint(ValueHint::FilePath)
+                    .help("Write spans to a flamegraph file"),
+            )
             .arg(Arg::new("console-logging").long("console-logging")
                 .takes_value(true)
-                .possible_values(["pretty","json"])
+                .possible_values(["pretty","json","off"])
                 .default_value("pretty")
                 .help(
                     "Instrument using RUST_LOG environment, writing in either human readable format or structured json to stdio",

--- a/crates/chronicle/src/bootstrap/cli.rs
+++ b/crates/chronicle/src/bootstrap/cli.rs
@@ -1023,6 +1023,12 @@ impl SubCommand for CliModel {
                             .help("Number of operations")
                             .required(true)
                     )
+                    .arg(
+                        Arg::new("cap")
+                            .value_name("CAP")
+                            .help("Pause after this many operations")
+                            .required(true)
+                    )
             );
 
         for agent in self.agents.iter() {

--- a/crates/chronicle/src/bootstrap/cli.rs
+++ b/crates/chronicle/src/bootstrap/cli.rs
@@ -45,6 +45,9 @@ pub enum CliError {
     #[error("Bad argument: {0}")]
     ArgumentParsing(#[from] clap::Error),
 
+    #[error("Blocking thread pool: {0}")]
+    Join(#[from] tokio::task::JoinError),
+
     #[error("Invalid IRI: {0}")]
     InvalidIri(#[from] iref::Error),
 
@@ -1010,6 +1013,15 @@ impl SubCommand for CliModel {
                             .value_hint(ValueHint::Url)
                             .value_parser(StringValueParser::new())
                             .help("A path or url to data import file"),
+                    )
+            )
+            .subcommand(
+                Command::new("perftest")
+                    .arg(
+                        Arg::new("ops")
+                            .value_name("OPS")
+                            .help("Number of operations")
+                            .required(true)
                     )
             );
 

--- a/crates/chronicle/src/bootstrap/mod.rs
+++ b/crates/chronicle/src/bootstrap/mod.rs
@@ -555,6 +555,8 @@ where
         info!("Perftest complete");
         info!("Perftest took {} seconds", elapsed_time.as_secs());
         info!("{} operations failed", failed_submissions);
+        info!("Sleeping for 5 minutes before shutting down this round of performance testing");
+        tokio::time::sleep(Duration::from_secs(300)).await;
         Ok((ApiResponse::Unit, ret_api))
     } else if let Some(cmd) = cli.matches(&matches)? {
         let identity = AuthId::chronicle();

--- a/crates/chronicle/src/bootstrap/mod.rs
+++ b/crates/chronicle/src/bootstrap/mod.rs
@@ -733,6 +733,7 @@ pub async fn bootstrap<Query, Mutation>(
         matches
             .get_one::<String>("instrument")
             .map(|s| Url::parse(s).expect("cannot parse instrument as URI: {s}")),
+        matches.get_one::<String>("flamegraph").map(|x| x.as_str()),
         if matches.contains_id("console-logging") {
             match matches.get_one::<String>("console-logging") {
                 Some(level) => match level.as_str() {
@@ -851,7 +852,7 @@ pub mod test {
     }
 
     async fn test_api<'a>() -> TestDispatch<'a> {
-        chronicle_telemetry::telemetry(None, chronicle_telemetry::ConsoleLogging::Pretty);
+        chronicle_telemetry::telemetry(None, None, chronicle_telemetry::ConsoleLogging::Pretty);
 
         let secretpath = TempDir::new().unwrap().into_path();
 

--- a/crates/chronicle/src/bootstrap/mod.rs
+++ b/crates/chronicle/src/bootstrap/mod.rs
@@ -499,6 +499,8 @@ where
         let perftest_ops_api = api.clone();
         let start_time = Instant::now();
 
+        let mut tx_notifications = api.notify_commit.subscribe();
+
         tokio::task::spawn(async move {
             while ops > 0 {
                 let identity = AuthId::chronicle();
@@ -508,7 +510,6 @@ where
             }
         });
 
-        let mut tx_notifications = api.notify_commit.subscribe();
         while ops > 0 {
             if let Ok(SubmissionStage::Committed(_, _)) = tx_notifications.recv().await {
                 ops -= 1;

--- a/crates/chronicle/src/bootstrap/mod.rs
+++ b/crates/chronicle/src/bootstrap/mod.rs
@@ -518,7 +518,12 @@ where
         let mut tx_notifications = api.notify_commit.subscribe();
 
         tokio::task::spawn(async move {
+            let mut cap = 50;
             while ops > 0 {
+                if cap == 0 {
+                    cap = 50;
+                    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+                }
                 let identity = AuthId::chronicle();
                 let namespace = system_namespace();
                 // If submission fails treat it as a lag error and retry
@@ -529,6 +534,7 @@ where
                 {
                     ops -= 1;
                 }
+                cap -= 1;
             }
         });
 

--- a/crates/chronicle/src/bootstrap/mod.rs
+++ b/crates/chronicle/src/bootstrap/mod.rs
@@ -498,8 +498,7 @@ where
         tokio::time::sleep(std::time::Duration::from_secs(20)).await;
 
         let mut ops = matches.value_of("ops").unwrap().parse::<u64>().unwrap();
-        // let cap = matches.value_of("cap").unwrap().parse::<u64>().unwrap();
-        // let delay_duration = std::time::Duration::from_secs(1 / cap);
+        let cap = matches.value_of("cap").unwrap().parse::<u64>().unwrap();
 
         let perftest_ops_api = api.clone();
 
@@ -518,10 +517,11 @@ where
         let mut tx_notifications = api.notify_commit.subscribe();
 
         tokio::task::spawn(async move {
-            let mut cap = 50;
+            let cap_set = cap;
+            let mut cap = cap;
             while ops > 0 {
                 if cap == 0 {
-                    cap = 50;
+                    cap = cap_set;
                     tokio::time::sleep(std::time::Duration::from_secs(1)).await;
                 }
                 let identity = AuthId::chronicle();

--- a/crates/common/src/prov/model/mod.rs
+++ b/crates/common/src/prov/model/mod.rs
@@ -107,7 +107,7 @@ pub enum ChronicleTransactionIdError {
     InvalidTransactionId { id: String },
 }
 
-#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
+#[derive(Serialize, Deserialize, PartialEq, Eq, Hash, Debug, Clone)]
 pub struct ChronicleTransactionId(String);
 
 impl Display for ChronicleTransactionId {

--- a/crates/common/src/prov/model/mod.rs
+++ b/crates/common/src/prov/model/mod.rs
@@ -107,7 +107,7 @@ pub enum ChronicleTransactionIdError {
     InvalidTransactionId { id: String },
 }
 
-#[derive(Serialize, Deserialize, PartialEq, Eq, Hash, Debug, Clone)]
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
 pub struct ChronicleTransactionId(String);
 
 impl Display for ChronicleTransactionId {

--- a/crates/common/src/prov/model/mod.rs
+++ b/crates/common/src/prov/model/mod.rs
@@ -452,7 +452,7 @@ impl ProvModel {
     ) {
         self.derivation
             .entry((namespace_id, id.clone()))
-            .or_insert_with(BTreeSet::new)
+            .or_default()
             .insert(Derivation {
                 typ,
                 generated_id: id,
@@ -485,11 +485,11 @@ impl ProvModel {
         };
         self.delegation
             .entry((namespace_id.clone(), responsible_id.clone()))
-            .or_insert_with(BTreeSet::new)
+            .or_default()
             .insert(delegation.clone());
         self.acted_on_behalf_of
             .entry((namespace_id.clone(), delegate_id.clone()))
-            .or_insert_with(BTreeSet::new)
+            .or_default()
             .insert(delegation);
     }
 
@@ -502,7 +502,7 @@ impl ProvModel {
     ) {
         self.association
             .entry((namespace_id.clone(), activity_id.clone()))
-            .or_insert_with(BTreeSet::new)
+            .or_default()
             .insert(Association {
                 namespace_id: namespace_id.clone(),
                 id: AssociationId::from_component_ids(agent_id, activity_id, role.as_ref()),
@@ -520,7 +520,7 @@ impl ProvModel {
     ) {
         self.generation
             .entry((namespace, generated_id.clone()))
-            .or_insert_with(BTreeSet::new)
+            .or_default()
             .insert(Generation {
                 activity_id: activity_id.clone(),
                 generated_id: generated_id.clone(),
@@ -535,7 +535,7 @@ impl ProvModel {
     ) {
         self.generated
             .entry((namespace, generated_id.clone()))
-            .or_insert_with(BTreeSet::new)
+            .or_default()
             .insert(GeneratedEntity {
                 entity_id: entity_id.clone(),
                 generated_id: generated_id.clone(),
@@ -545,7 +545,7 @@ impl ProvModel {
     pub fn used(&mut self, namespace: NamespaceId, activity_id: &ActivityId, entity_id: &EntityId) {
         self.usage
             .entry((namespace, activity_id.clone()))
-            .or_insert_with(BTreeSet::new)
+            .or_default()
             .insert(Usage {
                 activity_id: activity_id.clone(),
                 entity_id: entity_id.clone(),
@@ -560,7 +560,7 @@ impl ProvModel {
     ) {
         self.was_informed_by
             .entry((namespace.clone(), activity.clone()))
-            .or_insert_with(BTreeSet::new)
+            .or_default()
             .insert((namespace, informing_activity.clone()));
     }
 
@@ -573,7 +573,7 @@ impl ProvModel {
     ) {
         self.attribution
             .entry((namespace_id.clone(), entity_id.clone()))
-            .or_insert_with(BTreeSet::new)
+            .or_default()
             .insert(Attribution {
                 namespace_id: namespace_id.clone(),
                 id: AttributionId::from_component_ids(agent_id, entity_id, role.as_ref()),
@@ -586,7 +586,7 @@ impl ProvModel {
     pub fn had_identity(&mut self, namespace: NamespaceId, agent: &AgentId, identity: &IdentityId) {
         self.had_identity
             .entry((namespace.clone(), agent.clone()))
-            .or_insert_with(BTreeSet::new)
+            .or_default()
             .insert((namespace, identity.clone()));
     }
 

--- a/crates/opa-tp/src/main.rs
+++ b/crates/opa-tp/src/main.rs
@@ -58,6 +58,7 @@ async fn main() {
         matches
             .get_one::<String>("instrument")
             .and_then(|s| Url::parse(s).ok()),
+        None,
         match matches.get_one::<String>("console-logging") {
             Some(level) => match level.as_str() {
                 "pretty" => ConsoleLogging::Pretty,

--- a/crates/opa-tp/src/tp.rs
+++ b/crates/opa-tp/src/tp.rs
@@ -452,7 +452,7 @@ mod test {
 
     impl TestTransactionContext {
         pub fn new() -> Self {
-            chronicle_telemetry::telemetry(None, chronicle_telemetry::ConsoleLogging::Pretty);
+            chronicle_telemetry::telemetry(None, None, chronicle_telemetry::ConsoleLogging::Pretty);
             Self {
                 state: RefCell::new(BTreeMap::new()),
                 events: RefCell::new(vec![]),

--- a/crates/opactl/src/main.rs
+++ b/crates/opactl/src/main.rs
@@ -377,7 +377,7 @@ async fn dispatch_args<
 
 #[tokio::main]
 async fn main() {
-    chronicle_telemetry::telemetry(None, chronicle_telemetry::ConsoleLogging::Pretty);
+    chronicle_telemetry::telemetry(None, None, chronicle_telemetry::ConsoleLogging::Pretty);
     let args = cli::cli().get_matches();
     let address: &Url = args.get_one("sawtooth-address").unwrap();
     let client = ZmqRequestResponseSawtoothChannel::new(
@@ -980,12 +980,12 @@ pub mod test {
     }
 
     fn embed_opa_tp() -> EmbeddedOpaTp {
-        chronicle_telemetry::telemetry(None, chronicle_telemetry::ConsoleLogging::Pretty);
+        chronicle_telemetry::telemetry(None, None, chronicle_telemetry::ConsoleLogging::Pretty);
         EmbeddedOpaTp::new()
     }
 
     fn reuse_opa_tp_state(tp: EmbeddedOpaTp) -> EmbeddedOpaTp {
-        chronicle_telemetry::telemetry(None, chronicle_telemetry::ConsoleLogging::Pretty);
+        chronicle_telemetry::telemetry(None, None, chronicle_telemetry::ConsoleLogging::Pretty);
         EmbeddedOpaTp::new_with_state(tp.context.lock().unwrap().state.borrow().clone()).unwrap()
     }
 

--- a/crates/sawtooth-tp/src/main.rs
+++ b/crates/sawtooth-tp/src/main.rs
@@ -59,6 +59,7 @@ async fn main() {
         matches
             .get_one::<String>("instrument")
             .and_then(|s| Url::parse(s).ok()),
+        None,
         match matches.get_one::<String>("console-logging") {
             Some(level) => match level.as_str() {
                 "pretty" => ConsoleLogging::Pretty,

--- a/crates/sawtooth-tp/src/opa.rs
+++ b/crates/sawtooth-tp/src/opa.rs
@@ -33,7 +33,7 @@ impl TpOpa {
 
     pub fn executor_context(
         &self,
-        ctx: &mut dyn TransactionContext,
+        ctx: &dyn TransactionContext,
     ) -> Result<ExecutorContext, ApplyError> {
         let policy_name_settings_entry =
             ctx.get_state_entry(&sawtooth_settings_address("chronicle.opa.policy_name"))?;

--- a/crates/sawtooth-tp/src/tp.rs
+++ b/crates/sawtooth-tp/src/tp.rs
@@ -103,8 +103,7 @@ impl TP for ChronicleTransactionHandler {
 
     async fn tp_operations(submission: Submission) -> Result<ChronicleTransaction, ApplyError> {
         use chronicle_protocol::protocol::messages::submission::IdentityVariant;
-        use common::prov::transaction;
-        use common::prov::transaction::ToChronicleTransaction;
+        use common::prov::{transaction, transaction::ToChronicleTransaction};
         let identity =
             chronicle_identity_from_submission(match submission.identity_variant.unwrap() {
                 IdentityVariant::IdentityOld(id) => id,
@@ -380,8 +379,7 @@ impl TransactionHandler for ChronicleTransactionHandler {
 pub mod test {
     use std::{
         cell::RefCell,
-        collections::hash_map::DefaultHasher,
-        collections::BTreeMap,
+        collections::{hash_map::DefaultHasher, BTreeMap},
         hash::{Hash, Hasher},
     };
 
@@ -584,7 +582,7 @@ pub mod test {
 
     #[tokio::test]
     async fn simple_non_contradicting_operation() {
-        chronicle_telemetry::telemetry(None, chronicle_telemetry::ConsoleLogging::Pretty);
+        chronicle_telemetry::telemetry(None, None, chronicle_telemetry::ConsoleLogging::Pretty);
 
         let keystore = DirectoryStoredKeys::new(TempDir::new().unwrap().into_path()).unwrap();
         keystore.generate_chronicle().unwrap();

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -79,7 +79,23 @@ consecutive checks and is set to 1800 seconds (or 30 minutes) by default.
 By default, liveness checks are disabled.
 
 For configuration via Helm Chart, see our documentation on
-[Helm Options and the Liveness Health Check](./helm-options.md#liveness-health-check).
+[Helm Options and the Liveness Health
+Check](./helm-options.md#liveness-health-check).
+
+##### Instrumentation
+
+Instrumentation level is controlled by Rust's RUST_LOG environment variable -
+see <https://docs.rs/env_logger/latest/env_logger/>.
+
+###### `--console-logging`
+
+One of pretty, json or off. Pretty is suited to local development, json for
+production.
+
+###### `--flamegraph`
+
+Takes a path to a file and will write tracing information to it for use with
+analytic tools like <https://crates.io/crates/inferno>.
 
 ##### Deprecated Options
 


### PR DESCRIPTION
# WIP: Performance test

## [CHRON-467](https://blockchaintp.atlassian.net/browse/CHRON-467)

- adds a `perftest` sub-command that takes an argument for the number of Chronicle commands to be dispatched and timed, and a `cap` argument for the number of submissions allowed to run per second. The task dispatches `x` number of Chronicle commands, writing them to the `system` namespace, and then waits for `x` number of confirmations of commits or failures before recording the elapsed time. 
- See [results](https://blockchaintp.atlassian.net/l/cp/1DkgDatf)

## Updates 

More recent updates [here](https://blockchaintp.atlassian.net/l/cp/1DkgDatf)

### July 31
Altering the `chronicle` container Chart `args` to `tail -f /dev/null` and `exec`ing into the container to run the `perftest` command. To @ryanbtp's point in the discussion, I've found that running 50 transactions from the perftest can be done repeatedly, manually rerunning the command after completion gives us a set of the same results. Upping the number of commands to 100 shows the exponential pattern we see elsewhere. Will explore introducing pauses to the `perftest` code.

## issues: 
- @ryanbtp, @mtbc, different approaches to tracking commit messages and `tx_id`s affects results; 
    - I tested this with renditions that ensured the commit messages matched to guarantee we can rely on this being the case, i.e. send forty `perftest` commands and receiving forty commit messages means all forty transactions were successful. Reverting back to not checking because of the cost of doing so.
- @scealiontach, still trying to nail down requirements regarding test conditions and what's "good enough" - is installing the chart and running the performance test a decent measure, or do we need to be able to keep running multiple tests after we have already written to Sawtooth in a previous test? [Multiple runs](https://blockchaintp.atlassian.net/l/cp/o0QT8mGF) are showing an exponential growth in elapsed times. 
    - I've stopped installing a `perftest` configured `chronicle` Helm Chart and started using `port-forward` instead. Getting slow - ~ 40 seconds for 10 commands - results. @ryanbtp, @mtbc, I'm going to investigate further what this means in terms of @ryanbtp's points below about the `Api` initialization and getting the last commit block.   

## installing Chart configured to `perftest`
**TL;DR** - restart issues because the Chronicle `Pod` is coupled to the postgres database, exponential growth in times taken with each restart until it eventually just chokes up.

- It does restart itself, but sometimes needs a (`kubectl delete pod perftest-chronicle-chronicle-0`) kick due to `Lagged` receiver errors after the container restarts.
- Using the Helm configuration here means that the Chronicle `Statefulset` will start up in `perftest` mode and begin repeatedly running the performance test. Once finished the process will simply restart. Logs will need to be observed for now as they will disappear once the Pod restarts after each performance test is done. 
- For results see the [Chronicle perftest page](https://blockchaintp.atlassian.net/l/cp/o0QT8mGF) in Atlassian.

**Note** that first runs seem to contain a number of queuing errors that are not present second or third time around. But let's see. I've been running 2500 mutations each round in the `perftest` namespace on `azcue-1`. Things really start to slow down and then grind to a halt after a few rounds. And now trying 1000. Note also, for ease of looking at the results, I've used `info` level for logs related to the performance testing. `kubectl logs --namespace=perftest perftest-chronicle-chronicle-0 -c chronicle -f` to view the relevant logs. After about 5 runs through we start seeing a **lot** more queuing errors. 

Look out for these messages for an indication of how many commands are left before the test ends its current round:

```json
{"timestamp":"2023-07-29T14:18:08.036048Z","level":"INFO","fields":{"message":"1042 operations remaining"},"target":"chronicle::bootstrap","threadId":"ThreadId(7)"}
```

Look out for the following at the end of the logs when the task has completed:

Perftest complete:

```json
{"timestamp":"2023-07-29T14:32:19.613629Z","level":"INFO","fields":{"message":"Perftest complete"},"target":"chronicle::bootstrap","span":{"config":"Config { secrets: SecretConfig { path: \"/var/lib/chronicle/secrets/\" }, validator: ValidatorConfig { address: Url { scheme: \"tcp\", cannot_be_a_base: false, username: \"\", password: ***SECRET***, host: Some(Domain(\"perftest-sawtooth.perftest.svc.cluster.local\")), port: Some(4004), path: \"\", query: None, fragment: None } }, namespace_bindings: {\"default\": fd717fd6-70f1-44c1-81de-287d5e101089} }","name":"execute_subcommand"},"spans":[{"config":"Config { secrets: SecretConfig { path: \"/var/lib/chronicle/secrets/\" }, validator: ValidatorConfig { address: Url { scheme: \"tcp\", cannot_be_a_base: false, username: \"\", password: ***SECRET***, host: Some(Domain(\"perftest-sawtooth.perftest.svc.cluster.local\")), port: Some(4004), path: \"\", query: None, fragment: None } }, namespace_bindings: {\"default\": fd717fd6-70f1-44c1-81de-287d5e101089} }","name":"execute_subcommand"}],"threadId":"ThreadId(1)"}
```

How many seconds the test took to reach completion:

```json
{"timestamp":"2023-07-29T14:32:19.613676Z","level":"INFO","fields":{"message":"Perftest took 1643 seconds"},"target":"chronicle::bootstrap","span":{"config":"Config { secrets: SecretConfig { path: \"/var/lib/chronicle/secrets/\" }, validator: ValidatorConfig { address: Url { scheme: \"tcp\", cannot_be_a_base: false, username: \"\", password: ***SECRET***, host: Some(Domain(\"perftest-sawtooth.perftest.svc.cluster.local\")), port: Some(4004), path: \"\", query: None, fragment: None } }, namespace_bindings: {\"default\": fd717fd6-70f1-44c1-81de-287d5e101089} }","name":"execute_subcommand"},"spans":[{"config":"Config { secrets: SecretConfig { path: \"/var/lib/chronicle/secrets/\" }, validator: ValidatorConfig { address: Url { scheme: \"tcp\", cannot_be_a_base: false, username: \"\", password: ***SECRET***, host: Some(Domain(\"perftest-sawtooth.perftest.svc.cluster.local\")), port: Some(4004), path: \"\", query: None, fragment: None } }, namespace_bindings: {\"default\": fd717fd6-70f1-44c1-81de-287d5e101089} }","name":"execute_subcommand"}],"threadId":"ThreadId(1)"}
```

How many operations failed:

```json
{"timestamp":"2023-07-29T14:32:19.613697Z","level":"INFO","fields":{"message":"0 operations failed"},"target":"chronicle::bootstrap","span":{"config":"Config { secrets: SecretConfig { path: \"/var/lib/chronicle/secrets/\" }, validator: ValidatorConfig { address: Url { scheme: \"tcp\", cannot_be_a_base: false, username: \"\", password: ***SECRET***, host: Some(Domain(\"perftest-sawtooth.perftest.svc.cluster.local\")), port: Some(4004), path: \"\", query: None, fragment: None } }, namespace_bindings: {\"default\": fd717fd6-70f1-44c1-81de-287d5e101089} }","name":"execute_subcommand"},"spans":[{"config":"Config { secrets: SecretConfig { path: \"/var/lib/chronicle/secrets/\" }, validator: ValidatorConfig { address: Url { scheme: \"tcp\", cannot_be_a_base: false, username: \"\", password: ***SECRET***, host: Some(Domain(\"perftest-sawtooth.perftest.svc.cluster.local\")), port: Some(4004), path: \"\", query: None, fragment: None } }, namespace_bindings: {\"default\": fd717fd6-70f1-44c1-81de-287d5e101089} }","name":"execute_subcommand"}],"threadId":"ThreadId(1)"}
```

- This can be configured with a Helm `values.yaml` file like the one below. Note that we are using images built from source:

```yaml
---
perftest:
  enabled: true
  ops: 2500

imagePullSecrets:
  enabled: true
  value: 
    - name: regcred
    
image: 
  pullPolicy: Always
  repository: dev.catenasys.com:8083/joseph/perftest
  tag: latest
  
logLevel: info,cranelift_codegen=off,wasmtime_cranelift=off,regalloc2::ion=off,cranelift_wasm=off
  
opa:
  enabled: true
  opaInit:
    image:
      pullPolicy: Always
      repository: dev.catenasys.com:8083/joseph/opactl-amd64
      tag: latest
  tp:
    image:
      repository: dev.catenasys.com:8083/joseph/opa-tp-amd64
      tag: latest
      pullPolicy: Always

tp:
  image:
    pullPolicy: Always
    repository: dev.catenasys.com:8083/joseph/chronicle-tp-amd64
    tag: latest    
```


[CHRON-467]: https://blockchaintp.atlassian.net/browse/CHRON-467?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ