### PR TITLE
fix(charts): make offered endpoints explicit in Chronicle Helm Chart

### DIFF
--- a/charts/chronicle/templates/_chronicle.tpl
+++ b/charts/chronicle/templates/_chronicle.tpl
@@ -128,3 +128,15 @@ http://{{ include "chronicle.id-provider.service" . }}:8090/userinfo
 {{- define "chronicle.root-key.secret" -}}
 {{ include "common.names.fullname" . }}-root-key
 {{- end -}}
+
+{{- define "chronicle.offer-endpoints" -}}
+{{- if or (.Values.endpoints.data.enabled) (.Values.endpoints.graphql.enabled) -}}
+  {{- if and (.Values.endpoints.data.enabled) (.Values.endpoints.graphql.enabled) -}}
+    --offer-endpoints data graphql \
+  {{- else if .Values.endpoints.data.enabled -}}
+    --offer-endpoints data \
+  {{- else if .Values.endpoints.graphql.enabled -}}
+    --offer-endpoints graphql \
+  {{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/chronicle/templates/statefulset.yaml
+++ b/charts/chronicle/templates/statefulset.yaml
@@ -126,6 +126,7 @@ spec:
                   {{- if .Values.healthCheck.enabled }}
                   --liveness-check {{ .Values.healthCheck.interval }} \
                   {{- end }}
+                  {{ include "chronicle.offer-endpoints" . }}
                   {{- if .Values.auth.required }}
                   --require-auth \
                   {{- end }}

--- a/charts/chronicle/values.yaml
+++ b/charts/chronicle/values.yaml
@@ -36,6 +36,13 @@ devIdProvider:
     ## @md | `devIdProvider.image.tag` | the image tag | latest |
     tag: BTP2.1.0-0.7.4
 
+## @md | `endpoints` | which API endpoints to offer | data, graphql |
+endpoints:
+  data:
+    enabled: true
+  graphql:
+    enabled: true
+
 ## @md | `extraVolumes` | a list of additional volumes to add to chronicle | [] |
 extraVolumes: []
 ## @md | `extraVolumeMounts` | a list of additional volume mounts to add to chronicle | [] |

--- a/docs/helm-options.md
+++ b/docs/helm-options.md
@@ -1,5 +1,23 @@
 # Other Chronicle Helm Options
 
+## Endpoints
+
+Chronicle can offer endpoints for `data` (at `/context` and `/data`) and
+`graphql` (at `/` and `/ws`).
+
+These are served by default and can be configured in the Chronicle Helm Chart
+`values.yaml` with the following options:
+
+```yaml
+endpoints:
+  data:
+    enabled: true
+  graphql:
+    enabled: true
+```
+
+See [command line options](cli#offer-endpoints-name-name) for more information.
+
 ## Liveness Health Check
 
 Chronicle can enable liveness depth charge checks to ensure system availability.


### PR DESCRIPTION
# [CHRON-468](https://blockchaintp.atlassian.net/browse/CHRON-468)

To test this, run `helm template path/to/chronicle/charts/chronicle` on this Chart, playing with variations in `values.yaml` of:

```yaml
endpoints:
  data:
    enabled: true
  graphql:
    enabled: true
```

## PR Checklist

### Please complete this checklist after opening your PR

* [x] I have updated documentation as necessary
* [x] I have updated helm chart(s) if needed
* [x] I have added tests if needed
* [x] All new and existing tests are passing
* [x] Any breaking changes are clearly flagged and documented
* [x] I’ve included a link to any relevant ticket(s)


[CHRON-468]: https://blockchaintp.atlassian.net/browse/CHRON-468?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ